### PR TITLE
Don't overwrite the container's log configuration

### DIFF
--- a/nodejs/awsx/ecs/container.ts
+++ b/nodejs/awsx/ecs/container.ts
@@ -55,7 +55,7 @@ export function computeContainerDefinition(
                 name: containerName,
             };
 
-            if (logGroupId !== undefined) {
+            if (logGroupId === undefined) {
                 containerDefinition.logConfiguration = {
                     logDriver: "awslogs",
                     options: {


### PR DESCRIPTION
Currently we're setting them all to be awslogs (and not setting them if it doesn't exist)
