### PR TITLE
Fix networkMode for Windows ecs task definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Fix networkMode for Windows ecs ec2 task definition. Removed the default assignment of 
+  networkMode = 'awsvpc' when networkMode is undefined. It is required to leave networkMode
+  undefined for Windows container task definitions.
 
 ## 0.18.14 (2019-11-21)
 * Allow the user to pass `family` to the `ecs.TaskDefinition`

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -33,7 +33,6 @@ export class EC2TaskDefinition extends ecs.TaskDefinition {
             ...args,
             containers,
             requiresCompatibilities: ["EC2"],
-            networkMode: utils.ifUndefined(args.networkMode, "awsvpc"),
         };
 
         delete (<any>argsCopy).container;


### PR DESCRIPTION
Don't default to networkMode = "awsvpc" if networkMode is undefined.
This is needed to support Windows container task definitions, which are required to be configured with networkMode undefined.

See aws documentation: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html