### PR TITLE
Update NetworkTargetGroupHealthCheck to match specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 * Ensure API Gateway static routes use POSIX paths. File paths with '\\' are transformed to '/' when uploaded.
 [#581](https://github.com/pulumi/pulumi-awsx/pull/581)
 * Add `cloudtrail.Trail` component which can generate the required roles and bucket for a CloudTrail.
+* Update `lb.NetworkTargetGroupHealthCheck` to allow for `path` and `matcher` properties.
 
 ## 0.22.0 (2020-09-01)
 

--- a/nodejs/awsx/lb/network.ts
+++ b/nodejs/awsx/lb/network.ts
@@ -309,27 +309,10 @@ export interface NetworkLoadBalancerArgs {
  */
 export interface NetworkTargetGroupHealthCheck extends mod.TargetGroupHealthCheck {
     /**
-     * Applies to Application Load Balancers only (HTTP/HTTPS), not Network Load Balancers (TCP)
-     */
-    matcher?: never;
-
-    /**
-     * Applies to Application Load Balancers only (HTTP/HTTPS), not Network Load Balancers (TCP).
-     */
-    path?: never;
-
-    /**
      * For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds
      * for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
      */
     timeout?: never;
-
-    /**
-     * The number of consecutive health check failures required before considering the target
-     * unhealthy . For Network Load Balancers, this value must be the same as the
-     * healthy_threshold.
-     */
-    unhealthyThreshold?: pulumi.Input<number>;
 }
 
 export interface NetworkTargetGroupArgs {

--- a/nodejs/awsx/lb/targetGroup.ts
+++ b/nodejs/awsx/lb/targetGroup.ts
@@ -167,7 +167,7 @@ export interface TargetGroupHealthCheck {
 
     /**
      * The number of consecutive health check failures required before considering the target
-     * unhealthy . For Network Load Balancers, this value must be the same as the
+     * unhealthy. For Network Load Balancers, this value must be the same as the
      * healthy_threshold. Defaults to 3.
      */
     unhealthyThreshold?: pulumi.Input<number>;


### PR DESCRIPTION
Based on https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html it's possible to set the path and matcher for NLB target group health checks.

Fixes https://github.com/pulumi/pulumi-awsx/issues/605