### PR TITLE
Enable ipv6 for Vpc subnets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.18.6 (Unreleased)
 
 - awsx.ecs.Cluster can be created from an existing aws.ecs.Cluster's id.
+- An `awsx.ec2.Vpc` with `assignGeneratedIpv6CidrBlock: true` will now set
+  `assignIpv6AddressOnCreation: true` by default for child subnets.  This can be overridden by
+  setting that value explicitly to `false` with the subnet's args.
 
 ## 0.18.5 (6/12/2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## 0.18.6 (Unreleased)
 
 - awsx.ecs.Cluster can be created from an existing aws.ecs.Cluster's id.
+
+### Compatibility issues
+
 - An `awsx.ec2.Vpc` with `assignGeneratedIpv6CidrBlock: true` will now set
   `assignIpv6AddressOnCreation: true` by default for child subnets.  This can be overridden by
   setting that value explicitly to `false` with the subnet's args.
+
 
 ## 0.18.5 (6/12/2019)
 

--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -178,8 +178,7 @@ export interface SubnetArgs {
      */
     cidrBlock: pulumi.Input<string>;
     /**
-     * Specify true to indicate
-     * that network interfaces created in the specified subnet should be
+     * Specify true to indicate that network interfaces created in the specified subnet should be
      * assigned an IPv6 address. Default is `false`
      */
     assignIpv6AddressOnCreation?: pulumi.Input<boolean>;
@@ -197,9 +196,8 @@ export interface SubnetArgs {
      */
     ipv6CidrBlock?: pulumi.Input<string>;
     /**
-     * Specify true to indicate
-     * that instances launched into the subnet should be assigned
-     * a public IP address. Default is `false`.
+     * Specify true to indicate that instances launched into the subnet should be assigned a public
+     * IP address. Default is `false`.
      */
     mapPublicIpOnLaunch?: pulumi.Input<boolean>;
     /**

--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -52,9 +52,14 @@ export class Subnet extends pulumi.ComponentResource {
             // when importing a subnet.
         }
         else {
+            // Allow the individual subnet to decide it if wants an ipv6 address assigned at
+            // creation. If not specified, assign by default if the Vpc has ipv6 assigned to
+            // it, don't assign otherwise.
+            const assignIpv6AddressOnCreation = utils.ifUndefined(args.assignIpv6AddressOnCreation, vpc.vpc.assignGeneratedIpv6CidrBlock);
             this.subnet = new aws.ec2.Subnet(name, {
                 vpcId: vpc.id,
                 ...args,
+                assignIpv6AddressOnCreation,
             }, parentOpts);
 
             this.routeTable = new aws.ec2.RouteTable(name, {
@@ -179,7 +184,8 @@ export interface SubnetArgs {
     cidrBlock: pulumi.Input<string>;
     /**
      * Specify true to indicate that network interfaces created in the specified subnet should be
-     * assigned an IPv6 address. Default is `false`
+     * assigned an IPv6 address. Default's to `true` if the Vpc this is associated with has
+     * `assignGeneratedIpv6CidrBlock: true`. `false` otherwise.
      */
     assignIpv6AddressOnCreation?: pulumi.Input<boolean>;
     /**

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -15,8 +15,6 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as deasync from "deasync";
-
 import * as x from "..";
 import { getAvailabilityZone } from "./../aws";
 import { VpcTopology } from "./vpcTopology";
@@ -95,7 +93,15 @@ export class Vpc extends pulumi.ComponentResource {
                 const subnet = new x.ec2.Subnet(subnetName, this, {
                     cidrBlock: desc.cidrBlock,
                     availabilityZone: getAvailabilityZone(desc.availabilityZone),
+
+                    // Allow the individual subnet to decide if it wants to be mapped.  If not
+                    // specified, default to mapping a public-ip open if the type is 'public', and
+                    // not mapping otherwise.
                     mapPublicIpOnLaunch: utils.ifUndefined(desc.mapPublicIpOnLaunch, type === "public"),
+
+                    // Allow the individual subnet to decide it if wants an ipv6 address assigned at
+                    // creation. If not specified, assign by default if the Vpc has ipv6 assigned to
+                    // it, don't assign otherwise.
                     assignIpv6AddressOnCreation: utils.ifUndefined(desc.assignIpv6AddressOnCreation, assignGeneratedIpv6CidrBlock);
 
                     // merge some good default tags, with whatever the user wants.  Their choices should

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -86,9 +86,13 @@ export class Vpc extends pulumi.ComponentResource {
                 { type: "private" },
             ]);
 
-            for (const desc of subnetDescriptions) {
+            for (let i = 0, n = subnetDescriptions.length; i < n; i++) {
+                const desc = subnetDescriptions[i];
                 const type = desc.type;
                 const subnetName = desc.subnetName;
+
+                const assignIpv6AddressOnCreation = utils.ifUndefined(desc.assignIpv6AddressOnCreation, assignGeneratedIpv6CidrBlock);
+                const ipv6CidrBlock = createIpv6CidrBlock(this, assignIpv6AddressOnCreation, i);
 
                 const subnet = new x.ec2.Subnet(subnetName, this, {
                     cidrBlock: desc.cidrBlock,
@@ -102,7 +106,8 @@ export class Vpc extends pulumi.ComponentResource {
                     // Allow the individual subnet to decide it if wants an ipv6 address assigned at
                     // creation. If not specified, assign by default if the Vpc has ipv6 assigned to
                     // it, don't assign otherwise.
-                    assignIpv6AddressOnCreation: utils.ifUndefined(desc.assignIpv6AddressOnCreation, assignGeneratedIpv6CidrBlock),
+                    ipv6CidrBlock: ipv6CidrBlock,
+                    assignIpv6AddressOnCreation,
 
                     // merge some good default tags, with whatever the user wants.  Their choices should
                     // always win out over any defaults we pick.
@@ -247,6 +252,43 @@ export class Vpc extends pulumi.ComponentResource {
 
 (<any>Vpc.prototype.addInternetGateway).doNotCapture = true;
 (<any>Vpc.prototype.addNatGateway).doNotCapture = true;
+
+function createIpv6CidrBlock(
+        vpc: Vpc,
+        assignIpv6AddressOnCreation: pulumi.Output<boolean>,
+        index: number): pulumi.Output<string> {
+
+    const result = pulumi.all([vpc.vpc.ipv6CidrBlock, assignIpv6AddressOnCreation])
+                         .apply(([vpcIpv6CidrBlock, assignIpv6AddressOnCreation]) => {
+                    if (!assignIpv6AddressOnCreation) {
+                        return undefined;
+                    }
+
+                    if (!vpcIpv6CidrBlock) {
+                        throw new pulumi.ResourceError(
+"Must set [assignGeneratedIpv6CidrBlock] to true on [Vpc] in order to assign ipv6 address to subnet.", vpc);
+                    }
+
+                    // Should be of the form: 2600:1f16:110:2600::/56
+                    const colonColonIndex = vpcIpv6CidrBlock.indexOf("::");
+                    if (colonColonIndex < 0 ||
+                        vpcIpv6CidrBlock.substr(colonColonIndex) !== "::/56") {
+
+                        throw new pulumi.ResourceError(`Vpc ipv6 cidr block was not in an expected form: ${vpcIpv6CidrBlock}`, vpc);
+                    }
+
+                    const header = vpcIpv6CidrBlock.substr(0, colonColonIndex);
+                    if (!header.endsWith("00")) {
+                        throw new pulumi.ResourceError(`Vpc ipv6 cidr block was not in an expected form: ${vpcIpv6CidrBlock}`, vpc);
+                    }
+
+                    // trim off the 00, and then add 00, 01, 02, 03, etc.
+                    const prefix = header.substr(0, header.length - 2);
+                    return prefix + index.toString().padStart(2, "0") + "::/64";
+                 });
+
+    return <pulumi.Output<string>>result;
+}
 
 function getNumberOfAvailabilityZones(vpc: Vpc, requestedCount: "all" | number | undefined) {
     if (typeof requestedCount === "number") {

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -102,7 +102,7 @@ export class Vpc extends pulumi.ComponentResource {
                     // Allow the individual subnet to decide it if wants an ipv6 address assigned at
                     // creation. If not specified, assign by default if the Vpc has ipv6 assigned to
                     // it, don't assign otherwise.
-                    assignIpv6AddressOnCreation: utils.ifUndefined(desc.assignIpv6AddressOnCreation, assignGeneratedIpv6CidrBlock);
+                    assignIpv6AddressOnCreation: utils.ifUndefined(desc.assignIpv6AddressOnCreation, assignGeneratedIpv6CidrBlock),
 
                     // merge some good default tags, with whatever the user wants.  Their choices should
                     // always win out over any defaults we pick.

--- a/nodejs/awsx/ec2/vpcTopology.ts
+++ b/nodejs/awsx/ec2/vpcTopology.ts
@@ -130,6 +130,8 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
                 subnetName,
                 availabilityZone: i,
                 cidrBlock: this.assignNextAvailableCidrBlock(cidrMask).toString(),
+                mapPublicIpOnLaunch: subnetArgs.mapPublicIpOnLaunch,
+                assignIpv6AddressOnCreation: subnetArgs.assignIpv6AddressOnCreation,
                 tags: subnetArgs.tags,
             });
         }
@@ -153,4 +155,6 @@ interface SubnetDescription {
     availabilityZone: number;
     cidrBlock: string;
     tags?: pulumi.Input<aws.Tags>;
+    mapPublicIpOnLaunch?: pulumi.Input<boolean>;
+    assignIpv6AddressOnCreation?: pulumi.Input<boolean>;
 }

--- a/nodejs/examples/vpc/index.ts
+++ b/nodejs/examples/vpc/index.ts
@@ -32,3 +32,7 @@ const vpcWithOnlyPrivateSubnets = new awsx.ec2.Vpc("custom3", {
         type: "private"
     }]
 });
+
+const vpcWithIpv6 = new awsx.ec2.Vpc("custom4", {
+    assignGeneratedIpv6CidrBlock: true,
+});


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/323

An `awsx.ec2.Vpc` with `assignGeneratedIpv6CidrBlock: true` will now set  `assignIpv6AddressOnCreation: true` by default for child subnets.  This can be overridden by  setting that value explicitly to `false` with the subnet's args.

This changes our behavior and falls under:
https://github.com/pulumi/home/wiki/Compatibility-philosophy-and-guidelines: 

> Changes to existing resources. We may decide at times to change certain defaults for a resource. Or to add information into a resource (for example 'tags'). Because this has the potential to change runtime behavior, we should let customers know and provide them guidance on what to do if they don't want their resource to change (for example, by manually providing the old value).

> If it is possible for the user to keep the resource from not changing through their own actions, then this can be released in a 'patch' release.

Because this behavior can be overridden, this is ok for a patch release.   Changelog has been updated to provide the appropriate informaiton on this.