### PR TITLE
Allow setting ignoreChanges on VPC Subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* Allow passing `ignoreChanges` into `Subnet`s created as part of an `awsx.ec2.Vpc`.
+
 ## 0.18.10 (2019-08-21)
 
 * Updated `@pulumi/awsx` to use the latest version of `@pulumi/docker`.

--- a/nodejs/awsx/aws_test.go
+++ b/nodejs/awsx/aws_test.go
@@ -79,6 +79,17 @@ func Test_Examples(t *testing.T) {
 			StackName: addRandomSuffix("vpc"),
 		}),
 		testBase.With(integration.ProgramTestOptions{
+			Dir:       path.Join(cwd, "../examples/vpcIgnoreSubnetChanges"),
+			StackName: addRandomSuffix("vpcIgnoreSubnetChanges"),
+			EditDirs: []integration.EditDir{
+				{
+					Dir:             "step2",
+					Additive:        true,
+					ExpectNoChanges: true,
+				},
+			},
+		}),
+		testBase.With(integration.ProgramTestOptions{
 			Dir:                    path.Join(cwd, "../examples/nlb/fargateShort"),
 			StackName:              addRandomSuffix("fargate"),
 			ExtraRuntimeValidation: containersRuntimeValidator(envRegion, true /*isFargate*/, true /*short*/),

--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -59,7 +59,11 @@ export class Subnet extends pulumi.ComponentResource {
                 vpcId: vpc.id,
                 ...args,
                 assignIpv6AddressOnCreation,
-            }, { parent: this });
+            }, {
+                parent: this,
+                // See https://github.com/pulumi/pulumi-awsx/issues/398.
+                ignoreChanges: opts.ignoreChanges,
+            });
 
             this.routeTable = new aws.ec2.RouteTable(name, {
                 vpcId: vpc.id,
@@ -209,6 +213,10 @@ export interface SubnetArgs {
      * A mapping of tags to assign to the resource.
      */
     tags?: pulumi.Input<aws.Tags>;
+    /**
+     * Ignore changes to any of the specified properties of the Subnet.
+     */
+    ignoreChanges?: string[];
 }
 
 // Make sure our exported args shape is compatible with the overwrite shape we're trying to provide.

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -117,7 +117,7 @@ export class Vpc extends pulumi.ComponentResource {
                 availabilityZone,
                 availabilityZoneId,
                 tags: utils.mergeTags({ type: desc.type, Name: desc.subnetName }, desc.args.tags),
-            }, { aliases: [{ parent: opts.parent }], parent: this });
+            }, { aliases: [{ parent: opts.parent }], ignoreChanges: desc.ignoreChanges, parent: this });
 
             this.addSubnet(desc.type, subnet);
         }
@@ -412,6 +412,11 @@ export interface VpcSubnetArgs {
     mapPublicIpOnLaunch?: pulumi.Input<boolean>;
 
     tags?: pulumi.Input<aws.Tags>;
+
+    /**
+     * Ignore changes to any of the specified properties of the Subnet.
+     */
+    ignoreChanges?: string[];
 }
 
 /**

--- a/nodejs/awsx/ec2/vpcTopology.ts
+++ b/nodejs/awsx/ec2/vpcTopology.ts
@@ -251,6 +251,7 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
                     assignIpv6AddressOnCreation,
                     tags: subnetArgs.tags,
                 },
+                ignoreChanges: subnetArgs.ignoreChanges,
             });
         }
 
@@ -341,6 +342,7 @@ class ExplicitLocationTopology extends VpcTopology {
                         assignIpv6AddressOnCreation: utils.ifUndefined(subnetArgs.assignIpv6AddressOnCreation, this.assignGeneratedIpv6CidrBlock),
                         tags: subnetArgs.tags,
                     },
+                    ignoreChanges: subnetArgs.ignoreChanges,
                 };
                 subnetDescriptions.push(subnetDesc);
 
@@ -454,6 +456,7 @@ export interface SubnetDescription {
     type: x.ec2.VpcSubnetType;
     subnetName: string;
     args: x.ec2.SubnetArgs;
+    ignoreChanges?: string[];
 }
 
 

--- a/nodejs/examples/vpcIgnoreSubnetChanges/Pulumi.yaml
+++ b/nodejs/examples/vpcIgnoreSubnetChanges/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: vpc-ignoreSubnetChanges
+runtime: nodejs
+description: A simple vpc demo.

--- a/nodejs/examples/vpcIgnoreSubnetChanges/index.ts
+++ b/nodejs/examples/vpcIgnoreSubnetChanges/index.ts
@@ -1,0 +1,30 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const vpcWithIgnoredSubnetTags = new awsx.ec2.Vpc("custom7", {
+    subnets: [{
+        type: "public",
+        ignoreChanges: ["tags"],
+        // tags: {
+        //     "Something": "Else",
+        // }
+    }],
+}, providerOpts)

--- a/nodejs/examples/vpcIgnoreSubnetChanges/package.json
+++ b/nodejs/examples/vpcIgnoreSubnetChanges/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "vpc",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0-beta",
+        "@pulumi/aws": "^1.0.0-beta",
+        "node-fetch": "^1.7.3",
+        "redis": "^2.8.0"
+    },
+    "devDependencies": {
+        "@types/node": "^10.0.0",
+        "@types/node-fetch": "^1.6.7",
+        "typescript": "^3.4.1"
+    },
+    "peerDependencies": {
+        "@pulumi/awsx": "latest"
+    }
+}

--- a/nodejs/examples/vpcIgnoreSubnetChanges/step2/index.ts
+++ b/nodejs/examples/vpcIgnoreSubnetChanges/step2/index.ts
@@ -1,0 +1,30 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const vpcWithIgnoredSubnetTags = new awsx.ec2.Vpc("custom7", {
+    subnets: [{
+        type: "public",
+        ignoreChanges: ["tags"],
+        tags: {
+            "Something": "Else",
+        }
+    }],
+}, providerOpts)

--- a/nodejs/examples/vpcIgnoreSubnetChanges/tsconfig.json
+++ b/nodejs/examples/vpcIgnoreSubnetChanges/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],        
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Adds one-off support for passing ignoreChanges through to VPC Subnets. This unblocks a common use case where tags may be added outside of Pulumi and need to be ignored.

Longer-term, this will be solved instead via pulumi/pulumi#2068 which will allow customizing any options on child resources via transformation callbacks.

Fixes #398.