### PR TITLE
Update `@pulumi/docker` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+## 0.18.10 (2019-08-21)
+
+* Updated `@pulumi/awsx` to use the latest version of `@pulumi/docker`.
+
 ## 0.18.9 (2019-08-06)
 
 * Updated `@pulumi/awsx` to use the latest versions of `@pulumi/pulumi` and `@pulumi/aws`.

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0-beta",
         "@pulumi/aws": "^1.0.0-beta",
-        "@pulumi/docker": "^0.17.2",
+        "@pulumi/docker": "^0.17.3",
         "@types/aws-lambda": "^8.10.23",
         "mime": "^2.0.0",
         "deasync": "^0.1.15"


### PR DESCRIPTION
This causes us to require the version of `@pulumi/docker` which depends on `1.0.0-beta`