### PR TITLE
Allow load balancer to be created using existing lb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Allow the user to pass `family` to the `ecs.TaskDefinition`
+* Allow an existing load balancer be passed to `awsx.lb.LoadBalancer`'s
 
 ## 0.18.13 (2019-10-15)
 

--- a/nodejs/awsx/lb/loadBalancer.ts
+++ b/nodejs/awsx/lb/loadBalancer.ts
@@ -120,7 +120,7 @@ export interface LoadBalancerArgs {
     /**
      * The existing AWS load balancer to use when creating the crosswalk load balancer
      */
-    loadBalancer?: aws.lb.LoadBalancer
+    loadBalancer?: aws.lb.LoadBalancer;
 
     /**
      * If true, deletion of the load balancer will be disabled via the AWS API. This will prevent

--- a/nodejs/awsx/lb/loadBalancer.ts
+++ b/nodejs/awsx/lb/loadBalancer.ts
@@ -116,7 +116,7 @@ export interface LoadBalancerArgs {
      * The type of load balancer to create. Possible values are `application` or `network`.
      */
     loadBalancerType: pulumi.Input<"application" | "network">;
-    
+
     /**
      * The existing AWS load balancer to use when creating the crosswalk load balancer
      */

--- a/nodejs/awsx/lb/loadBalancer.ts
+++ b/nodejs/awsx/lb/loadBalancer.ts
@@ -39,7 +39,7 @@ export abstract class LoadBalancer extends pulumi.ComponentResource {
         // people didn't have direct control over creating the LB.  In awsx though creating the LB
         // is easy to do, so we just let the user pass in the name they want.  We simply add an
         // alias from the old name to the new one to keep things from being recreated.
-        this.loadBalancer = new aws.lb.LoadBalancer(name, {
+        this.loadBalancer = args.loadBalancer || new aws.lb.LoadBalancer(name, {
             ...args,
             subnets: getSubnets(args, this.vpc, external),
             internal: external.apply(ex => !ex),
@@ -116,6 +116,11 @@ export interface LoadBalancerArgs {
      * The type of load balancer to create. Possible values are `application` or `network`.
      */
     loadBalancerType: pulumi.Input<"application" | "network">;
+    
+    /**
+     * The existing AWS load balancer to use when creating the crosswalk load balancer
+     */
+    loadBalancer?: aws.lb.LoadBalancer
 
     /**
      * If true, deletion of the load balancer will be disabled via the AWS API. This will prevent

--- a/nodejs/awsx/lb/loadBalancer.ts
+++ b/nodejs/awsx/lb/loadBalancer.ts
@@ -118,7 +118,7 @@ export interface LoadBalancerArgs {
     loadBalancerType: pulumi.Input<"application" | "network">;
 
     /**
-     * The existing AWS load balancer to use when creating the crosswalk load balancer
+     * An existing aws.lb.LoadBalancer to use when creating the awsx.lb.LoadBalancer.  If this is not provided one will be automatically created.
      */
     loadBalancer?: aws.lb.LoadBalancer;
 


### PR DESCRIPTION
Currently if a load balancer is created in one project, you cannot use crosswalk to create listeners in another project (that I can see anyway).

If I have missed something let me know.