### PR TITLE
Use the latest ECS optimized AMI instead as a default

### DIFF
--- a/nodejs/aws-infra/cluster.ts
+++ b/nodejs/aws-infra/cluster.ts
@@ -79,7 +79,9 @@ export interface ClusterArgs {
     publicKey?: string;
     /**
      * The name of the ECS-optimzed AMI to use for the Container Instances in this cluster, e.g.
-     * "amzn-ami-2017.09.l-amazon-ecs-optimized".
+     * "amzn-ami-2017.09.l-amazon-ecs-optimized". Defaults to using the latest recommended ECS Optimized AMI, which may
+     * change over time and cause recreation of EC2 instances when new versions are release. To control when these
+     * changes are adopted, set this parameter explicitly to the version you would like to use.
      *
      * See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html for valid values.
      */
@@ -314,11 +316,20 @@ function createAutoScalingGroup(
 
 // http://docs.aws.amazon.com/AmazonECS/latest/developerguide/container_agent_versions.html
 async function getEcsAmiId(name?: string) {
+    // If a name was not provided, use the latest recommended version.
+    if (!name) {
+        // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
+        const ecsRecommendedAMI = await aws.ssm.getParameter({
+            name: "/aws/service/ecs/optimized-ami/amazon-linux/recommended",
+        });
+        return JSON.parse(ecsRecommendedAMI.value).image_id;
+    }
+    // Else, if a name was provided, look it up and use that imageId.
     const result: aws.GetAmiResult = await aws.getAmi({
         filters: [
             {
                 name: "name",
-                values: [ name || "amzn-ami-2017.09.l-amazon-ecs-optimized" ],
+                values: [ name ],
             },
             {
                 name: "owner-id",


### PR DESCRIPTION
Instead of hard-coding in a specific version, set the default to use the latest ECS-optimized AMI.  This will cause infrastructure to churn automatically when new ECS-optimized AMIs are released, but this can be overridden by specifying a fixed version as a parameter to `new Cluster`.

Fixes pulumi/pulumi-cloud#226.

*Changelog*:  Clusters managed by `awsinfra.Cluster` now use the latest available ECS image by default instead of a fixed older version.  If a specific fixed version is desired, it can be set manually using `ecsOptimizedAMIName`.