### PR TITLE
Fix build break

### DIFF
--- a/nodejs/awsx/cloudwatch/metric.ts
+++ b/nodejs/awsx/cloudwatch/metric.ts
@@ -329,7 +329,7 @@ export function mergeDimensions(
     });
 }
 
-function hasOwnProperty<T>(obj: T, key: keyof T) {
+function hasOwnProperty<T extends object>(obj: T, key: keyof T) {
     return obj.hasOwnProperty(key);
 }
 


### PR DESCRIPTION
Build was failing with:

```
cloudwatch/metric.ts:333:16 - error TS2339: Property 'hasOwnProperty' does not exist on type 'T'.
333     return obj.hasOwnProperty(key);
```