### PR TITLE
Add support for users opting out of our default resource creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* ecs.TaskDefinition now accepts explicit `null` value for `.logGroup`, `.taskRole` and
+  `.executionRole` to explicitly opt out using or creating any default resources for them.
+
 ## 0.18.7 (2019-07-11)
 
 * LoadBalancers and TargetGroups will no longer create resources with 'hashed' names.  They will

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -373,11 +373,7 @@ export class API extends pulumi.ComponentResource {
             throw new pulumi.ResourceError(
                 "API must specify either [swaggerString] or as least one of the [route] options.", opts.parent);
         }
-        swaggerString = swaggerSpec.apply(s => {
-            const result = JSON.stringify(s);
-            console.log(result);
-            return result;
-        });
+        swaggerString = swaggerSpec.apply(s => JSON.stringify(s));
 
         const stageName = args.stageName || "stage";
 

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -373,7 +373,11 @@ export class API extends pulumi.ComponentResource {
             throw new pulumi.ResourceError(
                 "API must specify either [swaggerString] or as least one of the [route] options.", opts.parent);
         }
-        swaggerString = swaggerSpec.apply(s => JSON.stringify(s));
+        swaggerString = swaggerSpec.apply(s => {
+            const result = JSON.stringify(s);
+            console.log(result);
+            return result;
+        });
 
         const stageName = args.stageName || "stage";
 

--- a/nodejs/awsx/ecs/cluster.ts
+++ b/nodejs/awsx/ecs/cluster.ts
@@ -191,7 +191,7 @@ export interface ClusterArgs {
 
     /**
      * The security group to place new instances into.  If not provided, a default will be
-     * created.
+     * created. Pass an empty array to create no security groups.
      */
     securityGroups?: x.ec2.SecurityGroupOrId[];
 

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -133,21 +133,21 @@ export interface EC2TaskDefinitionArgs {
     // Properties we've added/changed.
 
     /**
-     * Log group for logging information related to the service.  If not provided a default instance
-     * with a one-day retention policy will be created.
+     * Log group for logging information related to the service.  If `undefined` a default instance
+     * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
     logGroup?: aws.cloudwatch.LogGroup;
 
     /**
-     * IAM role that allows your Amazon ECS container task to make calls to other AWS services.
-     * If not provided, a default will be created for the task.
+     * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
+     * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
     taskRole?: aws.iam.Role;
 
     /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
-     * If not provided, a default will be created for the task.
+     * If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
     executionRole?: aws.iam.Role;
 

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -266,21 +266,21 @@ export interface FargateTaskDefinitionArgs {
     // Properties we've added/changed.
 
     /**
-     * Log group for logging information related to the service.  If not provided a default instance
-     * with a one-day retention policy will be created.
+     * Log group for logging information related to the service.  If `undefined` a default instance
+     * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
     logGroup?: aws.cloudwatch.LogGroup;
 
     /**
-     * IAM role that allows your Amazon ECS container task to make calls to other AWS services.
-     * If not provided, a default will be created for the task.
+     * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
+     * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
     taskRole?: aws.iam.Role;
 
     /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
-     * If not provided, a default will be created for the task.
+     *  If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
     executionRole?: aws.iam.Role;
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/344#event-2431687822

I did a sweep of `@pulumi/awsx` for cases where we allow users to pass in a resource, but where we then also produce a default for them if they give us 'nothing'.  Previously 'nothing' was  effectively defined as `null` or `undefined`.  This allowed a good balance of reasonable defaults with user flexibility to provide what they wanted.  However, with our existing system, there was no way to say "i don't want *anything* here".  No matter what you did, you would end up with a Resource. 

We now support the concept of `null` being a way for users to explicitly state that htey do not want a resource at all.  This allows users to do one of:

1. pass nothing (or explicit `undefined`).  In that case, they get a default resource.
2. pass an explicit resource they created and want to use.  We'll respect that resource if provided.
3. pass `null`.  in that case we will not create a resource for them.

Note: we already supported this concept for *lists* of resources.  For lists, the semantics are:

1. pass nothing (or explicit `undefined/null`).  In that case, they get a default list of the right resource.
2. pass in a list explicitly *including the empty list*.  We'll respect that if so. 

In other words, we didn't conflate 'empty' with 'undefined/null'.  This just now extends that concept out to non-list options.