### PR TITLE
README change to rename security group to valid name

### DIFF
--- a/nodejs/awsx/ec2/README.md
+++ b/nodejs/awsx/ec2/README.md
@@ -132,12 +132,12 @@ const vpc = new awsx.ec2.Vpc("custom", {
    // ...
 });
 
-const sg = new awsx.ec2.SecurityGroup(`sg`, { vpc });
-SecurityGroupRule.ingress("https-access", sg,
+const sg = new awsx.ec2.SecurityGroup("custom", { vpc });
+awsx.ec2.SecurityGroupRule.ingress("https-access", sg,
    new awsx.ec2.AnyIPv4Location(),
    new awsx.ec2.TcpPorts(443),
    "allow https access");
-SecurityGroupRule.ingress("ssd-access", sg,
+awsx.ec2.SecurityGroupRule.ingress("ssd-access", sg,
    new awsx.ec2.AnyIPv4Location(),
    new awsx.ec2.TcpPorts(22),
    "allow ssh access");


### PR DESCRIPTION
Renames the security group to a valid name and adds the `awsx.ec2` namespace.

As "sg" the security group failed to be created with an error from AWS:
```
error: Error creating Security Group: InvalidParameterValue: Value (sg-017c251) for parameter GroupName is invalid. Group names may not be in the format sg-*.
```