### PR TITLE
Do not hash LoadBalancer or TargetGroup names when creating them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* LoadBalancers and TargetGroups will no longer create resources with 'hashed' names.  They will
+  instead use the name provided (like nearly all other resources do).  To prevent impact on existing
+  stacks, aliases have been provided to ensure proper tracking of the resources.
+
 ### Provider fixes + Reparenting
 
 - Many awsx components were both not parented properly and also did not correctly pass 'provider'


### PR DESCRIPTION
Better fix for: https://github.com/pulumi/pulumi-awsx/issues/296

As per internal discussions, we're just going to use the real name a user passed along for the actual resource and not hash anything.

Thanks to aliases we can do this without actually causing changes.  I have tested this out and validated things.  For users that *do* want the resource to change names, tehy will need to pass in a new name.  This will cause recreations.  However, that's acceptable as that's the actual intent of the work.