### PR TITLE
Update for Lambda full access deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-* Replaced deprecated `AmazonEC2ContainerServiceFullAccess` policy with `AmazonECS_FullAccess`. Note that this is a breaking change as now
+* (Breaking) Update the default task role in `ecs.TaskDefinition` to use the more scoped down `LambdaFullAccess` policy (the new one that AWS recommends).
+* (Breaking) Update the peer dependency for `@pulumi/aws` to ^3.25.1 so that callback functions will create a copy of the deprecated policy if necessary.
+* (Breaking) Replaced deprecated `AmazonEC2ContainerServiceFullAccess` policy with `AmazonECS_FullAccess`. Note that this is a breaking change as now
 only `@pulumi/aws` ^3.22.0 can act as a peer dependency whereas previous versions of this library allowed `@pulumi/aws` versions 1.x and 2.x.
   [#624](https://github.com/pulumi/pulumi-awsx/pull/624)
 * Allow the user to pass `TargetGroup` as `actions` of `ListenerRule`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-* (Breaking) Update the default task role in `ecs.TaskDefinition` to use the more scoped down `LambdaFullAccess` policy (the new one that AWS recommends).
+* (Breaking) Update the default task role in `ecs.TaskDefinition` to use the more scoped down `LambdaFullAccess`
+  policy (the new one that AWS recommends). As this significantly reduces the scope for the task definition, users
+  may need to attach additional policies if their task needs access to specific AWS services.
 * (Breaking) Update the peer dependency for `@pulumi/aws` to ^3.25.1 so that callback functions will create a copy of the deprecated policy if necessary.
 * (Breaking) Replaced deprecated `AmazonEC2ContainerServiceFullAccess` policy with `AmazonECS_FullAccess`. Note that this is a breaking change as now
 only `@pulumi/aws` ^3.22.0 can act as a peer dependency whereas previous versions of this library allowed `@pulumi/aws` versions 1.x and 2.x.

--- a/nodejs/awsx/ecs/taskDefinition.ts
+++ b/nodejs/awsx/ecs/taskDefinition.ts
@@ -146,8 +146,8 @@ export abstract class TaskDefinition extends pulumi.ComponentResource {
     // Default policy arns for the Task role.
     public static defaultTaskRolePolicyARNs() {
         return [
-            // Provides wide access to "serverless" services (Dynamo, S3, etc.)
-            aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+            // Provides full access to Lambda
+            aws.iam.ManagedPolicy.LambdaFullAccess,
             // Required for lambda compute to be able to run Tasks
             aws.iam.ManagedPolicy.AmazonECSFullAccess,
         ];

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -19,7 +19,7 @@
         "mime": "^2.0.0"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^3.22.0",
+        "@pulumi/aws": "^3.25.1",
         "@pulumi/pulumi": "^1.9.1 || ^2.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
- Update to `@pulumi/aws` 3.25.1 so that callback functions without specified policies create a copy of the deprecated policy.
- [Breaking] Update the default task role in `ecs.TaskDefinition` to use the more scoped down `LambdaFullAccess` policy (the new one that AWS recommends).