### PR TITLE
Fix a doc comment that causes an improperly formatted link in the lang docs

### DIFF
--- a/nodejs/awsx/ecr/repository.ts
+++ b/nodejs/awsx/ecr/repository.ts
@@ -56,7 +56,7 @@ export class Repository extends pulumi.ComponentResource {
 }
 
 /**
- * Creates a new [Repository] (optionally configured using [args]), builds the docker container
+ * Creates a new [Repository], optionally configured using [args], builds the docker container
  * specified by [pathOrBuild] and then pushes the built image to the repository.  The result
  * contains both the Repository created as well as the unique ID referencing the built image in that
  * repo.  This result type can be passed in as `image: ecr.buildAndPushImage(...)` for an


### PR DESCRIPTION
Related to https://github.com/pulumi/docs/issues/3870.

The parentheses leads to markdown that literally links to `https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/awsx/ecr/optionally configured using [args]`.

You can find this broken link for `Repository` resource in https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/awsx/ecr/#buildAndPushImage.