### PR TITLE
Expand apigateway.API class to enable IAM Authorization on routes

### DIFF
--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -121,6 +121,12 @@ export interface BaseRoute {
      * the route is called.
      */
     authorizers?: Authorizer[] | Authorizer;
+
+    /**
+     * By default, the route method auth type is set to `NONE`. If true, the auth type will be
+     * set to `AWS_IAM`.
+     */
+    iamAuthEnabled?: boolean;
 }
 
 export interface EventHandlerRoute extends BaseRoute {
@@ -871,6 +877,9 @@ function addBasePathOptionsToSwagger(
     }
     if (route.requestValidator) {
         swaggerOperation["x-amazon-apigateway-request-validator"] = route.requestValidator;
+    }
+    if (route.iamAuthEnabled) {
+        swaggerOperation["x-amazon-apigateway-auth"] = { type: "AWS_IAM" };
     }
     if (route.apiKeyRequired) {
         addAPIkeyToSecurityDefinitions(swagger);

--- a/nodejs/awsx/apigateway/swagger_json.ts
+++ b/nodejs/awsx/apigateway/swagger_json.ts
@@ -57,6 +57,7 @@ export interface SwaggerOperation {
     responses?: { [code: string]: SwaggerResponse };
     "x-amazon-apigateway-integration": ApigatewayIntegration;
     "x-amazon-apigateway-request-validator"?: RequestValidator;
+    "x-amazon-apigateway-auth"?: ApigatewayAuth;
 
     /**
      * security a list of objects whose keys are the names of the authorizer. Each authorizer name
@@ -135,6 +136,10 @@ export interface ApigatewayIntegration {
     connectionType?: pulumi.Input<IntegrationConnectionType | undefined>;
     connectionId?: pulumi.Input<string | undefined>;
     credentials?: pulumi.Output<string>;
+}
+
+export interface ApigatewayAuth {
+    type: string;
 }
 
 export type Method = "ANY" | "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "OPTIONS";


### PR DESCRIPTION
## Summary
### Problem
`awsx.apigateway.API` currently has no method of setting the `"x-amazon-apigateway-auth"` in its resultant swagger json string. This means that there's no way to enable IAM authorization on the method routes produced by `awsx.apigateway.API`. Additionally since `awsx.apigateway.API` produces a swagger json string rather than pulumi resources, there's also no way to amend the routes.

### Solution
Add an optional boolean to `BaseRoute` interface called `iamAuthEnabled`, then modify the `addBasePathOptionsToSwagger` method to add the `"x-amazon-apigateway-auth"` key to the swagger json string when routes have this boolean set to true.

### Acceptance Criteria
- [ ] `BaseRoute` interface has `iamAuthEnabled`
- [ ] `addBasePathOptionsToSwagger` creates `"x-amazon-apigateway-auth"` key when `iamAuthEnabled` is true
- [ ] Creating a route with `iamAuthEnabled` sets method auth type to `IAM_AUTH` in api gateway console

### Resources
Related issue:https://github.com/pulumi/pulumi-awsx/issues/564