### PR TITLE
Replace default ECS task definition AmazonEC2ContainerServiceFullAccess policy to AmazonECSFullAccess policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* Replace default ECS task definition AmazonEC2ContainerServiceFullAccess policy to AmazonECSFullAccess policy
 
 ## 0.23.0 (2020-12-18)
 

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -147,9 +147,9 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
     public static defaultTaskRolePolicyARNs() {
         return [
             // Provides wide access to "serverless" services (Dynamo, S3, etc.)
-            aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+            aws.iam.ManagedPolicy.AWSLambdaFullAccess,
             // Required for lambda compute to be able to run Tasks
-            aws.iam.ManagedPolicies.AmazonEC2ContainerServiceFullAccess,
+            aws.iam.ManagedPolicy.AmazonECSFullAccess,
         ];
     }
 

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -19,7 +19,7 @@
         "mime": "^2.0.0"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "@pulumi/aws": "^3.22.0",
         "@pulumi/pulumi": "^1.9.1 || ^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Close #610 