### PR TITLE
Allow for arbitrary launch configs to be provided for awsx.autoscaling.AutoScalingGroup, not just a specific ec2 launch config.

### DIFF
--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -14,6 +14,7 @@
         "@pulumi/pulumi": "^0.17.18",
         "@pulumi/aws": "^0.18.12",
         "@pulumi/docker": "^0.17.0",
+        "@pulumi/random": "^0.5.3",
         "@types/aws-lambda": "^8.10.23",
         "mime": "^2.0.0",
         "deasync": "^0.1.15"


### PR DESCRIPTION
WIP.  Looking for feedback/thoughts.

We've unfortunately hardcoded in ec2 specific launch config capabilities.  We could deprecate that and try to make thigns more general.  But this approach here also gives an escape hatch for customers that want to supply their own launch configs.