### PR TITLE
Pass parent opts in another location.

### DIFF
--- a/nodejs/awsx/autoscaling/launchConfiguration.ts
+++ b/nodejs/awsx/autoscaling/launchConfiguration.ts
@@ -115,7 +115,7 @@ async function getEcsAmiId(name: string | undefined, opts: pulumi.InvokeOptions)
         // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/retrieve-ecs-optimized_AMI.html
         const ecsRecommendedAMI = await aws.ssm.getParameter({
             name: "/aws/service/ecs/optimized-ami/amazon-linux/recommended",
-        });
+        }, opts);
         return JSON.parse(ecsRecommendedAMI.value).image_id;
     }
 


### PR DESCRIPTION
Missed a case.  Caught by our "long" tests.