### PR TITLE
Expand the set of parameters to an APIGateway that will force redeployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-## 0.19.1 (2020-01-20)
+- Account for all scenarios where an API Gateway REST API should be redeployed. For more details
+  see: [#485](https://github.com/pulumi/pulumi-awsx/issues/485).
 
-- Account for all scenarios where an API Gateway REST API should be redeployed. For more details see:
-  [#485](https://github.com/pulumi/pulumi-awsx/issues/485).
+  This will cause all existing `awsx.apigateway.API`s to be redeployed.  However, these resources
+  are safe to redeploy with zero downtime, so existing stacks should not be negatively affected.
 
 ## 0.19.0 (2020-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+## 0.19.1 (2020-01-20)
+
+- Account for all scenarios where an API Gateway REST API should be redeployed. For more details see:
+  [#485](https://github.com/pulumi/pulumi-awsx/issues/485).
+
 ## 0.19.0 (2020-01-15)
 
 * Due the necessity to perform many async operations during creation, many parts of an

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -553,6 +553,11 @@ export class API extends pulumi.ComponentResource {
             body: swaggerString,
         }, { parent: this });
 
+        // Account for all potential REST API Args that should trigger a redeployment
+        const argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize,
+            this.restAPI.policy, swaggerString ]).apply(([apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger ]) => JSON.stringify({apiKey,
+                binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger }) );
+
         // Create a deployment of the Rest API.
         this.deployment = new aws.apigateway.Deployment(name, {
             ...args.deploymentArgs,
@@ -566,7 +571,7 @@ export class API extends pulumi.ComponentResource {
             // when needed.  The Stage allocated below will be the stable stage that always points
             // to the latest deployment of the API.
             variables: {
-                version: swaggerString.apply(s => sha1hash(s)),
+                version: argsHash.apply(s => sha1hash(s)),
             },
         }, { parent: this });
 

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -554,9 +554,10 @@ export class API extends pulumi.ComponentResource {
         }, { parent: this });
 
         // Account for all potential REST API Args that should trigger a redeployment
-        const argsHash = pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize,
-            this.restAPI.policy, swaggerString ]).apply(([apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger ]) => JSON.stringify({apiKey,
-                binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger }) );
+        const version =
+            pulumi.all([this.restAPI.apiKeySource, this.restAPI.binaryMediaTypes, this.restAPI.endpointConfiguration, this.restAPI.minimumCompressionSize, this.restAPI.policy, swaggerString ])
+                  .apply(([apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger ]) =>
+                        sha1hash(JSON.stringify({apiKey, binaryMediaTypes, endpointConfig, minimumCompression, policy, swagger })));
 
         // Create a deployment of the Rest API.
         this.deployment = new aws.apigateway.Deployment(name, {
@@ -570,9 +571,7 @@ export class API extends pulumi.ComponentResource {
             // end up anywhere.  But this will still cause the right replacement of the Deployment
             // when needed.  The Stage allocated below will be the stable stage that always points
             // to the latest deployment of the API.
-            variables: {
-                version: argsHash.apply(s => sha1hash(s)),
-            },
+            variables: { version },
         }, { parent: this });
 
         this.swaggerLambdas = swaggerLambdas || new Map();


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/485

- Include the following outputs from the REST API
- API Key Source
- Binary Media Types
- Endpoint Configuration
- Minimum Compression Size
- Gateway Policy
- Swagger string containing route information

Including these arguments should trigger a redeployment of the API whenever any of the above change