### PR TITLE
Add some deployment-time-only methods to the doNotCapture list.

### DIFF
--- a/nodejs/awsx/lb/listener.ts
+++ b/nodejs/awsx/lb/listener.ts
@@ -123,6 +123,11 @@ export abstract class Listener
     }
 }
 
+utils.Capture(Listener.prototype).containerPortMapping.doNotCapture = true;
+utils.Capture(Listener.prototype).containerLoadBalancer.doNotCapture = true;
+utils.Capture(Listener.prototype).addListenerRule.doNotCapture = true;
+utils.Capture(Listener.prototype).attachTarget.doNotCapture = true;
+
 /**
  * See https://www.terraform.io/docs/providers/aws/r/lb_listener.html#default_action
  */


### PR DESCRIPTION
This is impacting a case where one of these resources is captured and used from an aws lambda.  We want to expose the outputs of this resource, but not hte methods that pull in pulumi modules that do not exist at cloud runtime.