### PR TITLE
Use `natGatewayId` instead of `gatewayId` to specify NAT gateway route

### DIFF
--- a/nodejs/awsx/ec2/natGateway.ts
+++ b/nodejs/awsx/ec2/natGateway.ts
@@ -71,7 +71,7 @@ export class NatGateway
             // Choose Add another route. For Destination, type 0.0.0.0/0. For Target, select the ID
             // of your NAT gateway.
             destinationCidrBlock: "0.0.0.0/0",
-            gatewayId: this.natGateway.id,
+            natGatewayId: this.natGateway.id,
         };
     }
 }


### PR DESCRIPTION
Fixes #267.

Per the docs, it appears that `natGatewayId` is the intended way to specify this - it's not clear why `gatewayId` was working to begin with - but it still appears to cause refresh cycle probems as seen in #267.

```ts
    /**
     * Identifier of a VPC internet gateway or a virtual private gateway.
     */
    gatewayId?: pulumi.Input<string>;
    /**
     * Identifier of a VPC NAT gateway.
     */
    natGatewayId?: pulumi.Input<string>;
```