### PR TITLE
Allow network listener to take TLS options.

### DIFF
--- a/nodejs/awsx/elasticloadbalancingv2/network.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/network.ts
@@ -328,4 +328,17 @@ export interface NetworkListenerArgs {
      * defaultAction will be chosen that forwards to a new [NetworkTargetGroup] created from [port].
      */
     defaultAction?: aws.elasticloadbalancingv2.ListenerArgs["defaultAction"] | x.elasticloadbalancingv2.ListenerDefaultAction;
+
+    /**
+     * The ARN of the default SSL server certificate. Exactly one certificate is required if the
+     * protocol is HTTPS. For adding additional SSL certificates, see the
+     * [`aws_lb_listener_certificate`
+     * resource](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.html).
+     */
+    certificateArn?: pulumi.Input<string>;
+
+    /**
+     * The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
+     */
+    sslPolicy?: pulumi.Input<string>;
 }


### PR DESCRIPTION
Needed the types changed to allow the following:

```
  const worthTLSListener = worthTargetGroup.createListener("sandbox_worth_tls", {
    port: 443,
    protocol: "TLS",
    certificateArn: worthCert.arn,
    sslPolicy: "ELBSecurityPolicy-2016-08"
  });
```