### PR TITLE
Allow users to specify the names used for LBs and TGs

### DIFF
--- a/nodejs/awsx/elasticloadbalancingv2/application.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/application.ts
@@ -267,7 +267,7 @@ export interface ApplicationLoadBalancerArgs {
      * begin or end with a hyphen. If not specified, the [name] parameter passed into the
      * LoadBalancer constructor will be hashed and used as the name.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * Whether or not the load balancer is exposed to the internet. Defaults to `true` if
@@ -368,7 +368,7 @@ export interface ApplicationTargetGroupArgs {
      * TargetGroup constructor will be hashed and used as the name.  If a [loadBalancer] is not
      * provided, this name will be used to name that resource as well.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * The load balancer this target group is associated with.  If not provided, a new load balancer
@@ -452,7 +452,7 @@ export interface ApplicationListenerArgs {
      * An explicit name to use for dependent resources.  Specifically, if a LoadBalancer or
      * TargetGroup is not provided, this name will be used to name those resources.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * The load balancer this listener is associated with.  If not provided, a new load balancer

--- a/nodejs/awsx/elasticloadbalancingv2/application.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/application.ts
@@ -99,7 +99,10 @@ export class ApplicationTargetGroup extends mod.TargetGroup {
     public readonly __isApplicationTargetGroup: boolean;
 
     constructor(name: string, args: ApplicationTargetGroupArgs = {}, opts?: pulumi.ComponentResourceOptions) {
-        const loadBalancer = args.loadBalancer || new ApplicationLoadBalancer(name, { vpc: args.vpc }, opts);
+        const loadBalancer = args.loadBalancer || new ApplicationLoadBalancer(name, {
+            vpc: args.vpc,
+            name: args.name,
+        }, opts);
         const { port, protocol } = computePortInfo(args.port, args.protocol);
 
         super("awsx:x:elasticloadbalancingv2:ApplicationTargetGroup", name, loadBalancer, {
@@ -181,7 +184,10 @@ export class ApplicationListener extends mod.Listener {
             throw new Error("Do not provide both [args.defaultAction] and [args.defaultActions].");
         }
 
-        const loadBalancer = args.loadBalancer || new ApplicationLoadBalancer(name, { vpc: args.vpc }, opts);
+        const loadBalancer = args.loadBalancer || new ApplicationLoadBalancer(name, {
+            vpc: args.vpc,
+            name: args.name,
+        }, opts);
 
         const { port, protocol } = computePortInfo(args.port, args.protocol);
         const { defaultActions, defaultListener } = getDefaultActions(
@@ -237,7 +243,12 @@ function getDefaultActions(
             : { defaultActions: [args.defaultAction], defaultListener: undefined };
     }
 
-    const targetGroup = new ApplicationTargetGroup(name, { loadBalancer, port, protocol }, opts);
+    const targetGroup = new ApplicationTargetGroup(name, {
+        loadBalancer,
+        port,
+        protocol,
+        name: args.name,
+    }, opts);
     return { defaultActions: [targetGroup.listenerDefaultAction()], defaultListener: targetGroup };
 }
 
@@ -249,6 +260,14 @@ export interface ApplicationLoadBalancerArgs {
      * unspecified.
      */
     vpc?: x.ec2.Vpc;
+
+    /**
+     * The name of the LoadBalancer. This name must be unique within your AWS account, can have a
+     * maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not
+     * begin or end with a hyphen. If not specified, the [name] parameter passed into the
+     * LoadBalancer constructor will be hashed and used as the name.
+     */
+    name?: pulumi.Input<string>;
 
     /**
      * Whether or not the load balancer is exposed to the internet. Defaults to `true` if
@@ -345,6 +364,13 @@ export interface ApplicationTargetGroupArgs {
     vpc?: x.ec2.Vpc;
 
     /**
+     * The name of the TargetGroup. If not specified, the [name] parameter passed into the
+     * TargetGroup constructor will be hashed and used as the name.  If a [loadBalancer] is not
+     * provided, this name will be used to name that resource as well.
+     */
+    name?: pulumi.Input<string>;
+
+    /**
      * The load balancer this target group is associated with.  If not provided, a new load balancer
      * will be automatically created.
      */
@@ -421,6 +447,12 @@ export interface ApplicationListenerArgs {
      * unspecified.
      */
     vpc?: x.ec2.Vpc;
+
+    /**
+     * An explicit name to use for this resource and dependent resources.  If a LoadBalancer or
+     * TargetGroup is not provided, this name will be used to name those resources as well.
+     */
+    name?: pulumi.Input<string>;
 
     /**
      * The load balancer this listener is associated with.  If not provided, a new load balancer

--- a/nodejs/awsx/elasticloadbalancingv2/application.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/application.ts
@@ -449,8 +449,8 @@ export interface ApplicationListenerArgs {
     vpc?: x.ec2.Vpc;
 
     /**
-     * An explicit name to use for this resource and dependent resources.  If a LoadBalancer or
-     * TargetGroup is not provided, this name will be used to name those resources as well.
+     * An explicit name to use for dependent resources.  Specifically, if a LoadBalancer or
+     * TargetGroup is not provided, this name will be used to name those resources.
      */
     name?: pulumi.Input<string>;
 

--- a/nodejs/awsx/elasticloadbalancingv2/loadBalancer.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/loadBalancer.ts
@@ -27,7 +27,7 @@ export abstract class LoadBalancer extends pulumi.ComponentResource {
         super(type, name, {}, opts);
 
         const longName = `${name}`;
-        const shortName = utils.sha1hash(`${longName}`);
+        const shortName = args.name || utils.sha1hash(`${longName}`);
 
         const parentOpts = { parent: this };
 
@@ -83,7 +83,7 @@ export interface LoadBalancerArgs {
      * begin or end with a hyphen. If not specified, the [name] parameter passed into the
      * LoadBalancer constructor will be hashed and used as the name.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * Whether or not the load balancer is exposed to the internet. Defaults to `true` if

--- a/nodejs/awsx/elasticloadbalancingv2/loadBalancer.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/loadBalancer.ts
@@ -78,6 +78,14 @@ export interface LoadBalancerArgs {
     vpc?: x.ec2.Vpc;
 
     /**
+     * The name of the LoadBalancer. This name must be unique within your AWS account, can have a
+     * maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not
+     * begin or end with a hyphen. If not specified, the [name] parameter passed into the
+     * LoadBalancer constructor will be hashed and used as the name.
+     */
+    name?: pulumi.Input<string>;
+
+    /**
      * Whether or not the load balancer is exposed to the internet. Defaults to `true` if
      * unspecified.
      */

--- a/nodejs/awsx/elasticloadbalancingv2/network.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/network.ts
@@ -206,7 +206,7 @@ export interface NetworkLoadBalancerArgs {
      * begin or end with a hyphen. If not specified, the [name] parameter passed into the
      * LoadBalancer constructor will be hashed and used as the name.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * Whether or not the load balancer is exposed to the internet. Defaults to `true` if
@@ -297,7 +297,7 @@ export interface NetworkTargetGroupArgs {
      * TargetGroup constructor will be hashed and used as the name.  If a [loadBalancer] is not
      * provided, this name will be used to name that resource as well.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * The load balancer this target group is associated with.  If not provided, a new load balancer
@@ -380,7 +380,7 @@ export interface NetworkListenerArgs {
      * An explicit name to use for dependent resources.  Specifically, if a LoadBalancer or
      * TargetGroup is not provided, this name will be used to name those resources.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * The load balancer this listener is associated with.  If not provided, a new load balancer

--- a/nodejs/awsx/elasticloadbalancingv2/network.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/network.ts
@@ -377,8 +377,8 @@ export interface NetworkListenerArgs {
     vpc?: x.ec2.Vpc;
 
     /**
-     * An explicit name to use for this resource and dependent resources.  If a LoadBalancer or
-     * TargetGroup is not provided, this name will be used to name those resources as well.
+     * An explicit name to use for dependent resources.  Specifically, if a LoadBalancer or
+     * TargetGroup is not provided, this name will be used to name those resources.
      */
     name?: pulumi.Input<string>;
 

--- a/nodejs/awsx/elasticloadbalancingv2/targetGroup.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/targetGroup.ts
@@ -40,7 +40,7 @@ export abstract class TargetGroup
         const parentOpts = { parent: this };
 
         const longName = `${name}`;
-        const shortName = utils.sha1hash(`${longName}`);
+        const shortName = args.name || utils.sha1hash(`${longName}`);
 
         this.vpc = args.vpc;
         this.targetGroup = new aws.elasticloadbalancingv2.TargetGroup(shortName, {
@@ -160,7 +160,7 @@ export interface TargetGroupArgs {
      * The name of the TargetGroup. If not specified, the [name] parameter passed into the
      * TargetGroup constructor will be hashed and used as the name.
      */
-    name?: pulumi.Input<string>;
+    name?: string;
 
     /**
      * The amount time for Elastic Load Balancing to wait before changing the state of a

--- a/nodejs/awsx/elasticloadbalancingv2/targetGroup.ts
+++ b/nodejs/awsx/elasticloadbalancingv2/targetGroup.ts
@@ -157,6 +157,12 @@ export interface TargetGroupArgs {
     vpc: x.ec2.Vpc;
 
     /**
+     * The name of the TargetGroup. If not specified, the [name] parameter passed into the
+     * TargetGroup constructor will be hashed and used as the name.
+     */
+    name?: pulumi.Input<string>;
+
+    /**
      * The amount time for Elastic Load Balancing to wait before changing the state of a
      * deregistering target from draining to unused. The range is 0-3600 seconds. The default value
      * is 300 seconds.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/296

When we ported code down from 'cloud' we unfortunately kept some code that unnecessarily hashes an LB's name to produce the resource name for the actual cloud.  This leads to gibberish in the AWS console for those names, which isn't great.

We can't change this behavior due to the impact it would have on existing stacks.  So, for now, we allow a person to workaround this by explicitly providing the name they'd like to use like so:  `new ApplicationLoadBalancer("PreferredName", { name: "PreferredName" })`.  