### PR TITLE
Update ecs types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 [#581](https://github.com/pulumi/pulumi-awsx/pull/581)
 * Add `cloudtrail.Trail` component which can generate the required roles and bucket for a CloudTrail.
 * Update `lb.NetworkTargetGroupHealthCheck` to allow for `path` and `matcher` properties.
+* Update ECS types [#616](https://github.com/pulumi/pulumi-awsx/pull/616)
 
 ## 0.22.0 (2020-09-01)
 

--- a/nodejs/awsx/ecs/container.ts
+++ b/nodejs/awsx/ecs/container.ts
@@ -485,6 +485,13 @@ export interface Container {
     hostname?: pulumi.Input<string>;
 
     /**
+     * When this parameter is true, this allows you to deploy containerized applications that
+     * require stdin or a tty to be allocated. This parameter maps to OpenStdin in the Create
+     * a container section of the Docker Remote API and the --interactive option to docker run.
+     */
+    interactive?: pulumi.Input<string>;
+
+    /**
      * The links parameter allows containers to communicate with each other without the need for
      * port mappings. This parameter is only supported if the network mode of a task definition is
      * bridge. The name:internalName construct is analogous to name:alias in Docker links. Up to 255

--- a/nodejs/awsx/ecs/container.ts
+++ b/nodejs/awsx/ecs/container.ts
@@ -486,10 +486,10 @@ export interface Container {
 
     /**
      * When this parameter is true, this allows you to deploy containerized applications that
-     * require stdin or a tty to be allocated. This parameter maps to OpenStdin in the Create
-     * a container section of the Docker Remote API and the --interactive option to docker run.
+     * require stdin or a tty to be allocated. This parameter maps to OpenStdin in the Create a
+     * container section of the Docker Remote API and the --interactive option to docker run.
      */
-    interactive?: pulumi.Input<string>;
+    interactive?: pulumi.Input<boolean>;
 
     /**
      * The links parameter allows containers to communicate with each other without the need for

--- a/nodejs/awsx/ecs/service.ts
+++ b/nodejs/awsx/ecs/service.ts
@@ -206,6 +206,14 @@ export interface ServiceArgs {
     enableEcsManagedTags?: pulumi.Input<boolean>;
 
     /**
+     * Enable to force a new task deployment of the service. This can be used to update tasks
+     * to use a newer Docker image with same image/tag combination (e.g. `myimage:latest`), roll
+     * Fargate tasks onto a newer platform version, or immediately deploy `orderedPlacementStrategy`
+     * and `placementConstraints` updates.
+     */
+    forceNewDeployment?: pulumi.Input<boolean>;
+
+    /**
      * Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent
      * premature shutdown, up to 7200. Only valid for services configured to use load balancers.
      */
@@ -282,6 +290,18 @@ export interface ServiceArgs {
      */
     serviceRegistries?: aws.ecs.ServiceArgs["serviceRegistries"];
 
+    /**
+     * Key-value mapping of resource tags
+     */
+    tags?: pulumi.Input<aws.Tags>;
+
+    /**
+     * Wait for the service to reach a steady state (like [`aws ecs wait
+     * services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html))
+     * before continuing. Defaults to `true`.
+     */
+    waitForSteadyState?: pulumi.Input<boolean>;
+
     // Changes we made to the core args type.
 
     /**
@@ -298,18 +318,6 @@ export interface ServiceArgs {
      * Security groups determining how this service can be reached.
      */
     securityGroups: x.ec2.SecurityGroup[];
-
-    /**
-     * Wait for the service to reach a steady state (like [`aws ecs wait
-     * services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html))
-     * before continuing. Defaults to `true`.
-     */
-    waitForSteadyState?: pulumi.Input<boolean>;
-
-    /**
-     * Key-value mapping of resource tags
-     */
-    tags?: pulumi.Input<aws.Tags>;
 }
 
 // Make sure our exported args shape is compatible with the overwrite shape we're trying to provide.

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -290,7 +290,7 @@ type OverwriteShape = utils.Overwrite<aws.ecs.TaskDefinitionArgs, {
 }>;
 
 export interface TaskDefinitionArgs {
-    // Properties copied from aws.ecs.TaskDefinitionArgs
+    // Added for AWSX
 
     /**
      * The vpc that the service for this task will run in.  Does not normally need to be explicitly
@@ -299,29 +299,26 @@ export interface TaskDefinitionArgs {
     vpc?: x.ec2.Vpc;
 
     /**
-     * A set of placement constraints rules that are taken into consideration during task placement.
-     * Maximum number of `placement_constraints` is `10`.
-     */
-    placementConstraints?: aws.ecs.TaskDefinitionArgs["placementConstraints"];
-
-    /**
-     * A set of volume blocks that containers in your task may use.
-     */
-    volumes?: aws.ecs.TaskDefinitionArgs["volumes"];
-
-    // Properties we've added/changed.
-
-    /**
      * Log group for logging information related to the service.  If `undefined` a default instance
      * with a one-day retention policy will be created.  If `null`, no log group will be created.
      */
     logGroup?: aws.cloudwatch.LogGroup | null;
 
+    // Copied from aws.ecs.TaskDefinitionArgs
+
     /**
-     * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
-     * `undefined`, a default will be created for the task.  If `null`, no task will be created.
+     * All the containers to make a ClusterTaskDefinition from.  Useful when creating a
+     * ClusterService that will contain many containers within.
+     *
+     * Either [container] or [containers] must be provided.
      */
-    taskRole?: aws.iam.Role | null;
+    containers: Record<string, ecs.Container>;
+
+    /**
+     * The number of cpu units used by the task.  If not provided, a default will be computed
+     * based on the cumulative needs specified by [containerDefinitions]
+     */
+    cpu?: pulumi.Input<string>;
 
     /**
      * The execution role that the Amazon ECS container agent and the Docker daemon can assume.
@@ -336,10 +333,14 @@ export interface TaskDefinitionArgs {
     family?: pulumi.Input<string>;
 
     /**
-     * The number of cpu units used by the task.  If not provided, a default will be computed
-     * based on the cumulative needs specified by [containerDefinitions]
+     * Configuration block(s) with Inference Accelerators settings. Detailed below.
      */
-    cpu?: pulumi.Input<string>;
+    inferenceAccelerators?: pulumi.Input<pulumi.Input<aws.types.input.ecs.TaskDefinitionInferenceAccelerator>[]>;
+
+    /**
+     * The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+     */
+    ipcMode?: pulumi.Input<string>;
 
     /**
      * The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
@@ -348,28 +349,48 @@ export interface TaskDefinitionArgs {
     memory?: pulumi.Input<string>;
 
     /**
-     * A set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
-     */
-    requiresCompatibilities: pulumi.Input<["FARGATE"] | ["EC2"]>;
-
-    /**
      * The Docker networking mode to use for the containers in the task. The valid values are
      * `none`, `bridge`, `awsvpc`, and `host`.
      */
     networkMode?: pulumi.Input<"none" | "bridge" | "awsvpc" | "host">;
 
     /**
-     * All the containers to make a ClusterTaskDefinition from.  Useful when creating a
-     * ClusterService that will contain many containers within.
-     *
-     * Either [container] or [containers] must be provided.
+     * The process namespace to use for the containers in the task. The valid values are `host` and `task`.
      */
-    containers: Record<string, ecs.Container>;
+    pidMode?: pulumi.Input<string>;
+
+    /**
+     * A set of placement constraints rules that are taken into consideration during task placement.
+     * Maximum number of `placement_constraints` is `10`.
+     */
+    placementConstraints?: aws.ecs.TaskDefinitionArgs["placementConstraints"];
+
+    /**
+     * The proxy configuration details for the App Mesh proxy.
+     */
+    proxyConfiguration?: aws.ecs.TaskDefinitionArgs["proxyConfiguration"];
+
+    /**
+     * A set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
+     */
+    requiresCompatibilities: pulumi.Input<["FARGATE"] | ["EC2"]>;
 
     /**
      * Key-value mapping of resource tags
      */
     tags?: pulumi.Input<aws.Tags>;
+
+    /**
+     * IAM role that allows your Amazon ECS container task to make calls to other AWS services. If
+     * `undefined`, a default will be created for the task.  If `null`, no task will be created.
+     */
+    taskRole?: aws.iam.Role | null;
+
+    /**
+     * A set of volume blocks that containers in your task may use.
+     */
+    volumes?: aws.ecs.TaskDefinitionArgs["volumes"];
+
 }
 
 // Make sure our exported args shape is compatible with the overwrite shape we're trying to provide.


### PR DESCRIPTION
The awsx.ecs types have drifted a little relative to the aws.ecs types.  This change brings them up to date with the latest types in the AWS package.  In particular this adds:
* `Container#interactive`
* `ServiceArgs#forceNewDeployment`
* `TaskDefinitionArgs#inferenceAccelerators`
* `TaskDefinitionArgs#ipcMode`
* `TaskDefinitionArgs#pidMode`
* `TaskDefinitionArgs#proxyConfiguration`

Aside: The implementation includes an Override type that attempts to derive the correct type from the upstream types.  If this had been used directly, it would have avoided the need for this maintenance.  But documentation and error message experiences in TypeScript are not good for these derived types, so we instead also manually maintain a copy of the types.  We then attempt to verify that the manually maintained copy is compatible, but that attempt only verifies required properties, leaving the possibility that drift in optional properties (which in practice is the only kind of drift that can happen) will not be caught.  We likely need to revisit the overall strategy here.

Fixes #615.