### PR TITLE
Default a container's log name to something more useful.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- The default log stream for an `awsx.ecs.Container` has changed.  Previously it would a stream named `container-name/container-name/task-id`.  Now it will be `service-or-task-name/container-name/task-id`.  See []() for more details.
+- The default log stream for an `awsx.ecs.Container` has changed.  Previously it would a stream named `container-name/container-name/task-id`.  Now it will be `service-or-task-name/container-name/task-id`.  See [#507](https://github.com/pulumi/pulumi-awsx/pull/507) for more details.
 
 ## 0.19.2 (2020-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- The default log stream for an `awsx.ecs.Container` has changed.  Previously it would a stream named `container-name/container-name/task-id`.  Now it will be `service-or-task-name/container-name/task-id`.  See []() for more details.
+
 ## 0.19.2 (2020-01-31)
 
 - Add support for `FirelensConfiguration` to `ecs.Container`.

--- a/nodejs/awsx/ecs/container.ts
+++ b/nodejs/awsx/ecs/container.ts
@@ -55,13 +55,20 @@ export function computeContainerDefinition(
                 name: containerName,
             };
 
-            if (logGroupId !== undefined) {
+            // From https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+            // AWS recommends:
+            //
+            // For Amazon ECS services, you could use the service name as the prefix, which would
+            // allow you to trace log streams to the service that the container belongs to, the name
+            // of the container that sent them, and the ID of the task to which the container
+            // belongs.
+            if (logGroupId !== undefined && containerDefinition.logConfiguration === undefined) {
                 containerDefinition.logConfiguration = {
                     logDriver: "awslogs",
                     options: {
                         "awslogs-group": logGroupId,
                         "awslogs-region": region,
-                        "awslogs-stream-prefix": containerName,
+                        "awslogs-stream-prefix": name,
                     },
                 };
             }
@@ -526,6 +533,11 @@ export interface Container {
      * [Create-a-container](https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate)
      * section of the [Docker-Remote-API](https://docs.docker.com/engine/api/v1.35/) and the
      * `--log-driver` parameter to [docker-run](https://docs.docker.com/engine/reference/run/).
+     *
+     * If this property is not `undefined` then a default log configuration will be made using the
+     * `awslogs` driver with a log stream in the form `task-or-service-name/container-name/task-id`
+     *
+     * To disable logs entirely, pass in `null` here.
      */
     logConfiguration?: pulumi.Input<aws.ecs.LogConfiguration>;
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/501

Note: this change may affect existing infrastructure (and any external systems that depend on it).  Specifically, it changes the default `awslogs` stream for an `awsx.ecs.Container` from:

1. `container-name/container-name/task-id` to
2. `service-or-task-name/container-name/task-id`

This should make it much easier to understand use the logs produced by ecs Containers.

If this change is not desirable for your stack at this time, you can explicitly override this by providing your own log configuration.  To do that, just add the following to your Container specification in your Pulumi app:

```ts
containers: {
    "your-container-name": {
        logConfiguration: {
            logDriver: "awslogs",
            options: {
                "awslogs-group": "yourLogGroupId",
                "awslogs-region": "yourRegion",
                "awslogs-stream-prefix": "your-container-name",
            },
        },
    },
},
```

This will keep the stream IDs the same, preventing any disruption around other systems that may depend on this.