### PR TITLE
Allow subnets to inherit opts

### DIFF
--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -59,7 +59,7 @@ export class Subnet extends pulumi.ComponentResource {
                 vpcId: vpc.id,
                 ...args,
                 assignIpv6AddressOnCreation,
-            }, { parent: this });
+            }, { ...opts, parent: this });
 
             this.routeTable = new aws.ec2.RouteTable(name, {
                 vpcId: vpc.id,

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -117,7 +117,7 @@ export class Vpc extends pulumi.ComponentResource {
                 availabilityZone,
                 availabilityZoneId,
                 tags: utils.mergeTags({ type: desc.type, Name: desc.subnetName }, desc.args.tags),
-            }, { aliases: [{ parent: opts.parent }], parent: this });
+            }, { aliases: [{ parent: opts.parent }], ...opts, parent: this });
 
             this.addSubnet(desc.type, subnet);
         }


### PR DESCRIPTION
In order to prevent pulumi from deleting `kubernetes.io/cluster/<cluster-name>` tags on my subnets I want to add an `ignoreChanges` on tags for my subnets. This PR allows me to do that with something like:

```
new awsx.ec2.Vpc(name, vpcArgs, { ignoreChanges: ['tags'] });
```

 If anyone has a better approach for solving this problem I'm open to ideas!