### PR TITLE
Properly pass along parent when making invoke call.

### DIFF
--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -62,7 +62,7 @@ export class Vpc extends pulumi.ComponentResource {
         }
         else {
             const cidrBlock = args.cidrBlock === undefined ? "10.0.0.0/16" : args.cidrBlock;
-            const numberOfAvailabilityZones = getNumberOfAvailabilityZones(args.numberOfAvailabilityZones);
+            const numberOfAvailabilityZones = getNumberOfAvailabilityZones(this, args.numberOfAvailabilityZones);
 
             const numberOfNatGateways = args.numberOfNatGateways === undefined ? numberOfAvailabilityZones : args.numberOfNatGateways;
             if (numberOfNatGateways > numberOfAvailabilityZones) {
@@ -235,13 +235,13 @@ export class Vpc extends pulumi.ComponentResource {
 (<any>Vpc.prototype.addInternetGateway).doNotCapture = true;
 (<any>Vpc.prototype.addNatGateway).doNotCapture = true;
 
-function getNumberOfAvailabilityZones(requestedCount: "all" | number | undefined) {
+function getNumberOfAvailabilityZones(vpc: Vpc, requestedCount: "all" | number | undefined) {
     if (typeof requestedCount === "number") {
         return requestedCount;
     }
 
     if (requestedCount === "all") {
-        const availabilityZones = utils.promiseResult(aws.getAvailabilityZones());
+        const availabilityZones = utils.promiseResult(aws.getAvailabilityZones(/*args:*/undefined, { parent: vpc }));
         if (availabilityZones && availabilityZones.names && availabilityZones.names.length > 0) {
             return availabilityZones.names.length;
         }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/314

As mentioned in #314

> Easy to fix, but easy bug to make. I'm going to bring this up at our backcompat discussion tomorrow. If we're willing to break things, we might want to put on the table the idea of just outright moving to a model where "parent" is required. It's basically a footgun for us that keeps hitting us over and over again.