### PR TITLE
Produce a better message when we can't partition the VPC cidr space to meet the user's desired config

### DIFF
--- a/nodejs/awsx/ec2/cidr.ts
+++ b/nodejs/awsx/ec2/cidr.ts
@@ -57,7 +57,7 @@ export class Cidr32Block {
         const ipAddressesInBlock = 2 ** trailing1Bits;
 
         // i.e. if we have 256 ipAddresses in the blockq and the starting ipAddress is
-        // 192.168.100.0, then thene exclusive endIpAddress is 192.168.101.000. Or, inclusively
+        // 192.168.100.0, then then exclusive endIpAddress is 192.168.101.000. Or, inclusively
         // the range is from 192.168.100.0 to 192.168.100.255.
         this.endIpAddressExclusive = startIpAddressInclusive + ipAddressesInBlock;
     }

--- a/nodejs/awsx/tests/ec2/ec2.spec.ts
+++ b/nodejs/awsx/tests/ec2/ec2.spec.ts
@@ -372,4 +372,36 @@ describe("topology", () => {
 ]`);
         });
     });
+
+    describe("small cidr", () => {
+        it("1 AZ, 1 subnet", () => {
+            assert.equal(topologyToJson("10.0.0.0/28", 1, [
+                { type: "private" },
+            ]), `[
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/28"
+    }
+]`);
+        });
+        it("1 AZ, 2 subnets", () => {
+            assert.throws(() => topologyToJson("10.0.0.0/28", 1, [
+                { type: "public" },
+                { type: "private" },
+            ]));
+        });
+        it("2 AZs, 2 subnets", () => {
+            assert.throws(() => topologyToJson("10.0.0.0/28", 2, [
+                { type: "public" },
+                { type: "private" },
+            ]));
+        });
+        it("2 AZs, 1 subnets", () => {
+            assert.throws(() => topologyToJson("10.0.0.0/28", 2, [
+                { type: "private" },
+            ]));
+        });
+    });
 });

--- a/nodejs/awsx/tests/ec2/ec2.spec.ts
+++ b/nodejs/awsx/tests/ec2/ec2.spec.ts
@@ -373,7 +373,158 @@ describe("topology", () => {
         });
     });
 
-    describe("small cidr", () => {
+    describe("26 block", () => {
+        // a 26 block can only fit four subnets since it only has 64 addresses available.
+        it("1 AZ, 1 subnet", () => {
+            assert.equal(topologyToJson("10.0.0.0/26", 1, [
+                { type: "private" },
+            ]), `[
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/26"
+    }
+]`);
+        });
+        it("1 AZ, 2 subnets", () => {
+            assert.equal(topologyToJson("10.0.0.0/26", 1, [
+                { type: "public" },
+                { type: "private" },
+            ]), `[
+    {
+        "type": "public",
+        "subnetName": "testing-public-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/27"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.32/27"
+    }
+]`);
+        });
+        it("2 AZs, 1 subnets", () => {
+            assert.equal(topologyToJson("10.0.0.0/26", 2, [
+                { type: "private" },
+            ]), `[
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/27"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-1",
+        "availabilityZone": 1,
+        "cidrBlock": "10.0.0.32/27"
+    }
+]`);
+        });
+        it("2 AZs, 2 subnets", () => {
+            assert.equal(topologyToJson("10.0.0.0/26", 2, [
+                { type: "public" },
+                { type: "private" },
+            ]), `[
+    {
+        "type": "public",
+        "subnetName": "testing-public-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/28"
+    },
+    {
+        "type": "public",
+        "subnetName": "testing-public-1",
+        "availabilityZone": 1,
+        "cidrBlock": "10.0.0.16/28"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.32/28"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-1",
+        "availabilityZone": 1,
+        "cidrBlock": "10.0.0.48/28"
+    }
+]`);
+        });
+        it("2 AZs, 3 subnets", () => {
+            assert.throws(() => topologyToJson("10.0.0.0/26", 2, [
+                { type: "public" },
+                { type: "private" },
+                { type: "isolated" },
+            ]));
+        });
+    });
+
+    describe("27 block", () => {
+        // a 27 block can only fit two subnets since it only has 32 addresses available.
+        it("1 AZ, 1 subnet", () => {
+            assert.equal(topologyToJson("10.0.0.0/27", 1, [
+                { type: "private" },
+            ]), `[
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/27"
+    }
+]`);
+        });
+        it("1 AZ, 2 subnets", () => {
+            assert.equal(topologyToJson("10.0.0.0/27", 1, [
+                { type: "public" },
+                { type: "private" },
+            ]), `[
+    {
+        "type": "public",
+        "subnetName": "testing-public-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/28"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.16/28"
+    }
+]`);
+        });
+        it("2 AZs, 1 subnets", () => {
+            assert.equal(topologyToJson("10.0.0.0/27", 2, [
+                { type: "private" },
+            ]), `[
+    {
+        "type": "private",
+        "subnetName": "testing-private-0",
+        "availabilityZone": 0,
+        "cidrBlock": "10.0.0.0/28"
+    },
+    {
+        "type": "private",
+        "subnetName": "testing-private-1",
+        "availabilityZone": 1,
+        "cidrBlock": "10.0.0.16/28"
+    }
+]`);
+        });
+        it("2 AZs, 2 subnets", () => {
+            assert.throws(() => topologyToJson("10.0.0.0/27", 2, [
+                { type: "public" },
+                { type: "private" },
+            ]));
+        });
+    });
+
+    describe("28 block", () => {
+        // a 28 block can only fit a single subnet since it only has 16 addresses available.
         it("1 AZ, 1 subnet", () => {
             assert.equal(topologyToJson("10.0.0.0/28", 1, [
                 { type: "private" },
@@ -392,14 +543,14 @@ describe("topology", () => {
                 { type: "private" },
             ]));
         });
-        it("2 AZs, 2 subnets", () => {
+        it("2 AZs, 1 subnets", () => {
             assert.throws(() => topologyToJson("10.0.0.0/28", 2, [
-                { type: "public" },
                 { type: "private" },
             ]));
         });
-        it("2 AZs, 1 subnets", () => {
+        it("2 AZs, 2 subnets", () => {
             assert.throws(() => topologyToJson("10.0.0.0/28", 2, [
+                { type: "public" },
                 { type: "private" },
             ]));
         });


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/275

Note: this solely improves our error we give users here.  Instead of the cryptic:

`Cidr mask must be between "16" and "28" but was 30`

You get:

```
Error: Not enough address space in VPC to create desired subnet config.
VPC has 16 IPs, but is being asked to split into a total of 2 subnets.
2 subnets are necessary to have 2 AZ(s) each with 1 subnet(s) in them.
This needs 8 IPs/subnet, which is smaller than the minimum (16) allowed by AWS.
```