### PR TITLE
Replace SecurityGroupOrId[] with SecurityGroupsOrIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 
 * Allow an existing `aws.lb.Listener` to be passed to `awsx.lb.Listener`.
+* Replace `SecurityGroupOrId[]` with `SecurityGroupsOrIds`.
 
 ## 0.21.0 (2020-07-27)
 

--- a/nodejs/awsx/autoscaling/launchConfiguration.ts
+++ b/nodejs/awsx/autoscaling/launchConfiguration.ts
@@ -267,7 +267,7 @@ type OverwriteAutoScalingLaunchConfigurationArgs = utils.Overwrite<utils.Mutable
     ecsOptimizedAMIName?: string;
     instanceType?: pulumi.Input<aws.ec2.InstanceType>;
     placementTenancy?: pulumi.Input<"default" | "dedicated">;
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
     userData?: pulumi.Input<string> | AutoScalingUserData;
 }>;
 
@@ -410,7 +410,7 @@ export interface AutoScalingLaunchConfigurationArgs {
     /**
     * A list of associated security group IDs.
     */
-   securityGroups?: x.ec2.SecurityGroupOrId[];
+   securityGroups?: x.ec2.SecurityGroupsOrIds;
 
     /**
      * The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see `user_data_base64` instead.

--- a/nodejs/awsx/ec2/securityGroup.ts
+++ b/nodejs/awsx/ec2/securityGroup.ts
@@ -102,24 +102,28 @@ export class SecurityGroup extends pulumi.ComponentResource {
 utils.Capture(SecurityGroup.prototype).createEgressRule.doNotCapture = true;
 utils.Capture(SecurityGroup.prototype).createIngressRule.doNotCapture = true;
 
-export type SecurityGroupOrId = SecurityGroup | pulumi.Input<string>;
+export type SecurityGroupsOrIds = SecurityGroup[] | pulumi.Input<string[]>;
 
 /** @internal */
 export function getSecurityGroups(
-        vpc: x.ec2.Vpc, name: string, args: SecurityGroupOrId[] | undefined,
+        vpc: x.ec2.Vpc, name: string, args: SecurityGroupsOrIds | undefined,
         opts: pulumi.ResourceOptions | undefined) {
     if (!args) {
         return undefined;
     }
 
-    const result: x.ec2.SecurityGroup[] = [];
+    if (Array.isArray()) {
+        return args;
+    }
+
+    const result: SecurityGroup[] = [];
     for (let i = 0, n = args.length; i < n; i++) {
         const obj = args[i];
-        if (x.ec2.SecurityGroup.isSecurityGroupInstance(obj)) {
+        if (SecurityGroup.isSecurityGroupInstance(obj)) {
             result.push(obj);
         }
         else {
-            result.push(x.ec2.SecurityGroup.fromExistingId(`${name}-${i}`, obj, { vpc }, opts));
+            result.push(SecurityGroup.fromExistingId(`${name}-${i}`, obj, { vpc }, opts));
         }
     }
 

--- a/nodejs/awsx/ecs/cluster.ts
+++ b/nodejs/awsx/ecs/cluster.ts
@@ -165,7 +165,7 @@ function getOrCreateCluster(name: string, args: ClusterArgs, parent: Cluster) {
 type OverwriteShape = utils.Overwrite<aws.ecs.ClusterArgs, {
     vpc?: x.ec2.Vpc;
     cluster?: aws.ecs.Cluster | pulumi.Input<string>;
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
     tags?: pulumi.Input<aws.Tags>;
 }>;
 
@@ -213,7 +213,7 @@ export interface ClusterArgs {
      * The security group to place new instances into.  If not provided, a default will be
      * created. Pass an empty array to create no security groups.
      */
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 
     /**
      * Key-value mapping of resource tags

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -201,7 +201,7 @@ type OverwriteEC2ServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
     taskDefinitionArgs?: EC2TaskDefinitionArgs;
     launchType?: never;
     networkConfiguration?: never;
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 }>;
 
 export interface EC2ServiceArgs {
@@ -272,7 +272,7 @@ export interface EC2ServiceArgs {
      *
      * Defaults to [cluster.securityGroups] if unspecified.
      */
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 
     /**
      * The subnets to connect the instances to.  If unspecified then these will be the public

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -338,7 +338,7 @@ type OverwriteFargateServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
     taskDefinitionArgs?: FargateTaskDefinitionArgs;
     launchType?: never;
     networkConfiguration?: never;
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 }>;
 
 export interface FargateServiceArgs {
@@ -416,7 +416,7 @@ export interface FargateServiceArgs {
      *
      * Defaults to [cluster.securityGroups] if unspecified.
      */
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 
     /**
      * The subnets to connect the instances to.  If unspecified and [assignPublicIp] is true, then

--- a/nodejs/awsx/lb/application.ts
+++ b/nodejs/awsx/lb/application.ts
@@ -383,7 +383,7 @@ export interface ApplicationLoadBalancerArgs {
      * be created for the ALB.  To prevent a default instance from being created, pass in an empty
      * array here.
      */
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 }
 
 /**

--- a/nodejs/awsx/lb/loadBalancer.ts
+++ b/nodejs/awsx/lb/loadBalancer.ts
@@ -152,7 +152,7 @@ export interface LoadBalancerArgs {
      * A list of security group IDs to assign to the LB. Only valid for Load Balancers of type
      * `application`.
      */
-    securityGroups?: x.ec2.SecurityGroupOrId[];
+    securityGroups?: x.ec2.SecurityGroupsOrIds;
 }
 
 export interface LoadBalancerSubnets {


### PR DESCRIPTION
There seems to be a one-way street. You can go from `Input<string>[]` to `Input<string[]>` with `pulumi.all`, but there's no way to go in the other direction. The current API expects `Input<string>[]`, which there's no way to create from a persisted array of security group ids (`Input<string[]>`). This will fix that

Closes https://github.com/pulumi/pulumi-awsx/issues/558