### PR TITLE
Creation of awsx Listener from aws Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+* Allow an existing `aws.lb.Listener` to be passed to `awsx.lb.Listener`.
+
 ## 0.21.0 (2020-07-27)
 
 * Update `Metric` to support the latest `@pulumi/aws` resource shape. This is a breaking change that narrows the type of `dimensions`

--- a/nodejs/awsx/lb/application.ts
+++ b/nodejs/awsx/lb/application.ts
@@ -233,7 +233,7 @@ export class ApplicationListener extends mod.Listener {
         // target group used by the load balancer to route requests, you must verify that the
         // security groups associated with the load balancer allow traffic on the new port in both
         // directions.
-        if (args.external !== false) {
+        if (!args.listener && args.external !== false) {
             const args = {
                 location: new x.ec2.AnyIPv4Location(),
                 ports: new x.ec2.TcpPorts(port),
@@ -498,6 +498,13 @@ export interface ApplicationTargetGroupArgs {
 }
 
 export interface ApplicationListenerArgs {
+
+    /**
+     * An existing aws.lb.Listener to use for this awsx.lb.Listener.
+     * If not provided, one will be created.
+     */
+    listener?: aws.lb.Listener;
+
     /**
      * The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
      * unspecified.

--- a/nodejs/awsx/lb/listener.ts
+++ b/nodejs/awsx/lb/listener.ts
@@ -58,7 +58,7 @@ export abstract class Listener
         const defaultSslPolicy = pulumi.output(args.certificateArn)
                                        .apply(a => a ? "ELBSecurityPolicy-2016-08" : undefined!);
 
-        this.listener = new aws.lb.Listener(name, {
+        this.listener = args.listener || new aws.lb.Listener(name, {
             ...args,
             loadBalancerArn: args.loadBalancer.loadBalancer.arn,
             sslPolicy: utils.ifUndefined(args.sslPolicy, defaultSslPolicy),
@@ -322,6 +322,13 @@ type OverwriteShape = utils.Overwrite<aws.lb.ListenerArgs, {
 }>;
 
 export interface ListenerArgs {
+
+    /**
+     * An existing aws.lb.Listener to use for this awsx.lb.Listener.
+     * If not provided, one will be created.
+     */
+    listener?: aws.lb.Listener;
+
     loadBalancer: x.lb.LoadBalancer;
 
     /**

--- a/nodejs/awsx/lb/network.ts
+++ b/nodejs/awsx/lb/network.ts
@@ -417,6 +417,13 @@ export interface NetworkTargetGroupArgs {
 }
 
 export interface NetworkListenerArgs {
+
+    /**
+     * An existing aws.lb.Listener to use for this awsx.lb.Listener.
+     * If not provided, one will be created.
+     */
+    listener?: aws.lb.Listener;
+
     /**
      * The vpc this load balancer will be used with.  Defaults to `[Vpc.getDefault]` if
      * unspecified.


### PR DESCRIPTION
Ok, so I've made it a bit farther, but it turns out that https://github.com/pulumi/pulumi-awsx/pull/548 alone really wasn't enough and we need to do the same for the listener. In fact the only reason I need the load balancer is to pass it in via the args when constructing the listener

I have an infra project where I'm setting up common resources like the database and load balancer. And then a frontend sub-project and backend sub-project. Both of the sub-projects will need to setup their routes with the application load balancer listener and then pass the listener to the fargate service