### PR TITLE
Don't fail if packages have already been published

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -25,15 +25,36 @@ publish() {
         NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
     fi
 
+    PKG_NAME=$(jq -r .name < package.json)
+    PKG_VERSION=$(jq -r .version < package.json)
+
     # If the package doesn't have a pre-release tag, use the tag of latest instead of
     # dev. NPM uses this tag as the default version to add, so we want it to mean
     # the newest released version.
-    if [[ $(jq -r .version < package.json) != *-* ]]; then
+    if [[ "${PGK_VERSION}" != *-* ]]; then
         NPM_TAG="latest"
     fi
 
-    # Now, perform the publish.
-    npm publish -tag ${NPM_TAG}
+    # Now, perform the publish. The logic here is a little goofy because npm provides
+    # no way to say "if the package already exists, don't fail" but we want these
+    # semantics (so, for example, we can restart builds which may have failed after
+    # publishing, or so two builds can run concurrently, which is the case for when we
+    # tag master right after pushing a new commit and the push and tag travis jobs both
+    # get the same version.
+    #
+    # We exploit the fact that `npm info <package-name>@<package-version>` has no output
+    # when the package does not exist.
+    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+        if ! npm publish -tag "${NPM_TAG}"; then
+	    # if we get here, we have a TOCTOU issue, so check again
+	    # to see if it published. If it didn't bail out.
+	    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+		echo "NPM publishing failed, aborting"
+		exit 1
+	    fi
+
+	fi
+    fi
     npm info 2>/dev/null
 
     # And finally restore the original package.json.


### PR DESCRIPTION
This is https://github.com/pulumi/scripts/pull/84 but for
pulumi/awsx (which doesn't use the shared script because it is not a provider)