### PR TITLE
Allow null value for logGroup in ECS services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 * Update `Service`, `EC2Service` and `FargateService` interface to support the full set of supported ECS Service properties
 * Ensure `CustomResourceOptions` are passed to underlying `ecs.Service` when using `awsx.ecs.FargateService` and `awsx.ecs.EC2Service`
+* Update ECS Task Definitions to accept `logGroup: null`. [#516](https://github.com/pulumi/pulumi-awsx/pull/516)
 
 ## 0.19.2 (2020-01-31)
 

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -146,7 +146,7 @@ export interface EC2TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -279,7 +279,7 @@ export interface FargateTaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -276,7 +276,7 @@ function computeContainerDefinitions(
 type OverwriteShape = utils.Overwrite<aws.ecs.TaskDefinitionArgs, {
     family?: pulumi.Input<string>;
     containerDefinitions?: never;
-    logGroup?: aws.cloudwatch.LogGroup
+    logGroup?: aws.cloudwatch.LogGroup | null;
     taskRoleArn?: never;
     taskRole?: aws.iam.Role;
     executionRoleArn?: never;

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -315,7 +315,7 @@ export interface TaskDefinitionArgs {
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null`, no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
 
     /**
      * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If


### PR DESCRIPTION
It was already stated that `null` is allowed.
```diff
     /**
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null` no log group will be created.
      */
-    logGroup?: aws.cloudwatch.LogGroup;
+    logGroup?: aws.cloudwatch.LogGroup | null;
```

Fixes/related to #344