### PR TITLE
Ensuring apigateway.RestApiArgs are up to date with the pulumi-aws library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+* Ensure that `awsx.apigateway.APIArgs` `RestApiArgs` reflect the underlying pulumi-aws library
 
 ## 0.25.0 (2021-02-12)
 

--- a/nodejs/awsx/apigateway/api.ts
+++ b/nodejs/awsx/apigateway/api.ts
@@ -406,38 +406,7 @@ export interface APIArgs {
  * Additional optional args that can be passed along to the RestApi created by the
  * awsx.apigateway.API.
  */
-export interface RestApiArgs {
-    /**
-     * The name of the REST API.  Defaults to the name of the awsx.apigateway.Api if unspecified.
-     */
-    name?: pulumi.Input<string>;
-
-    /**
-     * The list of binary media types supported by the RestApi. Defaults to `* / *` if unspecified.
-     */
-    binaryMediaTypes?: pulumi.Input<pulumi.Input<string>[]>;
-
-    /**
-     * The source of the API key for requests. Valid values are HEADER (default) and AUTHORIZER.
-     */
-    apiKeySource?: pulumi.Input<string>;
-    /**
-     * The description of the REST API
-     */
-    description?: pulumi.Input<string>;
-    /**
-     * Nested argument defining API endpoint configuration including endpoint type. Defined below.
-     */
-    endpointConfiguration?: pulumi.Input<aws.types.input.apigateway.RestApiEndpointConfiguration>;
-    /**
-     * Minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default).
-     */
-    minimumCompressionSize?: pulumi.Input<number>;
-    /**
-     * JSON formatted policy document that controls access to the API Gateway.
-     */
-    policy?: pulumi.Input<string>;
-}
+export type RestApiArgs = aws.apigateway.RestApiArgs;
 
 /**
  * Additional optional args that can be passed along to the Stage created by the


### PR DESCRIPTION
Fixes: #639