### PR TITLE
Remove old onFailure logic

### DIFF
--- a/nodejs/awsx/autoscaling/autoscaling.ts
+++ b/nodejs/awsx/autoscaling/autoscaling.ts
@@ -292,7 +292,6 @@ export class AutoScalingGroup extends pulumi.ComponentResource {
         this.stack = new aws.cloudformation.Stack(name, {
             ...args,
             name: this.launchConfiguration.stackName,
-            onFailure: "DO_NOTHING",
             templateBody: getCloudFormationTemplate(
                 name,
                 this.launchConfiguration.id,


### PR DESCRIPTION
This as added as a temporary measure to track something down in travis.  it was not intended to be committed.