### PR TITLE
Fix duplicate H1 tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/pulumi/pulumi-awsx.svg?token=eHg7Zp5zdDDJfTjY8ejq&branch=master)](https://travis-ci.com/pulumi/pulumi-awsx)
 
-# Pulumi AWS Infrastructure Components
+## Pulumi AWS Infrastructure Components
 
 Pulumi's framework for Amazon Web Services (AWS) infrastructure.
 
@@ -29,7 +29,7 @@ The AWS Infrastructure package exposes many high level abstractions.  Including,
 * ~~`Cluster`~~. Deprecated.  Use [ecs.Cluster](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/awsx/ecs/#clusters) instead.
 
 
-## Installing
+### Installing
 
 This package is available in JavaScript/TypeScript for use with Node.js.  Install it using either `npm`:
 
@@ -39,7 +39,7 @@ or `yarn`:
 
     $ yarn add @pulumi/awsx
 
-## Reference
+### Reference
 
 For detailed reference documentation, please visit [the API docs](
 https://pulumi.io/reference/pkg/nodejs/@pulumi/awsx/index.html).

--- a/nodejs/awsx/apigateway/README.md
+++ b/nodejs/awsx/apigateway/README.md
@@ -1,16 +1,16 @@
-# Pulumi API Gateway Components
+## Pulumi API Gateway Components
 
 Pulumi's API for simplifying working with [API Gateway](https://aws.amazon.com/api-gateway/). The API currently provides ways to define routes that accepts and forwards traffic to a specified destination. A route is a publicly accessible URI that supports the defined HTTP methods and responds according to the route definition.
 
-## Defining an Endpoint
+### Defining an Endpoint
 
 To define an endpoint you will need to specify a route. You can also define the stage name (else it will default to "stage"). A `stage` is an addressable instance of the Rest API.
 
-### Routes
+#### Routes
 
 The destination is determined by the route, which can be an [Event Handler Route](#Event-Handler-Route), a [Static Route](#Static-Route), an [Integration Route](#Integration-Route) or a [Raw Data Route](#Raw-Data-Route).
 
-#### Event Handler Route
+##### Event Handler Route
 
 An Event Handler Route is a route that will map to a [Lambda](https://aws.amazon.com/lambda/). You will need to specify the path, method and the Lambda. Pulumi allows you to define the Lambda inline with your application code and provisions the appropriate permissions on your behalf so that API Gateway can communicate with your Lambda.
 
@@ -71,7 +71,7 @@ let endpoint = new awsx.apigateway.API("example", {
 })
 ```
 
-#### Static Route
+##### Static Route
 
 A Static Route is a route that will map to static content in files/directories. You will need to define the local path and then the files (and subdirectories) will be uploaded into S3 objects. If the local path points to a file, you can specify the content-type. Else, the content types for all files in a directory are inferred.
 
@@ -91,7 +91,7 @@ let endpoint = new awsx.apigateway.API("example", {
 
 A complete example can be found [here](https://github.com/pulumi/pulumi-awsx/blob/master/nodejs/awsx/examples/api/index.ts).
 
-#### Integration Route
+##### Integration Route
 
 An Integration Route is a route that will map an endpoint to a specified backend. The supported types are:
 
@@ -116,7 +116,7 @@ let endpoint = new awsx.apigateway.API("example", {
 
 For more information API Integrations, visit the [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-integration-types.html).
 
-#### Raw Data Route
+##### Raw Data Route
 
 A Raw Data Route is a fallback route for when raw swagger control is desired.  The `data` field should be an object that will be then included in the final swagger specification. For more information on the `x-amazon-apigateway-integration` swagger object, visit the [AWS documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-integration.html).
 
@@ -144,11 +144,11 @@ let endpoint = new awsx.apigateway.API("example", {
 })
 ```
 
-### Request Validation
+#### Request Validation
 
 API Gateway can perform basic validations against request parameters, a request payload or both. When a validation fails, a 400 error is returned immediately.
 
-#### Validators
+##### Validators
 
 Validators can be assigned at the API level or at the method level. The validators defined at a method level override any validator set at the API level.
 
@@ -172,7 +172,7 @@ let endpoint = new awsx.apigateway.API("example", {
 })
 ```
 
-#### Request Parameters
+##### Request Parameters
 
 For each required request parameter, you must define the name and where the parameter is expected (i.e. "path", "query", or "header").
 
@@ -193,11 +193,11 @@ let endpoint = new awsx.apigateway.API("example", {
 })
 ```
 
-#### Request Body
+##### Request Body
 
 Request body validation is currently not supported. If you have a strong use case, please comment on this [open issue](https://github.com/pulumi/pulumi-awsx/issues/198).
 
-### API Keys
+#### API Keys
 
 To require an API Key for an API Gateway route you set the `apiKeyRequired` property equal to `true`. At the API level, you can choose if you want the API Key source to be `HEADER` (i.e. client includes a `x-api-key` header with the API Key) or `AUTHORIZER` (i.e. a Lambda authorizer sends the API Key as part of the authorization response). If the API Key source is not set, then the source will default to `HEADER`.
 
@@ -254,13 +254,13 @@ const apikeys = awsx.apigateway.createAssociatedAPIKeys("my-api-keys", {
 });
 ```
 
-### Lambda Authorizers
+#### Lambda Authorizers
 
 [Lambda Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html) are AWS Lambda functions that provide control access to an API. You can define a Lambda Authorizer for an Event Handler Route or a Static Route. API Gateway supports `request` or `token` type Lambda authorizers. A `token` Lambda Authorizer uses an authorization token (i.e. a header in the form `Authorization: Token <token>`) to authorize the user, whereas a `request` Lambda Authorizer uses the request parameters (i.e. headers, path parameter or query parameters).
 
 To define an Authorizer, you provide a Lambda that fulfills `aws.lambda.EventHandler<AuthorizerEvent, AuthorizerResponse>` or you provide information on a pre-existing Lambda authorizer. The example below shows defining the Authorizer Lambda directly inline. See the [Event Handler Route](#Event-Handler-Route) section for other ways you can define a Lambda for the Authorizer.
 
-#### Request Authorizer
+##### Request Authorizer
 
 Below is an example of a custom `request` Lambda Authorizer that uses `awsx.apigateway.getRequestLambdaAuthorizer` to simplify defining the authorizer.
 
@@ -317,7 +317,7 @@ const api = new awsx.apigateway.API("myapi", {
 });
 ```
 
-#### Token Authorizer
+##### Token Authorizer
 
 Below is an example of a custom `token` Lambda Authorizer that uses `awsx.apigateway.` to simplify the creation of the authorizer.
 
@@ -377,7 +377,7 @@ const api = new awsx.apigateway.API("myapi", {
 });
 ```
 
-#### Specifying the Role
+##### Specifying the Role
 
 If your Authorizer requires access to other AWS resources, you will need to provision the appropriate role. You can do so by using `new aws.lambda.CallbackFunction`.
 
@@ -414,7 +414,7 @@ const api = new awsx.apigateway.API("myapi", {
 });
 ```
 
-#### Using a Pre-existing AWS Lambda
+##### Using a Pre-existing AWS Lambda
 
 You can also define the Lambda Authorizer elsewhere and then reference the required values.
 
@@ -443,7 +443,7 @@ const apiWithAuthorizer = new awsx.apigateway.API("authorizer-api", {
 
 A complete example of defining the Lambda Authorizer elsewhere can be found [here](https://github.com/pulumi/pulumi-awsx/blob/61d2996b8bdb20ea625e66e17ebbaa7b62f9c163/nodejs/awsx/examples/api/index.ts#L94-L152).
 
-#### Authorizer Response
+##### Authorizer Response
 
 A helper function `awsx.apigateway.authorizerResponse` has been created to simplify generating the authorizer response. This can be used when defining the authorizer handler as follows:
 
@@ -468,7 +468,7 @@ const api = new awsx.apigateway.API("myapi", {
 });
 ```
 
-### Cognito Authorizers
+#### Cognito Authorizers
 
 [Cognito Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html) allow you to use [Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html) as an Authorizer for API Gateway. This will require users to sign in to the user pool, obtain an identity/access token and then call your API with said token.
 
@@ -490,7 +490,7 @@ const apiWithCognitoAuthorizer = new awsx.apigateway.API("cognito-protected-api"
 });
 ```
 
-### Swagger String
+#### Swagger String
 
 You can use a OpenAPI specification that is in string form to initialize the API Gateway. This in a way is an escape hatch for implementing featured not yet supported by Pulumi. You must manually provide permission for any route targets to be invoked by API Gateway when using this option.
 

--- a/nodejs/awsx/autoscaling/README.md
+++ b/nodejs/awsx/autoscaling/README.md
@@ -1,8 +1,8 @@
-# Pulumi Autoscaling Components
+## Pulumi Autoscaling Components
 
 AutoScalingGroups (ASGs) allow you to allocate a set of EC2 instances on which to run code (like ECS Services) for a `Cluster`.  Groups can define hard constraints in terms of the minimum, maximum and desired number of instances that should be running.  They can also specify [Scaling Schedules](#scaling-schedules) that control changing these desired values (for example, to scale up on certain days with high expected load), as well as specifying [Scaling Policies](#scaling-policies) that will adjust how the group scales in response to events happening in the system.
 
-## Creating an AutoScalingGroup
+### Creating an AutoScalingGroup
 
 AutoScalingGroups are created for a corresponding `awsx.ecs.Cluster`.  This can be done by either manually creating a cluster, or using `Cluster.getDefault()` to get to the default cluster for the default VPC for the account.  The simplest way to create a `AutoScalingGroup` is to just do:
 
@@ -27,7 +27,7 @@ const autoScalingGroup = cluster.createAutoScalingGroup("testing", {
 
 Here we place in the public subnets of the VPC and provide `associatePublicIpAddress: true` so that instances will have IPs that are externally reachable.
 
-## Template parameters
+### Template parameters
 
 The `templateParameters` allows one to control additional aspects of the ASG.  For example, the following are supported:
 
@@ -35,7 +35,7 @@ The `templateParameters` allows one to control additional aspects of the ASG.  F
 2. Controlling how health checks are performed to determine if new instances should be created.
 3. Specifying an appropriate `defaultCooldown` period which controls how often the ASG actually scales things.  This cooldown period helps avoid rapid runaway scaling scenarios from happening.
 
-## Launch configuration
+### Launch configuration
 
 The `launchConfiguration` (or `launchConfigurationArgs`) properties help control the configuration
 of the actual instances that are launched by the ASG.  A launch configuration is an instance
@@ -47,7 +47,7 @@ launch the instance.
 
 If you don't provide either of these properties, a default configuration will be created on your behalf with basic values set as appropriate.
 
-## Scaling schedules
+### Scaling schedules
 
 Scaling based on a schedule allows you to set your own scaling schedule for predictable load changes. For example, every week the traffic to your web application starts to increase on Wednesday, remains high on Thursday, and starts to decrease on Friday. You can plan your scaling actions based on the predictable traffic patterns of your web application. Scaling actions are performed automatically as a function of time and date.
 
@@ -79,7 +79,7 @@ autoScalingGroup.scaleOnSchedule("scaleDownOnMonday", {
 });
 ```
 
-## Scaling policies
+### Scaling policies
 
 A more advanced way to scale; scaling policies lets you define parameters that control the scaling process. For example, you could have a web application that currently runs on two EC2 instances and you want the CPU utilization of the group to stay at around 50 percent when the load on the application changes. This is useful for scaling in response to changing conditions, when you don't necessarily know a specific schedule when those conditions will change.
 
@@ -98,7 +98,7 @@ There are two main ways to scale on demand:
    target based on a set of scaling adjustments, known as step adjustments. The adjustments vary
    based on the size of the alarm breach.
 
-### Target tracking scaling
+#### Target tracking scaling
 
 With target tracking scaling policies, you select a scaling metric and set a target value. Amazon
 EC2 Auto Scaling creates and manages the CloudWatch alarms that trigger the scaling policy and
@@ -107,7 +107,7 @@ or removes capacity as required to keep the metric at, or close to, the specifie
 addition to keeping the metric close to the target value, a target tracking scaling policy also
 adjusts to the changes in the metric due to a changing load pattern.
 
-#### Predefined target tracking scaling
+##### Predefined target tracking scaling
 
 AutoScalingGroups provide several predefined scaling metrics.
 
@@ -161,7 +161,7 @@ const policy = autoScalingGroup.scaleToTrackRequestCountPerTarget("onHighRequest
 });
 ```
 
-#### Custom metric target tracking scaling
+##### Custom metric target tracking scaling
 
 On top of the predefined targets defined above, you can also scale to any arbitrary
 [awsx.cloudwatch.Metric].  Note: not all metrics work for target tracking. This can be important
@@ -187,7 +187,7 @@ autoScalingGroup.scaleToTrackMetric("keepAround50Percent", {
 });
 ```
 
-### Step scaling
+#### Step scaling
 
 Step scaling policies increase or decrease the current capacity of your Auto Scaling group based on
 a set of scaling adjustments, known as step adjustments. The adjustments vary based on the size of

--- a/nodejs/awsx/cloudwatch/README.md
+++ b/nodejs/awsx/cloudwatch/README.md
@@ -1,4 +1,4 @@
-# Pulumi Cloudwatch Components
+## Pulumi Cloudwatch Components
 
 Amazon CloudWatch monitors your Amazon Web Services (AWS) resources and the applications you run on AWS in real time. You can use Pulumi's CloudWatch components to collect and track [metrics](#Metrics), which are variables you can measure for your resources and applications.
 
@@ -8,7 +8,7 @@ You can create [alarms](#Alarms) which watch metrics and send notifications or a
 
 With CloudWatch, you gain system-wide visibility into resource utilization, application performance, and operational health.
 
-## Metrics
+### Metrics
 
 [Metric](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/metric.ts#L46) resources are the fundamental concept in CloudWatch. A metric represents a time-ordered set of data points that are published to CloudWatch. Think of a metric as a variable to monitor, and the data points as representing the values of that variable over time. For example, the CPU usage of a particular EC2 instance is one metric provided by Amazon EC2. The data points themselves can come from any application or business activity from which you collect data.
 
@@ -20,7 +20,7 @@ Metrics are uniquely defined by a name, a namespace, and zero or more dimensions
 
 see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric for more details.
 
-### Predefined metrics
+#### Predefined metrics
 
 Most commonly, applications will want to work with existing metrics produced by AWS services.  These metrics are exposed through the corresponding for awsx module in a submodule called `metrics`.  For example:
 
@@ -37,7 +37,7 @@ In this example, this will return the metric giving information about how long e
 
 Not all of these can be controlled for a particular metric, and not all values are legal for any given metric.  For example, some metrics may not support collecting the `Maximum` statistic.  See the docs for each individual Metric for more information on what is specifiable or not.
 
-## Alarms
+### Alarms
 
 You can create a CloudWatch alarm that watches a single CloudWatch metric. The alarm performs one or more actions based on the value of the metric or expression relative to a threshold over a number of time periods. The action can be an Amazon EC2 action, an Amazon EC2 Auto Scaling action, or a notification sent to an Amazon SNS topic.
 
@@ -45,11 +45,11 @@ You can also add alarms to CloudWatch dashboards and monitor them visually. When
 
 Alarms invoke actions for sustained state changes only. CloudWatch alarms do not invoke actions simply because they are in a particular state, the state must have changed and been maintained for a specified number of periods.
 
-After an alarm invokes an action due to a change in state, its subsequent behavior depends on the type of action that you have associated with the alarm. For Amazon EC2 Auto Scaling actions, the alarm continues to invoke the action for every period that the alarm remains in the new state. For Amazon SNS notifications, no additional actions are invoked. 
+After an alarm invokes an action due to a change in state, its subsequent behavior depends on the type of action that you have associated with the alarm. For Amazon EC2 Auto Scaling actions, the alarm continues to invoke the action for every period that the alarm remains in the new state. For Amazon SNS notifications, no additional actions are invoked.
 
 When creating an alarm, the following can be specified:
 
-1. `threshold`.  The value to compare the metric value against. 
+1. `threshold`.  The value to compare the metric value against.
 2. `comparisonOperator`.  The type of comparison that should be made between the metric value and the threshold value.  The default is `"GreaterThanOrEqualToThreshold"`.
 3. `evaluationPeriods`.  The number of periods over which data is compared to the specified threshold.
 
@@ -76,7 +76,7 @@ const alarm = funcMetric.createAlarm("alarm", {
 
 See [Autoscaling Scaling Policies](https://github.com/pulumi/pulumi-awsx/tree/master/nodejs/awsx/autoscaling#scaling-policies) for more details on easily connecting metric changes to autoscaling group changes.
 
-## Dashboards
+### Dashboards
 
 Amazon CloudWatch dashboards are customizable home pages in the CloudWatch console that you can use to monitor your resources in a single view, even those resources that are spread across different Regions. You can use CloudWatch dashboards to create customized views of the metrics and alarms for your AWS resources.
 
@@ -86,20 +86,20 @@ With dashboards, you can create the following:
 2. An operational playbook that provides guidance for team members during operational events about how to respond to specific incidents.
 3. A common view of critical resource and application measurements that can be shared by team members for faster communication flow during operational events.
 
-### Widgets
+#### Widgets
 
 Dashboards are created from [Widgets](#Widgets) that are then automatically placed on a 24 unit wide, infinitely tall grid, based on flow constraints.  When creating widgets, a desired Width-x-Height cab be supplied (otherwise a default size of 6x6 is used).  Widgets can then be related to other widgets by either placing them in a [Column](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_flow.ts#L96) or in a [Row](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_flow.ts#L130).  Widgets placed in a column can flow veritically as far as necessary.  Widgets placed in a row will wrap automatically after 24 grid spaces.
 
-#### Text widgets
+##### Text widgets
 
 You can place a simple piece of text on the dashboard using a [Text Widget](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_simple.ts#L127).  These can contain markdown and will be rendered by the dashboard in the requested location and size.
 
-#### Space widgets
+##### Space widgets
 
 The [Space Widget](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_simple.ts#L92) acts as a simple mechanism to place a gap (with a desired Width-x-Height) in between other widgets.
 
 
-#### Metric widgets
+##### Metric widgets
 
 The most common widgets that will be added to a Dashboard are 'metric' widgets.  i.e. widgets that display the latest reported values of some metric.  These metrics can be shown on the dashboard as either a [ine-graph](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_graph.ts#L64), [stacked-graph](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_graph.ts#L75), or as a [single-number](https://github.com/pulumi/pulumi-awsx/blob/27e8d976c2bb4e856937af90ad2633b6ad11e568/nodejs/awsx/cloudwatch/widgets_graph.ts#L86).  Creating these can be done like so:
 

--- a/nodejs/awsx/ec2/README.md
+++ b/nodejs/awsx/ec2/README.md
@@ -1,9 +1,9 @@
 
-# Pulumi EC2 Components
+## Pulumi EC2 Components
 
 Pulumi's API's for simplifying workin with [EC2](https://aws.amazon.com/ec2/).  The API currently primarily provides ways to define and configure a Virtual Private Cloud ([VPC](https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html)), as well as customize the [Security Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html) around it.
 
-## The Default VPC
+### The Default VPC
 
 By default, Amazon will create a 'Default VPC' in all regions of your account.  You can read more about this Default VPC [here](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html).  This VPC can be easily acquired in the following manner:
 
@@ -16,7 +16,7 @@ const vpc = awsx.ec2.Vpc.getDefault();
 
 Many components in awsx work with a specific VPC (for example, Clusters and LoadBalancers).  However, if a specific VPC is not provided, they will use this default VPC instead.  This makes it simple to set up infrastructure for the default VPC without having to explicitly provide it all the time.
 
-## Custom VPCs
+### Custom VPCs
 
 While using the default VPC can be very simple and convenient, it is not always desirable to do so, and it can often be advantageous to define your own VPCs with their own custom topology.  Doing this allows more fine grained control over many parts of the network structure including, but not limited to, controlling IP address configuration, as well as ingress/egress security filtering.
 
@@ -35,7 +35,7 @@ const vpc = new awsx.ec2.Vpc("custom", {
 
 This range will then be partitioned accordingly into the VPC depending on the other arguments provided.  The additional arguments that affect this partitioning are `subnets` and `numberOfAvailabilityZones`.
 
-## Availability Zones
+### Availability Zones
 
 Availability Zones are distinct locations that are engineered to be isolated from failures in other Availability Zones. By launching instances in separate Availability Zones, you can protect your applications from the failure of a single location
 
@@ -53,7 +53,7 @@ const vpc = new awsx.ec2.Vpc("custom", {
 
 Each availability zone will get an approximately equal share of the total CIDR address space for the VPC.
 
-## Subnets
+### Subnets
 
 Subnets allow you partition each availability zone into regions with different levels of access.  A `public` subnet is one whose traffic is routed to an [Internet Gateway (IG)](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html).  A `private` subnet is one that is configured to use a [NAT Gateway(NAT)](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat.html) so that it can reach the internet, but which prevents the internet from initiating connections to it.  Finally, an `isolated` subnet is one that cannot reach the internet either through an IG or with NAT.
 
@@ -101,7 +101,7 @@ const vpc = new awsx.ec2.Vpc("custom", {
 
 By default the subnets will divide the CIDR space for each availability zone equally.  If this is not desired, a particular size for each zone can be requested by passing in an appropriate netmask value between 16 and 28.  See [VPC and Subnet Sizing](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#VPC_Sizing) for more details.  This value can be provided for specific subnets you know the number of instances you want IP addresses for.  Whatever IP addresses are remaining in the availablity zone will be split over the subnets that do not provide a defined size.
 
-## Gateways
+### Gateways
 
 By default any VPC with `public` subnets will have an Internet Gateway created for it.  All `public` subnets will be routable for all IPv4 addresses connections.
 
@@ -120,7 +120,7 @@ const vpc = new awsx.ec2.Vpc("custom", {
 
 In the case where there is one NAT gateway per availability zone, then routing is very simple.  Each `private` subnet will have have connections routed through gateway in that availability zone.  In the case where there are less NAT gateways than availability zones, then routing works slightly differently.  If there are N NAT gateways requested, then the first N availability zones will get a NAT gateway.  Routing to `private` subnets in those availability zones works as above.  However, all remaining availability zones will have their `private` subnets routed to in a round-robin fashion from the availability zones with NAT gateways.  While this can save money, it also introduces higher risk as failure of one availability zone may impact others.
 
-## Security Groups
+### Security Groups
 
 All traffic in and out of a VPC is controlled by [Security Groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html).  Security groups can control incoming traffic through `ingress` rules and outgoing traffic through `egress` rules.  `ingress` and `egress` can be customized like so:
 

--- a/nodejs/awsx/lb/README.md
+++ b/nodejs/awsx/lb/README.md
@@ -1,8 +1,8 @@
-# Pulumi Elastic Load Balancing Components
+## Pulumi Elastic Load Balancing Components
 
 Pulumi's API's for simplifying [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/).  The API provides a simple way to create either Application (ALB) or Network (NLB) load balancers, and their associated Target Groups and Listeners.  For more details, see [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) and [Network Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html).
 
-## Network Load Balancer
+### Network Load Balancer
 
 To create an NLB
 
@@ -80,7 +80,7 @@ const nginx = new awsx.ecs.EC2Service("examples-nginx", {
 });
 ```
 
-# Application Load Balancers
+## Application Load Balancers
 
 ALBs follow the same pattern above as NLBs.  To create ad use them, simply replace usages of `Network` above with `Application`.  i.e. instead of `new awsx.lb.NetworkLoadBalancer` use `new awsx.lb.ApplicationLoadBalancer`.
 


### PR DESCRIPTION
When these get pulled into the docs site, they currently render multiple H1 tags, which flags them in our SEO alerts. This just turns the `H1`s into `H2`s, and moves everything below them one level in.