### PR TITLE
Fix ECS TaskDefinitionArgs type does not accept null

### DIFF
--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -146,13 +146,13 @@ export interface EC2TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
@@ -164,7 +164,7 @@ export interface EC2TaskDefinitionArgs {
      *
      * If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * The Docker networking mode to use for the containers in the task. The valid values are

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -279,13 +279,13 @@ export interface FargateTaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
@@ -297,7 +297,7 @@ export interface FargateTaskDefinitionArgs {
      *
      *  If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * The number of cpu units used by the task.  If not provided, a default will be computed

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -276,11 +276,11 @@ function computeContainerDefinitions(
 type OverwriteShape = utils.Overwrite<aws.ecs.TaskDefinitionArgs, {
     family?: pulumi.Input<string>;
     containerDefinitions?: never;
-    logGroup?: aws.cloudwatch.LogGroup
+    logGroup?: aws.cloudwatch.LogGroup | null
     taskRoleArn?: never;
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
     executionRoleArn?: never;
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
     cpu?: pulumi.Input<string>;
     memory?: pulumi.Input<string>;
     requiresCompatibilities: pulumi.Input<["FARGATE"] | ["EC2"]>;
@@ -315,20 +315,20 @@ export interface TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null`, no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null`, no task will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
      * If `undefined`, a default will be created for the task.  If `null`, no task will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.


### PR DESCRIPTION
Documented as "If `null` no XXX will be created." but its type does not accept null. This PR fixes it!