### PR TITLE
Update dependent version of @pulumi/pulumi to ensure it has an API we call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Explicitly require @pulumi/pulumi v1.9.1 and up as it contains an API that awsx depends on.
+
 ## 0.19.1 (2020-01-22)
 
 - Account for all scenarios where an API Gateway REST API should be redeployed. For more details

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -11,7 +11,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-awsx",
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/pulumi": "^1.9.1",
         "@pulumi/aws": "^1.0.0",
         "@pulumi/docker": "^1.0.0",
         "@types/aws-lambda": "^8.10.23",


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/495