### PR TITLE
Fix checking of executionRole in TaskDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 * Update `Service`, `EC2Service` and `FargateService` interface to support the full set of supported ECS Service properties
 * Ensure `CustomResourceOptions` are passed to underlying `ecs.Service` when using `awsx.ecs.FargateService` and `awsx.ecs.EC2Service`
 * Update `TaskDefinitionArgs`, `EC2TaskDefinitionArgs`, `FargateTaskDefinitionArgs` to allow for null taskRole, executionRole, and logGroup attributes.
+* Fix bug in `TaskDefinition` when `executionRole` is ignored when `taskRole` is `null`.
+  [#517](https://github.com/pulumi/pulumi-awsx/pull/517)
 
 ## 0.19.2 (2020-01-31)
 

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -63,7 +63,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
                         args.taskRole ? args.taskRole : TaskDefinition.createTaskRole(
             `${name}-task`, /*assumeRolePolicy*/ undefined, /*policyArns*/ undefined, { parent: this });
 
-        this.executionRole = args.taskRole === null ? undefined :
+        this.executionRole = args.executionRole === null ? undefined :
                              args.executionRole ? args.executionRole : TaskDefinition.createExecutionRole(
             `${name}-execution`, /*assumeRolePolicy*/ undefined, /*policyArns*/ undefined, { parent: this });
 


### PR DESCRIPTION
When `taskRole` is passed as `null` but `executionRole` is provided, `TaskDefinition` wrongly test another parameter and does not accept the execution role. This causes errors such as `Fargate requires task definition to have execution role ARN to support ECR images.`.