### PR TITLE
Allow nullable logGroup, taskRole, and executionRole for TaskDefinitionArgs, EC2TaskDefinitionArgs, and FargateTaskDefinitionArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 
 * Update `Service`, `EC2Service` and `FargateService` interface to support the full set of supported ECS Service properties
 * Ensure `CustomResourceOptions` are passed to underlying `ecs.Service` when using `awsx.ecs.FargateService` and `awsx.ecs.EC2Service`
-* Update `TaskDefinitionArgs` and `EC2TaskDefinitionArgs` to allow for null taskRole, executionRole, and logGroup attributes. This ensures that those resources aren't created if purposely nulled.
+* Update `TaskDefinitionArgs`, `EC2TaskDefinitionArgs`, `FargateTaskDefinitionArgs` to allow for null taskRole, executionRole, and logGroup attributes.
 
 ## 0.19.2 (2020-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 * Update `Service`, `EC2Service` and `FargateService` interface to support the full set of supported ECS Service properties
 * Ensure `CustomResourceOptions` are passed to underlying `ecs.Service` when using `awsx.ecs.FargateService` and `awsx.ecs.EC2Service`
+* Update `TaskDefinitionArgs` and `EC2TaskDefinitionArgs` to allow for null taskRole, executionRole, and logGroup attributes. This ensures that those resources aren't created if purposely nulled.
 
 ## 0.19.2 (2020-01-31)
 

--- a/nodejs/awsx/ecs/container.ts
+++ b/nodejs/awsx/ecs/container.ts
@@ -29,7 +29,7 @@ export function computeContainerDefinition(
     container: Container,
     applicationListeners: Record<string, x.lb.ApplicationListener>,
     networkListeners: Record<string, x.lb.NetworkListener>,
-    logGroup: aws.cloudwatch.LogGroup | undefined) {
+    logGroup: aws.cloudwatch.LogGroup | undefined | null) {
 
     const image = isContainerImageProvider(container.image)
         ? container.image.image(name, parent)

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -152,7 +152,7 @@ export interface EC2TaskDefinitionArgs {
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
@@ -164,7 +164,7 @@ export interface EC2TaskDefinitionArgs {
      *
      * If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * The Docker networking mode to use for the containers in the task. The valid values are

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -146,7 +146,7 @@ export interface EC2TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -279,13 +279,13 @@ export interface FargateTaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.
@@ -297,7 +297,7 @@ export interface FargateTaskDefinitionArgs {
      *
      *  If `undefined`, a default will be created for the task.  If `null` no role will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * The number of cpu units used by the task.  If not provided, a default will be computed

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -255,7 +255,7 @@ function computeContainerDefinitions(
     containers: Record<string, ecs.Container>,
     applicationListeners: Record<string, x.lb.ApplicationListener>,
     networkListeners: Record<string, x.lb.NetworkListener>,
-    logGroup: aws.cloudwatch.LogGroup | undefined): pulumi.Output<aws.ecs.ContainerDefinition[]> {
+    logGroup: aws.cloudwatch.LogGroup | undefined | null): pulumi.Output<aws.ecs.ContainerDefinition[]> {
 
     const result: pulumi.Output<aws.ecs.ContainerDefinition>[] = [];
 
@@ -276,7 +276,7 @@ function computeContainerDefinitions(
 type OverwriteShape = utils.Overwrite<aws.ecs.TaskDefinitionArgs, {
     family?: pulumi.Input<string>;
     containerDefinitions?: never;
-    logGroup?: aws.cloudwatch.LogGroup
+    logGroup?: aws.cloudwatch.LogGroup | null
     taskRoleArn?: never;
     taskRole?: aws.iam.Role;
     executionRoleArn?: never;
@@ -315,7 +315,7 @@ export interface TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null`, no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -278,9 +278,9 @@ type OverwriteShape = utils.Overwrite<aws.ecs.TaskDefinitionArgs, {
     containerDefinitions?: never;
     logGroup?: aws.cloudwatch.LogGroup | null
     taskRoleArn?: never;
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
     executionRoleArn?: never;
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
     cpu?: pulumi.Input<string>;
     memory?: pulumi.Input<string>;
     requiresCompatibilities: pulumi.Input<["FARGATE"] | ["EC2"]>;
@@ -321,14 +321,14 @@ export interface TaskDefinitionArgs {
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
      * `undefined`, a default will be created for the task.  If `null`, no task will be created.
      */
-    taskRole?: aws.iam.Role;
+    taskRole?: aws.iam.Role | null;
 
     /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
      *
      * If `undefined`, a default will be created for the task.  If `null`, no task will be created.
      */
-    executionRole?: aws.iam.Role;
+    executionRole?: aws.iam.Role | null;
 
     /**
      * An optional family name for the Task Definition. If not specified, then a suitable default will be created.


### PR DESCRIPTION
Fixes #514 