### PR TITLE
Expose ways to customize the Deployment, RestApi and Stage produce by an apigateway.API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* Added options to customize the Deployent, RestApi or Stage produced by an awsx.apigateway.API.
+
 ## 0.18.11 (2019-09-19)
 
 * Allow passing `ignoreChanges` into `Subnet`s created as part of an `awsx.ec2.Vpc`.


### PR DESCRIPTION
Supercedes https://github.com/pulumi/pulumi-awsx/pull/416.

Fixes this part of: https://github.com/pulumi/pulumi-awsx/issues/417

> There's no way to select REGIONAL for the endpoint configuration