### PR TITLE
apigateway.Deployment - account for all args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+## 0.19.1 (2020-01-20)
+
+- Account for all scenarios where an API Gateway REST API should be redeployed. For more details see:
+  [#485](https://github.com/pulumi/pulumi-awsx/issues/485).
+
 ## 0.19.0 (2020-01-15)
 
 * Due the necessity to perform many async operations during creation, many parts of an

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -554,7 +554,7 @@ export class API extends pulumi.ComponentResource {
         }, { parent: this });
 
         // Account for all potential REST API Args that should trigger a redeployment
-        let argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize, this.restAPI.policy, swaggerString]).apply(
+        const argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize, this.restAPI.policy, swaggerString]).apply(
             ( [apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger]) => (JSON.stringify({apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger}))
         ) 
 

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -554,33 +554,9 @@ export class API extends pulumi.ComponentResource {
         }, { parent: this });
 
         // Account for all potential REST API Args that should trigger a redeployment
-        const argsHash = pulumi
-          .all([
-            this.restAPI.apiKeySource,
-            this.restAPI.binaryMediaTypes,
-            this.restAPI.endpointConfiguration,
-            this.restAPI.minimumCompressionSize,
-            this.restAPI.policy,
-            swaggerString,
-          ])
-          .apply(
-            ([
-              apiKey,
-              binaryMediaTypes,
-              endpointConfig,
-              minimumCompression,
-              policy,
-              swagger,
-            ]) =>
-              JSON.stringify({
-                apiKey,
-                binaryMediaTypes,
-                endpointConfig,
-                minimumCompression,
-                policy,
-                swagger,
-              }),
-          );
+        const argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize,
+            this.restAPI.policy, swaggerString ]).apply(([apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger ]) => JSON.stringify({apiKey,
+                binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger }) );
 
         // Create a deployment of the Rest API.
         this.deployment = new aws.apigateway.Deployment(name, {

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -554,9 +554,33 @@ export class API extends pulumi.ComponentResource {
         }, { parent: this });
 
         // Account for all potential REST API Args that should trigger a redeployment
-        const argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize, this.restAPI.policy, swaggerString]).apply(
-            ( [apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger]) => (JSON.stringify({apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger}))
-        ) 
+        const argsHash = pulumi
+          .all([
+            this.restAPI.apiKeySource,
+            this.restAPI.binaryMediaTypes,
+            this.restAPI.endpointConfiguration,
+            this.restAPI.minimumCompressionSize,
+            this.restAPI.policy,
+            swaggerString,
+          ])
+          .apply(
+            ([
+              apiKey,
+              binaryMediaTypes,
+              endpointConfig,
+              minimumCompression,
+              policy,
+              swagger,
+            ]) =>
+              JSON.stringify({
+                apiKey,
+                binaryMediaTypes,
+                endpointConfig,
+                minimumCompression,
+                policy,
+                swagger,
+              }),
+          );
 
         // Create a deployment of the Rest API.
         this.deployment = new aws.apigateway.Deployment(name, {


### PR DESCRIPTION
- Include the following outputs from the REST API
- API Key Source
- Binary Media Types
- Endpoint Configuration
- Minimum Compression Size
- Gateway Policy
- Swagger string containing route information

Including these arguments should trigger a redeployment of the API whenever any of the above change

Closes #485 