### PR TITLE
Fix API doc markdown rendering issue

### DIFF
--- a/nodejs/awsx/ecs/metrics.ts
+++ b/nodejs/awsx/ecs/metrics.ts
@@ -55,6 +55,7 @@ export namespace metrics {
      * [Amazon-CloudWatch-User-Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/).
      *
      * Amazon ECS metrics use the AWS/ECS namespace and provide metrics for the following dimensions.
+     *
      * 1. "ClusterName": This dimension filters the data that you request for all resources in a
      *    specified cluster. All Amazon ECS metrics are filtered by ClusterName.
      * 2. "ServiceName": This dimension filters the data that you request for all resources in a

--- a/nodejs/awsx/rds/metrics.ts
+++ b/nodejs/awsx/rds/metrics.ts
@@ -145,6 +145,7 @@ export namespace metrics {
      * automatically sent to CloudWatch in 1-minute periods.
      *
      * Amazon RDS metrics data can be filtered by using any of the following dimensions:
+     *
      * 1. "DBInstanceIdentifier": This dimension filters the data you request for a specific database
      *    instance.
      * 2. "DBClusterIdentifier": This dimension filters the data you request for a specific Amazon

--- a/nodejs/awsx/s3/metrics.ts
+++ b/nodejs/awsx/s3/metrics.ts
@@ -101,6 +101,7 @@ export namespace metrics {
      * filters to specific business applications, workflows, or internal organizations.
      *
      * The following dimensions are used to filter Amazon S3 metrics:
+     *
      * 1. "BucketName": This dimension filters the data you request for the identified bucket only.
      * 2. "StorageType": This dimension filters the data that you have stored in a bucket by the
      *    following types of storage:


### PR DESCRIPTION
Hugo's markdown renderer requires a blank line before lists in order for them to render correctly.

Follow-up from https://github.com/pulumi/docs/pull/1106 so we don't regress next time we generate the docs.