### PR TITLE
Swap AmazonEC2ContainerServiceFullAccess for AmazonECS_FullAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-
-- Allow the user to pass `TargetGroup` as `actions` of `ListenerRule`.
+* Replaced deprecated `AmazonEC2ContainerServiceFullAccess` policy with `AmazonECS_FullAccess`. Note that this is a breaking change as now
+only `@pulumi/aws` ^3.22.0 can act as a peer dependency whereas previous versions of this library allowed `@pulumi/aws` versions 1.x and 2.x.
+  [#624](https://github.com/pulumi/pulumi-awsx/pull/624)
+* Allow the user to pass `TargetGroup` as `actions` of `ListenerRule`.
   [#503](https://github.com/pulumi/pulumi-awsx/pull/503)
-
 * Add support for `proxyConfiguration` to `awsx.ecs.FargateTaskDefinition` and `awsx.ecs.EC2TaskDefinition`.
 
 ## 0.23.0 (2020-12-18)

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -149,7 +149,7 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
             // Provides wide access to "serverless" services (Dynamo, S3, etc.)
             aws.iam.ManagedPolicies.AWSLambdaFullAccess,
             // Required for lambda compute to be able to run Tasks
-            aws.iam.ManagedPolicies.AmazonEC2ContainerServiceFullAccess,
+            aws.iam.ManagedPolicy.AmazonECSFullAccess,
         ];
     }
 

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -19,7 +19,7 @@
         "mime": "^2.0.0"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "@pulumi/aws": "^3.22.0",
         "@pulumi/pulumi": "^1.9.1 || ^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
I debated between taking a breaking change (as I'm doing here) vs. specifying the actual ARN string "arn:aws:iam::aws:policy/AmazonECS_FullAccess". Given this package is still in preview, the next release from a semver perspective is still a major release, so I think that's the right thing to do here versus trying to maintain backward compatibility.
