### PR TITLE
Allow using specific zones when creating a VPC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+* Introduce `requestedAvailabilityZone` on `ec2.vps.VpcArgs` that takes `number | "all" | string[]`, to allow specific zones for creating a VPC.
 
 ## 0.32.0 (2021-09-29)
 

--- a/nodejs/awsx/ec2/README.md
+++ b/nodejs/awsx/ec2/README.md
@@ -33,13 +33,13 @@ const vpc = new awsx.ec2.Vpc("custom", {
 });
 ```
 
-This range will then be partitioned accordingly into the VPC depending on the other arguments provided.  The additional arguments that affect this partitioning are `subnets` and `numberOfAvailabilityZones`.
+This range will then be partitioned accordingly into the VPC depending on the other arguments provided.  The additional arguments that affect this partitioning are `subnets` and `requestedAvailabilityZones`.
 
 ### Availability Zones
 
 Availability Zones are distinct locations that are engineered to be isolated from failures in other Availability Zones. By launching instances in separate Availability Zones, you can protect your applications from the failure of a single location
 
-If not provided `numberOfAvailabilityZones` will default to `2`, but a different value can be specified like so if appropriate for your region:
+Not providing a list of zones for `requestedAvailabilityZones` will default to `2`, but a different value can be specified like so if appropriate for your region:
 
 ```ts
 import * as aws from "@pulumi/aws";
@@ -47,7 +47,7 @@ import * as awsx from "@pulumi/awsx";
 
 const vpc = new awsx.ec2.Vpc("custom", {
    cidrBlock: "10.0.0.0/16",
-   numberOfAvailabilityZones: 3,
+   requestedAvailabilityZones: 3,
 });
 ```
 
@@ -77,7 +77,7 @@ import * as awsx from "@pulumi/awsx";
 
 const vpc = new awsx.ec2.Vpc("custom", {
    cidrBlock: "10.0.0.0/16",
-   numberOfAvailabilityZones: 3,
+   requestedAvailabilityZones: 3,
    subnets: [{ type: "public" }, { type: "private" }, { type: isolated }],
 });
 ```
@@ -90,7 +90,7 @@ import * as awsx from "@pulumi/awsx";
 
 const vpc = new awsx.ec2.Vpc("custom", {
    cidrBlock: "10.0.0.0/16",
-   numberOfAvailabilityZones: 3,
+   requestedAvailabilityZones: 3,
    subnets: [
      { type: "public" },
      { type: "private" },
@@ -113,7 +113,7 @@ import * as awsx from "@pulumi/awsx";
 
 const vpc = new awsx.ec2.Vpc("custom", {
    cidrBlock: "10.0.0.0/16",
-   numberOfAvailabilityZones: 3,
+   requestedAvailabilityZones: 3,
    numberOfNatGateways: 1,
 });
 ```

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -522,8 +522,8 @@ async function getAvailabilityZones(
                 mappedZones.length === requestedZones.length ?
                     resolve(mappedZones) :
                     reject(new pulumi.ResourceError("Availability zones did not match requested zones", parent));
-            })
-        })
+            });
+        });
     }
     else {
         return descriptions.slice(0, requestedZones === "all" ? descriptions.length : requestedZones);

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -522,7 +522,7 @@ async function getAvailabilityZones(
         if (mappedZones.length !== requestedZones.length) {
             throw new pulumi.ResourceError("Availability zones did not match requested zones", parent);
         }
-        return mappedZones
+        return mappedZones;
     }
     else {
         const count =

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -512,7 +512,7 @@ async function getAvailabilityZones(
     }
 
 
-    const descriptions = result.names.map((name, idx) => ({ name, id: result.zoneIds[idx] }) )
+    const descriptions = result.names.map((name, idx) => ({ name, id: result.zoneIds[idx] }) );
 
     if (Array.isArray(requestedZones) || typeof requestedZones === "object" ) {
         return new Promise((resolve, reject) => {

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -714,9 +714,6 @@ export interface VpcArgs {
      */
     requestedAvailabilityZones?: number | "all" | [string, ...string[]] | pulumi.Input<string[]>;
 
-    /**
-     * @deprecated Use `requestedAvailabilityZones`
-     */
     numberOfAvailabilityZones?: VpcArgs["requestedAvailabilityZones"];
 
     /**

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -504,7 +504,7 @@ utils.Capture(Vpc.prototype).initializeVpcArgs.doNotCapture = true;
 async function getAvailabilityZones(
         parent: pulumi.Resource | undefined,
         provider: pulumi.ProviderResource | undefined,
-        requestedZones: VpcArgs["requestedAvailabilityZones"]): Promise<topology.AvailabilityZoneDescription[]> {
+        requestedZones: VpcArgs["requestedAvailabilityZones"] = 2): Promise<topology.AvailabilityZoneDescription[]> {
 
     const result = await aws.getAvailabilityZones(/*args:*/ undefined, { provider, async: true });
     if (result.names.length !== result.zoneIds.length) {
@@ -526,11 +526,7 @@ async function getAvailabilityZones(
         })
     }
     else {
-        const count =
-            typeof requestedZones === "number" ? requestedZones :
-                requestedZones === "all" ? descriptions.length : 2;
-
-        return descriptions.slice(0, count);
+        return descriptions.slice(0, requestedZones === "all" ? descriptions.length : requestedZones);
     }
 
 }

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -514,8 +514,7 @@ async function getAvailabilityZones(
 
     const descriptions = result.names.map((name, idx) => ({ name, id: result.zoneIds[idx] }) )
 
-
-    if (typeof requestedZones === "object") {
+    if (Array.isArray(requestedZones) || typeof requestedZones === "object" ) {
         return new Promise((resolve, reject) => {
             pulumi.Output.create(requestedZones).apply(requestedZones => {
                 const mappedZones = descriptions.filter(zone => requestedZones.includes(zone.name));
@@ -713,7 +712,7 @@ export interface VpcArgs {
      * The names of the availability zones to use in the current region. Defaults to `2` if
      * unspecified. Use `"all"` to use all the availability zones in the current region.
      */
-    requestedAvailabilityZones?: number | "all" | pulumi.Input<[string, ...string[]]>;
+    requestedAvailabilityZones?: number | "all" | [string, ...string[]] | pulumi.Input<string[]>;
 
     /**
      * @deprecated Use `requestedAvailabilityZones`

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -504,7 +504,7 @@ utils.Capture(Vpc.prototype).initializeVpcArgs.doNotCapture = true;
 async function getAvailabilityZones(
         parent: pulumi.Resource | undefined,
         provider: pulumi.ProviderResource | undefined,
-        requestedZones: [string, ...string[]] | number | "all" | undefined): Promise<topology.AvailabilityZoneDescription[]> {
+        requestedZones: VpcArgs["requestedAvailabilityZones"]): Promise<topology.AvailabilityZoneDescription[]> {
 
     const result = await aws.getAvailabilityZones(/*args:*/ undefined, { provider, async: true });
     if (result.names.length !== result.zoneIds.length) {
@@ -512,7 +512,7 @@ async function getAvailabilityZones(
     }
 
 
-    const descriptions = result.names.map((name, idx) => ({name, id:result.zoneIds[idx]}))
+    const descriptions = result.names.map((name, idx) => ({ name, id: result.zoneIds[idx] }) )
 
     if (Array.isArray(requestedZones)) {
         const mappedZones = descriptions.filter(zone => requestedZones.includes(zone.name));
@@ -711,15 +711,15 @@ export interface VpcArgs {
     subnets?: VpcSubnetArgs[];
 
     /**
-     * @deprecated Use `requestedAvailabilityZones`
-     */
-    numberOfAvailabilityZones?: number | "all" | [string, ...string[]];
-
-    /**
      * The names of the availability zones to use in the current region. Defaults to `2` if
      * unspecified. Use `"all"` to use all the availability zones in the current region.
      */
     requestedAvailabilityZones?: number | "all" | [string, ...string[]];
+
+    /**
+     * @deprecated Use `requestedAvailabilityZones`
+     */
+    numberOfAvailabilityZones?: VpcArgs["requestedAvailabilityZones"];
 
     /**
      * The max number of NAT gateways to create if there are any private subnets created.  A NAT

--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -504,17 +504,15 @@ utils.Capture(Vpc.prototype).initializeVpcArgs.doNotCapture = true;
 async function getAvailabilityZones(
         parent: pulumi.Resource | undefined,
         provider: pulumi.ProviderResource | undefined,
-        requestedZones: string[] | number | "all" | undefined): Promise<topology.AvailabilityZoneDescription[]> {
+        requestedZones: [string, ...string[]] | number | "all" | undefined): Promise<topology.AvailabilityZoneDescription[]> {
 
     const result = await aws.getAvailabilityZones(/*args:*/ undefined, { provider, async: true });
     if (result.names.length !== result.zoneIds.length) {
         throw new pulumi.ResourceError("Availability zones for region had mismatched names and ids.", parent);
     }
 
-    const descriptions: topology.AvailabilityZoneDescription[] = [];
-    for (let i = 0, n = result.names.length; i < n; i++) {
-        descriptions.push({ name: result.names[i], id: result.zoneIds[i] });
-    }
+
+    const descriptions = result.names.map((name, idx) => ({name, id:result.zoneIds[idx]}))
 
     if (Array.isArray(requestedZones)) {
         const mappedZones = descriptions.filter(zone => requestedZones.includes(zone.name));
@@ -715,13 +713,13 @@ export interface VpcArgs {
     /**
      * @deprecated Use `requestedAvailabilityZones`
      */
-    numberOfAvailabilityZones?: number | "all" | string[];
+    numberOfAvailabilityZones?: number | "all" | [string, ...string[]];
 
     /**
      * The names of the availability zones to use in the current region. Defaults to `2` if
      * unspecified. Use `"all"` to use all the availability zones in the current region.
      */
-    requestedAvailabilityZones?: number | "all" | string[];
+    requestedAvailabilityZones?: number | "all" | [string, ...string[]];
 
     /**
      * The max number of NAT gateways to create if there are any private subnets created.  A NAT

--- a/nodejs/examples/vpc/index.ts
+++ b/nodejs/examples/vpc/index.ts
@@ -56,11 +56,11 @@ const vpcWithLocations = new awsx.ec2.Vpc("custom6", {
 }, providerOpts);
 
 const vpcWithSpecificZones = new awsx.ec2.Vpc("custom7", {
-    requestedAvailabilityZones: ["us-east-1a","us-east-1b","us-east-1c"],
+    requestedAvailabilityZones: ["us-east-1a", "us-east-1b", "us-east-1c"],
     subnets: [
-        { type: "public"},
-        { type: "private"},
-        { type: "isolated", name: "db"},
-        { type: "isolated", name: "redis"},
+        { type: "public" },
+        { type: "private" },
+        { type: "isolated", name: "db" },
+        { type: "isolated", name: "redis" },
     ],
 }, { provider: new aws.Provider("prov2", { region: "us-east-1" }) });

--- a/nodejs/examples/vpc/index.ts
+++ b/nodejs/examples/vpc/index.ts
@@ -57,22 +57,21 @@ const vpcWithLocations = new awsx.ec2.Vpc("custom6", {
 }, providerOpts);
 
 
-export = async () => {
-    const allZones =   await aws.getAvailabilityZones(/*args:*/ undefined, { provider: providerOpts.provider, async: true })
 
-    const selectedZones = new random.RandomShuffle("custom7_az", {
-        inputs: allZones.names,
-        resultCount: allZones.names.length / 2,
-    }).results;
+const allZones =   aws.getAvailabilityZones(undefined, { provider: providerOpts.provider, async: true }).then(allZones => allZones.names)
+const selectedZones = new random.RandomShuffle("custom7_az", {
+    inputs: allZones,
+    resultCount: allZones.then(z => z.length / 2)
+}).results;
 
-    const vpcWithSpecificZones = new awsx.ec2.Vpc("custom7", {
-        requestedAvailabilityZones: selectedZones,
-        subnets: [
-            { type: "public" },
-            { type: "private" },
-            { type: "isolated", name: "db" },
-            { type: "isolated", name: "redis" },
-        ],
-    }, providerOpts);
-}
+const vpcWithSpecificZones = new awsx.ec2.Vpc("custom7", {
+    requestedAvailabilityZones: selectedZones,
+    subnets: [
+        { type: "public" },
+        { type: "private" },
+        { type: "isolated", name: "db" },
+        { type: "isolated", name: "redis" },
+    ],
+}, providerOpts);
+// }
 

--- a/nodejs/examples/vpc/index.ts
+++ b/nodejs/examples/vpc/index.ts
@@ -73,5 +73,3 @@ const vpcWithSpecificZones = new awsx.ec2.Vpc("custom7", {
         { type: "isolated", name: "redis" },
     ],
 }, providerOpts);
-// }
-

--- a/nodejs/examples/vpc/index.ts
+++ b/nodejs/examples/vpc/index.ts
@@ -54,3 +54,13 @@ const vpcWithLocations = new awsx.ec2.Vpc("custom6", {
         { type: "isolated", name: "redis", location: "10.0.3.0/24" },
     ],
 }, providerOpts);
+
+const vpcWithSpecificZones = new awsx.ec2.Vpc("custom7", {
+    requestedAvailabilityZones: ["us-east-1a","us-east-1b","us-east-1c"],
+    subnets: [
+        { type: "public"},
+        { type: "private"},
+        { type: "isolated", name: "db"},
+        { type: "isolated", name: "redis"},
+    ],
+}, { provider: new aws.Provider("prov2", { region: "us-east-1" }) });

--- a/nodejs/examples/vpc/package.json
+++ b/nodejs/examples/vpc/package.json
@@ -9,7 +9,8 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^4.0.0"
+        "@pulumi/aws": "^4.0.0",
+        "@pulumi/random": "^4.0.0"
     },
     "devDependencies": {
         "@types/node": "^8.0.0"


### PR DESCRIPTION
Fixing: https://github.com/pulumi/pulumi-awsx/issues/493

Fixed the [review comments](https://github.com/pulumi/pulumi-awsx/pull/494) and made sure to base of v2. 
Took the liberty of adding deprecation warning to `numberOfAvailabilityZones` and introducing `requestedAvailabilityZone?: number | "all" | [string, ...string[]];`

That being said, I am not sure it's a great idea to rely on fresh calls to `getAvailabilityZones()`, maybe I'm wrong here, but couldn't there be a potential issue of getting different zones back, thus mutating an existing VPC? 

Assuming it does what I suspect, I'd think it's better to allow the user to decide if throwing an error is better than mutating an existing VPC when AWS returns different zones than what you're expecting. 

My take is, remove `"all"` & `number` and let the zones be explicit, or maybe use a cache with the argument as seed and if a zone is down, just chuck an error as it should, anyway that's out of scope from what I need right now. 

