### PR TITLE
Implement ListenerActions in TargetGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
 - Explicitly require `@pulumi/pulumi@>=1.9.1` as it contains an API that awsx depends on.
   [#492](https://github.com/pulumi/pulumi-awsx/pull/492)
 
+- Allow the user to pass `TargetGroup` as `actions` of `ListenerRule`.
+  [#503](https://github.com/pulumi/pulumi-awsx/pull/503)
+
 ## 0.19.1 (2020-01-22)
 
 - Account for all scenarios where an API Gateway REST API should be redeployed. For more details

--- a/nodejs/awsx/lb/targetGroup.ts
+++ b/nodejs/awsx/lb/targetGroup.ts
@@ -25,7 +25,8 @@ export abstract class TargetGroup
     extends pulumi.ComponentResource
     implements x.ecs.ContainerPortMappingProvider,
     x.ecs.ContainerLoadBalancerProvider,
-    x.lb.ListenerDefaultAction {
+    x.lb.ListenerDefaultAction,
+    x.lb.ListenerActions {
 
     public readonly loadBalancer: mod.LoadBalancer;
     public readonly targetGroup: aws.lb.TargetGroup;
@@ -93,6 +94,10 @@ export abstract class TargetGroup
             targetGroupArn: this.targetGroup.arn,
             type: "forward",
         }));
+    }
+
+    public actions(): aws.lb.ListenerRuleArgs["actions"] {
+        return [this.listenerDefaultAction()];
     }
 
     /** Do not call directly.  Intended for use by [Listener] and [ListenerRule] */


### PR DESCRIPTION
We can pass targetGroup to actions with this PR:

```ts
listener.addListenerRule('listener-rule', {
  conditions: [{ pathPattern: { values: ['/directory/*'] } }],
  actions: targetGroup,
  priority: 10
})
```