### PR TITLE
Fix publishing scripts

### DIFF
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -25,7 +25,7 @@ copy_package() {
 }
 
 # Copy the three packages
-copy_package "${ROOT}/aws-infra/bin/." "@pulumi/aws-infra"
+copy_package "${ROOT}/nodejs/aws-infra/bin/." "@pulumi/aws-infra"
 
 # Tar up the file and then print it out for use by the caller or script.
 tar -czf ${PUBFILE} -C ${PUBDIR} .

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -10,9 +10,9 @@ echo "Publishing NPM packages to NPMjs.com:"
 # dependencies from peerDependencies that are resolved via those links, to real installable dependencies.
 publish() {
     node $(dirname $0)/promote.js ${@:2} < \
-        ${ROOT}/$1/bin/package.json > \
-        ${ROOT}/$1/bin/package.json.publish
-    pushd ${ROOT}/$1/bin
+        ${ROOT}/nodejs/$1/bin/package.json > \
+        ${ROOT}/nodejs/$1/bin/package.json.publish
+    pushd ${ROOT}/nodejs/$1/bin
     mv package.json package.json.dev
     mv package.json.publish package.json
 


### PR DESCRIPTION
The path from the root to the sources changed in https://github.com/pulumi/pulumi-aws-infra/commit/6331994f8bd285e0672a1dd5b3653928195530fb but we did not update the scripts at that time (since the PR validation didn't draw our eye to it).