### PR TITLE
Fix issue causing clusters to not be serializable.

### DIFF
--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -296,6 +296,7 @@ export class Vpc extends pulumi.ComponentResource {
 
 (<any>Vpc.prototype.addInternetGateway).doNotCapture = true;
 (<any>Vpc.prototype.addNatGateway).doNotCapture = true;
+(<any>Vpc.prototype).partition.doNotCapture = true;
 
 function getAvailabilityZones(vpc: Vpc, requestedCount: "all" | number | undefined): topology.AvailabilityZoneDescription[] {
     const result = utils.promiseResult(aws.getAvailabilityZones(/*args:*/ undefined, { parent: vpc }));


### PR DESCRIPTION
This fixes the issue causing awsx to not pass CI.

Note: this demonstrates a general issue we have with complex awsx resources.  We need to ensure each type we have is capturable.  I will open issue to have a test for exactly this.

Opened https://github.com/pulumi/pulumi-awsx/issues/364 to track test hole here.