### PR TITLE
update link to example

### DIFF
--- a/nodejs/awsx/apigateway/README.md
+++ b/nodejs/awsx/apigateway/README.md
@@ -31,8 +31,7 @@ let endpoint = new awsx.apigateway.API("example", {
     }],
 })
 ```
-
-A complete example can be found [here](https://github.com/pulumi/pulumi-awsx/blob/master/nodejs/awsx/examples/api/index.ts).
+A complete example can be found [here](https://github.com/pulumi/pulumi-awsx/blob/master/nodejs/examples/api/index.ts).
 
 You can also link a route to an existing Lambda using `aws.lambda.Function.get`.
 


### PR DESCRIPTION
This was pointed out by Patrick Flaherty in slack.  Looks like the awsx folder was removed under the examples.