### PR TITLE
Allow the passing of (optional) family as a parameter to ec2Service

### DIFF
--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -155,6 +155,11 @@ export interface EC2TaskDefinitionArgs {
     taskRole?: aws.iam.Role;
 
     /**
+     * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
+     */
+    family?: pulumi.Input<string>;
+
+    /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
      * If `undefined`, a default will be created for the task.  If `null` no role will be created.

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -288,6 +288,11 @@ export interface FargateTaskDefinitionArgs {
     taskRole?: aws.iam.Role;
 
     /**
+     * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
+     */
+    family?: pulumi.Input<string>;
+
+    /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
      *  If `undefined`, a default will be created for the task.  If `null` no role will be created.


### PR DESCRIPTION
Fixes: #439

This will be passed down to the TaskDefiniton