### PR TITLE
Consistently use the awsx namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 
 * Allow an existing `aws.lb.Listener` to be passed to `awsx.lb.Listener`.
+* Use the `awsx` namespace for all objects
 
 ## 0.21.0 (2020-07-27)
 

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -508,7 +508,7 @@ export class API extends pulumi.ComponentResource {
     private readonly swaggerLambdas: SwaggerLambdas;
 
     constructor(name: string, args: APIArgs, opts: pulumi.ComponentResourceOptions = {}) {
-        super("aws:apigateway:x:API", name, {}, opts);
+        super("awsx:apigateway:x:API", name, {}, opts);
 
         let swaggerString: pulumi.Output<string>;
         let swaggerLambdas: SwaggerLambdas | undefined;

--- a/nodejs/awsx/lb/application.ts
+++ b/nodejs/awsx/lb/application.ts
@@ -51,7 +51,7 @@ export class ApplicationLoadBalancer extends mod.LoadBalancer {
             }, opts)];
         }
 
-        super("aws:lb:ApplicationLoadBalancer", name, argsCopy,
+        super("awsx:lb:ApplicationLoadBalancer", name, argsCopy,
             pulumi.mergeOptions(opts, { aliases: [{ type: "awsx:x:elasticloadbalancingv2:ApplicationLoadBalancer"}] }));
 
         this.listeners = [];


### PR DESCRIPTION
There are the only two that used `aws` instead of `awsx`. I'm not quite sure what the `:x:` is later on in the `apigateway` namespace and if I should leave it or if it's duplicative of the new `x` I just added