### PR TITLE
Revert "Properly parent VPC resources. (#210)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.18.1 (Unreleased)
+## 0.18.2 (Unreleased)
+
+## 0.18.1 (Released 4/14/2019)
 
 - TypeScript typings for awsx.apigateway.API have been updated to be more accurate.
 - Application LoadBalancers/Listeners/TargetGroups will now create a default SecurityGroup for their

--- a/nodejs/awsx/ec2/internetGateway.ts
+++ b/nodejs/awsx/ec2/internetGateway.ts
@@ -30,7 +30,6 @@ export class InternetGateway
         super("awsx:x:ec2:InternetGateway", name, {}, { parent: vpc, ...opts });
 
         this.vpc = vpc;
-        const parentOpts = { parent: this };
 
         if (isExistingInternetGatewayArgs(args)) {
             this.internetGateway = args.internetGateway;
@@ -39,7 +38,7 @@ export class InternetGateway
             this.internetGateway = new aws.ec2.InternetGateway(name, {
                 ...args,
                 vpcId: vpc.vpc.id,
-            }, parentOpts);
+            }, { parent: this });
         }
 
         this.registerOutputs();

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -53,8 +53,6 @@ export class Vpc extends pulumi.ComponentResource {
     constructor(name: string, args: VpcArgs | ExistingVpcArgs = {}, opts?: pulumi.ComponentResourceOptions) {
         super("awsx:x:ec2:Vpc", name, {}, opts);
 
-        const parentOpts = { parent: this };
-
         if (isExistingVpcArgs(args)) {
             this.vpc = args.vpc;
             this.id = this.vpc.id;
@@ -73,12 +71,12 @@ export class Vpc extends pulumi.ComponentResource {
                 enableDnsHostnames: utils.ifUndefined(args.enableDnsHostnames, true),
                 enableDnsSupport: utils.ifUndefined(args.enableDnsSupport, true),
                 instanceTenancy: utils.ifUndefined(args.instanceTenancy, "default"),
-            }, parentOpts);
+            });
             this.id = this.vpc.id;
 
             // Create the appropriate subnets.  Default to a single public and private subnet for each
             // availability zone if none were specified.
-            const topology = new VpcTopology(this, name, cidrBlock, numberOfAvailabilityZones);
+            const topology = new VpcTopology(this, name, cidrBlock, numberOfAvailabilityZones, opts);
             topology.createSubnets(args.subnets || [
                 { type: "public" },
                 { type: "private" },
@@ -125,6 +123,8 @@ export class Vpc extends pulumi.ComponentResource {
         if (this.internetGateway) {
             throw new Error("Cannot add InternetGateway to Vpc that already has one.");
         }
+
+        opts = { parent: this, ...opts };
 
         // See https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html#Add_IGW_Attach_Gateway
         // for more details.

--- a/nodejs/awsx/ec2/vpcTopology.ts
+++ b/nodejs/awsx/ec2/vpcTopology.ts
@@ -28,7 +28,8 @@ export class VpcTopology {
     constructor(private readonly vpc: x.ec2.Vpc,
                 private readonly vpcName: string,
                 vpcCidr: string,
-                private readonly numberOfAvailabilityZones: number) {
+                private readonly numberOfAvailabilityZones: number,
+                private readonly opts: pulumi.ComponentResourceOptions | undefined) {
 
         this.vpcCidrBlock = Cidr32Block.fromCidrNotation(vpcCidr);
     }
@@ -106,7 +107,6 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
         const type = subnetArgs.type;
         const subnets = this.vpc.getSubnets(type);
         const subnetIds = this.vpc.getSubnetIds(type);
-        const parentOpts = { parent: this.vpc };
 
         for (let i = 0; i < this.numberOfAvailabilityZones; i++) {
             const subnetName = getSubnetName(this.vpcName, subnetArgs, i);
@@ -118,7 +118,7 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
                 // merge some good default tags, with whatever the user wants.  Their choices should
                 // always win out over any defaults we pick.
                 tags: utils.mergeTags({ type, Name: subnetName }, subnetArgs.tags),
-            }, parentOpts);
+            }, this.opts);
 
             subnets.push(subnet);
             subnetIds.push(subnet.id);


### PR DESCRIPTION
This reverts commit 84a713411b3f4d6d69ead30bd2d6af8edc1c8569.

We want to take this.  but it will need to come with a minor-version-bump for pulumi/awsx since we're changing parent/child relationships.