### PR TITLE
If not specified, give an ALB a default security group so that AppListeners can add ingress/egress rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.18.1 (Unreleased)
 
 - TypeScript typings for awsx.apigateway.API have been updated to be more accurate.
+- Application LoadBalancers/Listeners/TargetGroups will now create a default SecurityGroup for their
+  LoadBalancer if none is provided.
 
 ## 0.18.0 (Release March 29, 2019)
 

--- a/nodejs/awsx/elasticloadbalancingv2/application.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/application.ts
@@ -42,11 +42,11 @@ export class ApplicationLoadBalancer extends mod.LoadBalancer {
             loadBalancerType: "application",
         };
 
-        if (!args.securityGroups) {
-            args.securityGroups = [new x.ec2.SecurityGroup(name, {
-                description: `Default security group for ALB "${name}"`,
-                vpc: args.vpc,
-            })];
+        if (!argsCopy.securityGroups) {
+            argsCopy.securityGroups = [new x.ec2.SecurityGroup(name, {
+                description: `Default security group for ALB: ${name}`,
+                vpc: argsCopy.vpc,
+            }, opts)];
         }
 
         super("awsx:x:elasticloadbalancingv2:ApplicationLoadBalancer", name, argsCopy, opts);

--- a/nodejs/awsx/elasticloadbalancingv2/application.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/application.ts
@@ -431,13 +431,17 @@ export interface ApplicationListenerArgs {
     sslPolicy?: pulumi.Input<string>;
 
     /**
-     * If the listener should be available externally.  If this is [true] and the LoadBalancer for
-     * this Listener is [external=true], then this listener is available to the entire internet.  If
-     * this is [true] and the LoadBalancer is [external=false], then this listener is available to
-     * everything in the LoadBalancer's VPC.
+     * If the listener should be available externally.
      *
-     * If this is [false] then access will controlled entirely by the egress an ingress rules of the
-     * security groups of the LoadBalancer.
+     * If this is [true] and the LoadBalancer for this Listener is [external=true], then this
+     * listener is available to the entire internet.  If this is [true] and the LoadBalancer is
+     * [external=false], then this listener is available to everything in the LoadBalancer's VPC. In
+     * both cases, the security groups for the ALB will all get ingress rules to the port for this
+     * listener from any IPv4 location.
+     *
+     * If this is [false] then access will controlled entirely by the egress and ingress rules of
+     * the security groups of the LoadBalancer.  No changes will be made to the security groups of
+     * the ALB.
      *
      * Defaults to [true].
      */

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -14,13 +14,13 @@
         "@pulumi/pulumi": "^0.17.4",
         "@pulumi/aws": "^0.18.0",
         "@pulumi/docker": "^0.17.0",
+        "@types/aws-lambda": "^8.10.23",
         "mime": "^2.0.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",
         "@types/mime": "^2.0.0",
         "@types/node": "^10.0.0",
-        "@types/aws-lambda": "^8.10.23",
         "tslint": "^5.11.0",
         "typedoc": "^0.13.0",
         "typescript": "^3.4.1"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/197