### PR TITLE
Add OPTIONS and ability to set custom gateway responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   `new awsx.ec2.Vpc("name", { numberOfAvailabilityZones: "all" })` to get this behavior.  If
   `numberOfAvailabilityZones` is not provided, the current behavior of defaulting to 2 availability
   zones remains.
+- Add OPTIONS as a valid method and add ability to set custom gateway responses for
+ [awsx.apigateway.API].
 
 ## 0.18.4 (5/14/2019)
 

--- a/nodejs/awsx/apigateway/swagger_json.ts
+++ b/nodejs/awsx/apigateway/swagger_json.ts
@@ -42,6 +42,9 @@ export interface SwaggerGatewayResponse {
     responseTemplates: {
         "application/json": string,
     };
+    responseParameters?: {
+        [parameter: string]: string,
+    };
 }
 
 export interface SwaggerInfo {
@@ -134,7 +137,7 @@ export interface ApigatewayIntegration {
     credentials?: pulumi.Output<string>;
 }
 
-export type Method = "ANY" | "GET" | "PUT" | "POST" | "DELETE" | "PATCH";
+export type Method = "ANY" | "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "OPTIONS";
 export type IntegrationConnectionType = "INTERNET" | "VPC_LINK";
 export type IntegrationType = "aws" | "aws_proxy" | "http" | "http_proxy" | "mock";
 export type IntegrationPassthroughBehavior = "when_no_match" | "when_no_templates" | "never";

--- a/nodejs/awsx/aws_test.go
+++ b/nodejs/awsx/aws_test.go
@@ -503,7 +503,7 @@ func validateAPITests(apiTests []apiTest) func(t *testing.T, stack integration.R
 
 			if tt.requiredAuth != nil {
 				resp := GetHTTP(t, req, 401)
-				assertRequestBody(t, `{"message":"Unauthorized"}`, false /*skipBodyValidation*/, resp)
+				assertRequestBody(t, `{"message":"401 Unauthorized"}`, false /*skipBodyValidation*/, resp)
 
 				for header, val := range tt.requiredAuth.headers {
 					req.Header.Add(header, val)
@@ -518,7 +518,7 @@ func validateAPITests(apiTests []apiTest) func(t *testing.T, stack integration.R
 
 			if tt.requiredToken != nil {
 				resp := GetHTTP(t, req, 401)
-				assertRequestBody(t, `{"message":"Unauthorized"}`, false /*skipBodyValidation*/, resp)
+				assertRequestBody(t, `{"message":"401 Unauthorized"}`, false /*skipBodyValidation*/, resp)
 
 				token := tt.requiredToken.getAuthToken(t, stack)
 				req.Header.Add(tt.requiredToken.header, token)

--- a/nodejs/examples/api/index.ts
+++ b/nodejs/examples/api/index.ts
@@ -45,6 +45,19 @@ const lambdaAuthorizer: awsx.apigateway.LambdaAuthorizer = {
     authorizerResultTtlInSeconds: 0,
 };
 
+const customUnauthorizedResponse = {
+    "UNAUTHORIZED": {
+        "statusCode": 401,
+        "responseTemplates": {
+            "application/json": "{\"message\":\"401 Unauthorized\"}",
+        },
+        "responseParameters": {
+            "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+        },
+    },
+};
+
 /**
  * In the following example, parameter validation is required for the `/a` route.
  * `curl $(pulumi stack output url)/a?key=hello` would return a 200, whereas
@@ -122,6 +135,7 @@ const api = new awsx.apigateway.API("myapi", {
         authorizers: lambdaAuthorizer,
     }],
     requestValidator: "ALL",
+    gatewayResponses: customUnauthorizedResponse,
 });
 
 // Export the url of the API.
@@ -200,6 +214,7 @@ const apiWithAuthorizer = new awsx.apigateway.API("authorizer-api", {
             handler: authorizerLambda,
         })],
     }],
+    gatewayResponses: customUnauthorizedResponse,
 });
 
 // Create a usage plan + associate the apikey with it
@@ -229,6 +244,7 @@ const apiWithCognitoAuthorizer = new awsx.apigateway.API("cognito-api", {
             providerARNs: [cognitoUserPool],
         })],
     }],
+    gatewayResponses: customUnauthorizedResponse,
 });
 
 export const cognitoUrl = apiWithCognitoAuthorizer.url;


### PR DESCRIPTION
I am working on my demo for Thursday and trying to enable CORS. To do this I need to create an OPTIONS endpoint, and be able to set a custom gateway response for the 401.

I would like to see an improved experience here, but for now this gets the job done:
```ts
    routes: [{
        path: "/hello",
        method: "OPTIONS",
        eventHandler: async () => {
            return {
                statusCode: 200,
                body: "",
                headers: {
                    "Access-Control-Allow-Origin": "*",
                    "Access-Control-Allow-Headers": "*",
                },
            };
        },
    },{
        path: "/hello",
        method: "GET",
        eventHandler: async () => {
            return {
                statusCode: 200,
                body: `{
                    "message": "hello"
                }`,
                headers: {
                    "Access-Control-Allow-Origin": "*",
                    "Access-Control-Allow-Headers": "*",
                },
            };
        },
        authorizers: awsx.apigateway.getTokenLambdaAuthorizer({
            authorizerName: "jwt-rsa-custom-authorizer",
            header: "Authorization",
            handler: authorizerLambda,
            identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
            authorizerResultTtlInSeconds: 3600,
        }),
    }],
    gatewayResponses: {
        "UNAUTHORIZED": {
            "statusCode": 401,
            "responseTemplates": {
                "application/json": "{\"message\": \"401 Unauthorized\" }",
            },
            "responseParameters": {
                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
                "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
            },
        },
    },
```