### PR TITLE
Make aws.ec2.Vpc instance a child of awsx.ec2.Vpc

### DIFF
--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -75,7 +75,7 @@ export class Vpc extends pulumi.ComponentResource {
                 enableDnsHostnames: utils.ifUndefined(args.enableDnsHostnames, true),
                 enableDnsSupport: utils.ifUndefined(args.enableDnsSupport, true),
                 instanceTenancy: utils.ifUndefined(args.instanceTenancy, "default"),
-            });
+            }, { parent: this });
             this.id = this.vpc.id;
 
             // Create the appropriate subnets.  Default to a single public and private subnet for each


### PR DESCRIPTION
With `parent` unset, the aws.ec2.Vpc resource which is created by `awsx.ec2.Vpc` components is created as a top-level resource with version 0.17.13 of the Pulumi CLI and the latest version of the package. This leaves the tree rendered as part of `pulumi {preview,update}` somewhat confusing if you have several instances of the class, since not all resources are nested under the component which created them:

```
     Type                                        Name                        Plan
 +   pulumi:pulumi:Stack                         dev                         create
 +   ├─ container                                network                     create
 +   │  ├─ awsx:x:ec2:Vpc                        vpc                         create
 +   │  │  ├─ awsx:x:ec2:InternetGateway         vpc                         create
// Many lines of output elided here
 +   └─ aws:ec2:Vpc                              vpc                         create    // This is always a root resource
```

This PR explicitly sets `parent` to `this` in the constructor of `awsx.ec2.Vpc` to avoid this.