### PR TITLE
Fill in name and binaryMediaTypes in RestApi.

### DIFF
--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -370,7 +370,7 @@ export class API extends pulumi.ComponentResource {
 
         // Create the API Gateway Rest API, using a swagger spec.
         this.restAPI = new aws.apigateway.RestApi(name, {
-            name: swaggerString.apply(s => { const spec = JSON.parse(s); return s.info.title; }),
+            name: swaggerString.apply(s => { const spec = JSON.parse(s); return spec.info.title; }),
             binaryMediaTypes: ["*/*"],
             body: swaggerString,
         }, { parent: this });

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -370,6 +370,8 @@ export class API extends pulumi.ComponentResource {
 
         // Create the API Gateway Rest API, using a swagger spec.
         this.restAPI = new aws.apigateway.RestApi(name, {
+            name: swaggerString.apply(s => { const spec = JSON.parse(s); return s.info.title; }),
+            binaryMediaTypes: ["*/*"],
             body: swaggerString,
         }, { parent: this });
 


### PR DESCRIPTION
Each of these fields is populated by the AWS provider, and any
differences between the read values and the inputs will cause spurious
diffs.

- If `body` is specified, the `name` field will be populated from the
  title present in the Swagger spec. Ensure that we fill in a matching
  name by parsing the spec and extracting its title.
- If `binaryMediaTypes` is unspecified, it will be populated with
  `[ "*/*" ]`, which causes a delete diff. To avoid this, just specify
  `[ "*/*" ]` explicitly.