### PR TITLE
fix: Make it possible to use capacity provider strategy for ecs services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 ## HEAD (Unreleased)
 _(none)_
 
+## 0.25.1 (2021-02-24)
+
+* Make it possible to use capacity provider strategy for `ecs.FargateService` and `ecs.Ec2Service`
+
 ## 0.25.0 (2021-02-12)
 
 * Allow passing of `forceNewDeployment` to `ecs.FargateService` and `ecs.Ec2Service`

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -85,7 +85,7 @@ export class EC2Service extends ecs.Service {
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
         const subnets = args.subnets || cluster.vpc.publicSubnetIds;
 
-        const useClusterDefaultCapacityProviderStrategies = utils.ifUndefined(args.useClusterDefaultCapacityProviderStrategies, false);
+        const useClusterDefaultCapacityProviderStrategies = !!args.useClusterDefaultCapacityProviderStrategies;
 
         const capacityProviderStrategies = !useClusterDefaultCapacityProviderStrategies ? args.capacityProviderStrategies : undefined;
 
@@ -129,12 +129,6 @@ type OverwriteEC2TaskDefinitionArgs = utils.Overwrite<ecs.TaskDefinitionArgs, {
 
 export interface EC2TaskDefinitionArgs {
     // Properties from ecs.TaskDefinitionArgs
-
-    /**
-     * Use the Cluster default capacity provider strategies. Defaults to false.
-     * If true, `capacityProviderStrategies` will not be used.
-     */
-    useClusterDefaultCapacityProviderStrategies?: boolean;
 
     /**
      * The vpc that the service for this task will run in.  Does not normally need to be explicitly
@@ -224,6 +218,12 @@ type OverwriteEC2ServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
 
 export interface EC2ServiceArgs {
     // Properties from ecs.ServiceArgs
+
+    /**
+     * Use the Cluster default capacity provider strategies. Defaults to false.
+     * If true, `capacityProviderStrategies` will not be used.
+     */
+    useClusterDefaultCapacityProviderStrategies?: boolean;
 
     /**
      * The capacity provider strategy to use for the service.

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -213,11 +213,19 @@ export class FargateService extends ecs.Service {
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
         const subnets = getSubnets(cluster, args.subnets, assignPublicIp);
 
+        const useClusterDefaultCapacityProviderStrategies = !!args.useClusterDefaultCapacityProviderStrategies;
+
+        const capacityProviderStrategies = !useClusterDefaultCapacityProviderStrategies ? args.capacityProviderStrategies : undefined;
+
+        // LaunchType should be Fargate only if we are not using the cluster capacity provider strategy nor using a custom one
+        const launchType = !useClusterDefaultCapacityProviderStrategies && !capacityProviderStrategies ? "FARGATE" : undefined;
+
         super("awsx:x:ecs:FargateService", name, {
             ...args,
             taskDefinition,
             securityGroups,
-            launchType: "FARGATE",
+            launchType,
+            capacityProviderStrategies,
             networkConfiguration: {
                 subnets,
                 assignPublicIp,
@@ -350,7 +358,13 @@ export interface FargateServiceArgs {
     // Properties from ecs.ServiceArgs
 
     /**
-     * The capacity provider strategy to use for the service.
+     * Use the Cluster default capacity provider strategies. Defaults to false.
+     * If true, `capacityProviderStrategies` will not be used.
+     */
+    useClusterDefaultCapacityProviderStrategies?: boolean;
+
+    /**
+     * The custom capacity provider strategy to use for the service.
      */
     capacityProviderStrategies?: aws.ecs.ServiceArgs["capacityProviderStrategies"];
 

--- a/nodejs/awsx/ecs/service.ts
+++ b/nodejs/awsx/ecs/service.ts
@@ -54,7 +54,6 @@ export abstract class Service extends pulumi.ComponentResource {
             cluster: this.cluster.cluster.arn,
             taskDefinition: args.taskDefinition.taskDefinition.arn,
             desiredCount: utils.ifUndefined(args.desiredCount, 1),
-            launchType: utils.ifUndefined(args.launchType, "EC2"),
             waitForSteadyState: utils.ifUndefined(args.waitForSteadyState, true),
         }, pulumi.mergeOptions(opts, {
                 parent: this,


### PR DESCRIPTION
This PR fixes pulumi/pulumi-awsx#599 and should not break existing code. I have tested it and it works like a charm but I would suggest you guys to test it to double check.