### PR TITLE
Restore default around how many subnets we pull in for teh default Vpc for a region.

### DIFF
--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -232,7 +232,12 @@ export class Vpc extends pulumi.ComponentResource {
         const vpcId = utils.promiseResult(aws.ec2.getVpc({ default: true }, { provider }).then(v => v.id));
         let vpc = defaultVpcs.get(vpcId);
         if (!vpc) {
-            const publicSubnetIds = utils.promiseResult(aws.ec2.getSubnetIds({ vpcId }, { provider }).then(subnets => subnets.ids));
+            // back compat.  We always would just use the first two public subnets of the region
+            // we're in.  So preserve that, even though we could get all of them here.  Pulling in
+            // more than the two we pulled in before could have deep implications for clients as
+            // those subnets are used to make many downstream resource-creating decisions.
+            const publicSubnetIds = utils.promiseResult(aws.ec2.getSubnetIds({ vpcId }, { provider }).then(subnets => subnets.ids))
+                                         .slice(0, 2);
 
             // Generate the name as `default-` + the actual name.  For back compat with how we
             // previously named things, also create an alias from "default-vpc" to this name for


### PR DESCRIPTION
This broke in https://github.com/pulumi/pulumi-awsx/commit/004393885a8dadae5301c00ee04e526004b5e381 (which has not shipped publicly yet).

previously we hardcoded in: 

```ts
        const subnetIds = vpcId.then(id => aws.ec2.getSubnetIds({ vpcId: id }))
            .then(subnets => subnets.ids);
        const subnet0 = subnetIds.then(ids => ids[0]);
        const subnet1 = subnetIds.then(ids => ids[1]);
        const publicSubnetIds = [subnet0, subnet1];
```

Because i could move away from async to sync, i changed the above to:

```ts
const publicSubnetIds = utils.promiseResult(aws.ec2.getSubnetIds({ vpcId }, { provider }).then(subnets => subnets.ids))
```

We need to restore the original behavior as these public subnets are often queried to make other flow-control or other sorts of downstream decisions.

Note: we could always consider an opt-in flag here if customers want to see all public subnets in the default vpc.