### PR TITLE
Create CapacityProviderService to make it possible to use capacity provider strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+* Create `CapacityProviderService` to make it possible to use capacity provider strategies solving [#599](https://github.com/pulumi/pulumi-awsx/issues/599).
 
 ## 0.25.0 (2021-02-12)
 

--- a/nodejs/awsx/aws_test.go
+++ b/nodejs/awsx/aws_test.go
@@ -55,6 +55,15 @@ func TestAccCapacityProviderServiceWithClusterDefaultStrategies(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccCapacityProviderServiceEC2CustomStrategy(t *testing.T) {
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "../examples/ecs/capacity-provider-service-ec2-custom-strategy"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccTaskDefinitionWithProxyConfiguration(t *testing.T) {
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/nodejs/awsx/aws_test.go
+++ b/nodejs/awsx/aws_test.go
@@ -46,6 +46,15 @@ func TestAccCluster(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccCapacityProviderServiceWithClusterDefaultStrategies(t *testing.T) {
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "../examples/ecs/capacity-provider-service-with-cluster-default-strategies"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccTaskDefinitionWithProxyConfiguration(t *testing.T) {
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/nodejs/awsx/ecs/capacityProviderService.ts
+++ b/nodejs/awsx/ecs/capacityProviderService.ts
@@ -1,0 +1,253 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+import * as ecs from ".";
+import * as x from "..";
+import * as utils from "../utils";
+
+
+
+export class CapacityProviderService extends ecs.Service {
+    public readonly taskDefinition: ecs.FargateTaskDefinition | ecs.EC2TaskDefinition;
+
+    constructor(name: string,
+                args: CapacityProviderServiceArgs,
+                opts: pulumi.ComponentResourceOptions = {}) {
+
+        if (!args.taskDefinition) {
+            throw new Error("The [taskDefinition] must be provided");
+        }
+
+        const cluster = args.cluster || x.ecs.Cluster.getDefault();
+
+        const taskDefinition = args.taskDefinition;
+
+
+        const securityGroups = x.ec2.getSecurityGroups(
+            cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
+
+        let assignPublicIp, networkConfiguration, subnets: pulumi.Input<pulumi.Input<string>[]>;
+
+        if (taskDefinition instanceof ecs.FargateTaskDefinition) {
+            assignPublicIp = utils.ifUndefined(args.assignPublicIp, true);
+            subnets = ecs._getSubnets(cluster, args.subnets, assignPublicIp);
+            networkConfiguration = {
+                subnets,
+                assignPublicIp,
+                securityGroups: securityGroups.map(g => g.id),
+            };
+        } else {
+            assignPublicIp = false;
+            subnets = args.subnets || cluster.vpc.publicSubnetIds;
+            networkConfiguration = taskDefinition.taskDefinition.networkMode.apply(n => {
+                // The network configuration for the service. This parameter is required for task
+                // definitions that use the `awsvpc` network mode to receive their own Elastic
+                // Network Interface, and it is not supported for other network modes.
+                if (n !== "awsvpc") {
+                    return undefined!;
+                }
+
+                return {
+                    subnets,
+                    assignPublicIp: false,
+                    securityGroups: securityGroups.map(g => g.id),
+                };
+            });
+        }
+
+        super("awsx:x:ecs:CapacityProviderService", name, {
+            ...args,
+            taskDefinition,
+            securityGroups,
+            networkConfiguration,
+        }, opts);
+
+        this.taskDefinition = taskDefinition;
+
+        this.registerOutputs();
+    }
+}
+
+type OverwriteCapacityProviderServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
+    taskDefinition: ecs.FargateTaskDefinition | ecs.EC2TaskDefinition;
+    launchType?: never;
+    networkConfiguration?: never;
+    securityGroups?: x.ec2.SecurityGroupOrId[];
+}>;
+
+export interface CapacityProviderServiceArgs {
+    // Properties from ecs.ServiceArgs
+
+    /**
+     * The custom capacity provider strategy to use for the service.
+     * If not set, the cluster default capacity provider strategies
+     * will be used.
+     */
+    capacityProviderStrategies?: aws.ecs.ServiceArgs["capacityProviderStrategies"];
+
+    /**
+     * onfiguration block containing deployment controller configuration.
+     */
+    deploymentController?: aws.ecs.ServiceArgs["deploymentController"];
+
+    /**
+     * The upper limit (as a percentage of the service's desiredCount) of the number of running
+     * tasks that can be running in a service during a deployment. Not valid when using the `DAEMON`
+     * scheduling strategy.
+     */
+    deploymentMaximumPercent?: pulumi.Input<number>;
+
+    /**
+     * The lower limit (as a percentage of the service's desiredCount) of the number of running
+     * tasks that must remain running and healthy in a service during a deployment.
+     */
+    deploymentMinimumHealthyPercent?: pulumi.Input<number>;
+
+    /**
+     * The number of instances of the task definition to place and keep running. Defaults to 1. Do
+     * not specify if using the `DAEMON` scheduling strategy.
+     */
+    desiredCount?: pulumi.Input<number>;
+
+    /**
+     * Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
+     */
+    enableEcsManagedTags?: pulumi.Input<boolean>;
+
+    /**
+     * Enable to force a new task deployment of the service. This can be used to update tasks to use a newer
+     * Docker image with same image/tag combination (e.g. myimage:latest), roll Fargate tasks onto a newer platform
+     * version, or immediately deploy orderedPlacementStrategies and placementConstraints updates.
+     */
+    forceNewDeployment?: pulumi.Input<boolean>;
+
+    /**
+     * Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent
+     * premature shutdown, up to 7200. Only valid for services configured to use load balancers.
+     */
+    healthCheckGracePeriodSeconds?: pulumi.Input<number>;
+
+    /**
+     * ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your
+     * behalf. This parameter is required if you are using a load balancer with your service, but
+     * only if your task definition does not use the `awsvpc` network mode. If using `awsvpc`
+     * network mode, do not specify this role. If your account has already created the Amazon ECS
+     * service-linked role, that role is used by default for your service unless you specify a role
+     * here.
+     */
+    iamRole?: pulumi.Input<string>;
+
+    /**
+     * A load balancer block. Load balancers documented below.
+     */
+    loadBalancers?: (pulumi.Input<x.ecs.ServiceLoadBalancer> | x.ecs.ServiceLoadBalancerProvider)[];
+
+    /**
+     * The name of the service (up to 255 letters, numbers, hyphens, and underscores)
+     */
+    name?: pulumi.Input<string>;
+
+    /**
+     * Whether or not public IPs should be provided for the instances.
+     *
+     * Defaults to [true] if unspecified.
+     */
+    assignPublicIp?: pulumi.Input<boolean>;
+
+    /**
+     * The security groups to use for the instances.
+     *
+     * Defaults to [cluster.securityGroups] if unspecified.
+     */
+    securityGroups?: x.ec2.SecurityGroupOrId[];
+
+    /**
+     * The subnets to connect the instances to.  If unspecified and [assignPublicIp] is true, then
+     * these will be the public subnets of the cluster's vpc.  If unspecified and [assignPublicIp]
+     * is false, then these will be the private subnets of the cluster's vpc.
+     */
+    subnets?: pulumi.Input<pulumi.Input<string>[]>;
+
+    /**
+     * Service level strategy rules that are taken into consideration during task placement. List
+     * from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy`
+     * blocks is `5`. Defined below.
+     */
+    orderedPlacementStrategies?: aws.ecs.ServiceArgs["orderedPlacementStrategies"];
+
+    /**
+     * rules that are taken into consideration during task placement. Maximum number of
+     * `placement_constraints` is `10`. Defined below.
+     */
+    placementConstraints?: aws.ecs.ServiceArgs["placementConstraints"];
+
+    /**
+     * The platform version on which to run your service. Only applicable for `launchType` set to `FARGATE`.
+     * Defaults to `LATEST`. More information about Fargate platform versions can be found in the
+     * [AWS ECS User Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
+     */
+    platformVersion?: pulumi.Input<string>;
+
+    /**
+     * The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`.
+     * Defaults to `REPLICA`. Note that [*Fargate tasks do not support the `DAEMON` scheduling
+     * strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html).
+     */
+    schedulingStrategy?: pulumi.Input<string>;
+
+    /**
+     * Specifies whether to propagate the tags from the task definition or the service
+     * to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
+     */
+    propagateTags?: pulumi.Input<string>;
+
+    /**
+     * The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
+     */
+    serviceRegistries?: aws.ecs.ServiceArgs["serviceRegistries"];
+
+    // Changes we made to the core args type.
+
+    /**
+     * Cluster this service will run in.  If unspecified, [Cluster.getDefault()] will be used.
+     */
+    cluster?: ecs.Cluster;
+
+    os?: pulumi.Input<"linux" | "windows">;
+
+    /**
+     * Wait for the service to reach a steady state (like [`aws ecs wait
+     * services-stable`](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html))
+     * before continuing. Defaults to `true`.
+     */
+    waitForSteadyState?: pulumi.Input<boolean>;
+
+    // Properties we're adding.
+
+    /**
+     * The task definition to create the service from.
+     */
+    taskDefinition: ecs.FargateTaskDefinition | ecs.EC2TaskDefinition;
+
+    /**
+     * Key-value mapping of resource tags
+     */
+    tags?: pulumi.Input<aws.Tags>;
+}
+
+// Make sure our exported args shape is compatible with the overwrite shape we're trying to provide.
+const test: string = utils.checkCompat<OverwriteCapacityProviderServiceArgs, CapacityProviderServiceArgs>();

--- a/nodejs/awsx/ecs/capacityProviderService.ts
+++ b/nodejs/awsx/ecs/capacityProviderService.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import * as ecs from ".";
 import * as x from "..";
 import * as utils from "../utils";
 
-
-
 export class CapacityProviderService extends ecs.Service {
     public readonly taskDefinition: ecs.FargateTaskDefinition | ecs.EC2TaskDefinition;
 
@@ -36,7 +34,6 @@ export class CapacityProviderService extends ecs.Service {
 
         const taskDefinition = args.taskDefinition;
 
-
         const securityGroups = x.ec2.getSecurityGroups(
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
 
@@ -44,7 +41,7 @@ export class CapacityProviderService extends ecs.Service {
 
         if (taskDefinition instanceof ecs.FargateTaskDefinition) {
             assignPublicIp = utils.ifUndefined(args.assignPublicIp, true);
-            subnets = ecs._getSubnets(cluster, args.subnets, assignPublicIp);
+            subnets = ecs.getSubnets(cluster, args.subnets, assignPublicIp);
             networkConfiguration = {
                 subnets,
                 assignPublicIp,

--- a/nodejs/awsx/ecs/capacityProviderService.ts
+++ b/nodejs/awsx/ecs/capacityProviderService.ts
@@ -38,10 +38,9 @@ export class CapacityProviderService extends ecs.Service {
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
 
         let assignPublicIp, networkConfiguration,
-        subnets: pulumi.Input<pulumi.Input<string>[]>, launchType: "FARGATE" | "EC2";
+        subnets: pulumi.Input<pulumi.Input<string>[]>;
 
         if (taskDefinition instanceof ecs.FargateTaskDefinition) {
-            launchType = "FARGATE";
             assignPublicIp = utils.ifUndefined(args.assignPublicIp, true);
             subnets = ecs.getSubnets(cluster, args.subnets, assignPublicIp);
             networkConfiguration = {
@@ -50,7 +49,6 @@ export class CapacityProviderService extends ecs.Service {
                 securityGroups: securityGroups.map(g => g.id),
             };
         } else {
-            launchType = "EC2";
             assignPublicIp = false;
             subnets = args.subnets || cluster.vpc.publicSubnetIds;
             networkConfiguration = taskDefinition.taskDefinition.networkMode.apply(n => {
@@ -72,7 +70,6 @@ export class CapacityProviderService extends ecs.Service {
         super("awsx:x:ecs:CapacityProviderService", name, {
             ...args,
             taskDefinition,
-            launchType,
             securityGroups,
             networkConfiguration,
         }, opts);

--- a/nodejs/awsx/ecs/ec2Service.ts
+++ b/nodejs/awsx/ecs/ec2Service.ts
@@ -206,16 +206,12 @@ type OverwriteEC2ServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
     taskDefinitionArgs?: EC2TaskDefinitionArgs;
     launchType?: never;
     networkConfiguration?: never;
+    capacityProviderStrategies?: never;
     securityGroups?: x.ec2.SecurityGroupOrId[];
 }>;
 
 export interface EC2ServiceArgs {
     // Properties from ecs.ServiceArgs
-
-    /**
-     * The capacity provider strategy to use for the service.
-     */
-    capacityProviderStrategies?: aws.ecs.ServiceArgs["capacityProviderStrategies"];
 
     /**
      * onfiguration block containing deployment controller configuration.

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -211,7 +211,7 @@ export class FargateService extends ecs.Service {
         const assignPublicIp = utils.ifUndefined(args.assignPublicIp, true);
         const securityGroups = x.ec2.getSecurityGroups(
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
-        const subnets = getSubnets(cluster, args.subnets, assignPublicIp);
+        const subnets = _getSubnets(cluster, args.subnets, assignPublicIp);
 
         super("awsx:x:ecs:FargateService", name, {
             ...args,
@@ -231,7 +231,7 @@ export class FargateService extends ecs.Service {
     }
 }
 
-function getSubnets(
+export function _getSubnets(
         cluster: ecs.Cluster,
         subnets: pulumi.Input<pulumi.Input<string>[]> | undefined,
         assignPublicIp: pulumi.Output<boolean>) {
@@ -343,16 +343,13 @@ type OverwriteFargateServiceArgs = utils.Overwrite<ecs.ServiceArgs, {
     taskDefinitionArgs?: FargateTaskDefinitionArgs;
     launchType?: never;
     networkConfiguration?: never;
+    capacityProviderStrategies?: never;
+    orderedPlacementStrategies?: never;
     securityGroups?: x.ec2.SecurityGroupOrId[];
 }>;
 
 export interface FargateServiceArgs {
     // Properties from ecs.ServiceArgs
-
-    /**
-     * The capacity provider strategy to use for the service.
-     */
-    capacityProviderStrategies?: aws.ecs.ServiceArgs["capacityProviderStrategies"];
 
     /**
      * onfiguration block containing deployment controller configuration.
@@ -436,13 +433,6 @@ export interface FargateServiceArgs {
      * is false, then these will be the private subnets of the cluster's vpc.
      */
     subnets?: pulumi.Input<pulumi.Input<string>[]>;
-
-    /**
-     * Service level strategy rules that are taken into consideration during task placement. List
-     * from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy`
-     * blocks is `5`. Defined below.
-     */
-    orderedPlacementStrategies?: aws.ecs.ServiceArgs["orderedPlacementStrategies"];
 
     /**
      * rules that are taken into consideration during task placement. Maximum number of

--- a/nodejs/awsx/ecs/fargateService.ts
+++ b/nodejs/awsx/ecs/fargateService.ts
@@ -211,7 +211,7 @@ export class FargateService extends ecs.Service {
         const assignPublicIp = utils.ifUndefined(args.assignPublicIp, true);
         const securityGroups = x.ec2.getSecurityGroups(
             cluster.vpc, name, args.securityGroups || cluster.securityGroups, opts) || [];
-        const subnets = _getSubnets(cluster, args.subnets, assignPublicIp);
+        const subnets = getSubnets(cluster, args.subnets, assignPublicIp);
 
         super("awsx:x:ecs:FargateService", name, {
             ...args,
@@ -231,7 +231,8 @@ export class FargateService extends ecs.Service {
     }
 }
 
-export function _getSubnets(
+/** @internal */
+export function getSubnets(
         cluster: ecs.Cluster,
         subnets: pulumi.Input<pulumi.Input<string>[]> | undefined,
         assignPublicIp: pulumi.Output<boolean>) {

--- a/nodejs/awsx/ecs/index.ts
+++ b/nodejs/awsx/ecs/index.ts
@@ -21,3 +21,4 @@ export * from "./metrics";
 export * from "./service";
 export * from "./ec2Service";
 export * from "./fargateService";
+export * from "./capacityProviderService";

--- a/nodejs/awsx/ecs/service.ts
+++ b/nodejs/awsx/ecs/service.ts
@@ -54,7 +54,6 @@ export abstract class Service extends pulumi.ComponentResource {
             cluster: this.cluster.cluster.arn,
             taskDefinition: args.taskDefinition.taskDefinition.arn,
             desiredCount: utils.ifUndefined(args.desiredCount, 1),
-            launchType: utils.ifUndefined(args.launchType, "EC2"),
             waitForSteadyState: utils.ifUndefined(args.waitForSteadyState, true),
         }, pulumi.mergeOptions(opts, {
                 parent: this,

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/.gitignore
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/Pulumi.yaml
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: capacity-provider-service-ec2-custom-strategy
+runtime: nodejs
+description: Test the CapacityProviderService to use the service capacity provider strategy

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
@@ -5,9 +5,9 @@ import * as pulumi from "@pulumi/pulumi";
 const config = new pulumi.Config("aws");
 const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
 
-const cluster = new awsx.ecs.Cluster("cluster", {}, providerOpts);
+const vpc = awsx.ec2.Vpc.getDefault(providerOpts);
 
-const vpc = new awsx.ec2.Vpc("vpc", {}, providerOpts);
+const cluster = new awsx.ecs.Cluster("cluster", { vpc }, providerOpts);
 
 const asg = cluster.createAutoScalingGroup("asg", {
   vpc,

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
@@ -1,0 +1,52 @@
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const cluster = new awsx.ecs.Cluster("cluster", {}, providerOpts);
+
+const vpc = new awsx.ec2.Vpc("vpc", {}, providerOpts);
+
+const asg = cluster.createAutoScalingGroup("asg", {
+  vpc,
+  subnetIds: vpc.publicSubnetIds,
+  templateParameters: { minSize: 1 },
+  launchConfigurationArgs: { instanceType: "t2.micro" },
+}, providerOpts);
+
+const cp = new aws.ecs.CapacityProvider("capacity-provider", {
+  name: "my-capacity-provider",
+  autoScalingGroupProvider: {
+    autoScalingGroupArn: asg.group.arn
+  }
+}, providerOpts);
+
+// Create a load balancer on port 80 and spin up two instances of Nginx.
+const lb = new awsx.lb.ApplicationListener("nginx-lb", { port: 80 }, providerOpts);
+
+const ec2Task = new awsx.ecs.EC2TaskDefinition("ec2-task", {
+  containers: {
+      application: {
+          image: "nginx:latest",
+          memory: 128,
+          essential: true,
+          cpu: 512,
+          portMappings: [lb],
+      },
+  },
+}, providerOpts);
+
+const service = new awsx.ecs.CapacityProviderService("my-service", {
+  cluster,
+  taskDefinition: ec2Task,
+  desiredCount: 1,
+  capacityProviderStrategies: [{
+    capacityProvider: cp.name,
+    weight: 1
+  }]
+}, providerOpts);
+
+// Export the load balancer's address so that it's easy to access.
+export const url = lb.endpoint.hostname;

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/index.ts
@@ -1,26 +1,50 @@
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
 
 const config = new pulumi.Config("aws");
 const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
 
 const vpc = awsx.ec2.Vpc.getDefault(providerOpts);
 
-const cluster = new awsx.ecs.Cluster("cluster", { vpc, capacityProviders: ["my-capacity-provider"] }, providerOpts);
+const clusterName = "cluster";
+const clusterIdentifier = new random.RandomString("cluster", {
+  special: false,
+  upper: false,
+  length: 6,
+}).result.apply(s => "cluster-" + s);
 
-const asg = cluster.createAutoScalingGroup("asg", {
+// Create the cluster's security group ahead of time so we can use it for the ASG.
+const clusterSecurityGroup = awsx.ecs.Cluster.createDefaultSecurityGroup(clusterName, vpc, providerOpts);
+
+const userData: awsx.autoscaling.AutoScalingUserData = {
+  extraBootcmdLines: () => clusterIdentifier.apply(clusterId =>
+    [{ contents: `- echo ECS_CLUSTER='${clusterId}' >> /etc/ecs/ecs.config` }]),
+};
+
+const asg = new awsx.autoscaling.AutoScalingGroup("asg", {
   vpc,
   subnetIds: vpc.publicSubnetIds,
   templateParameters: { minSize: 1 },
-  launchConfigurationArgs: { instanceType: "t2.micro", securityGroups: cluster.securityGroups },
- }, providerOpts);
+  launchConfigurationArgs: {
+    instanceType: "t2.micro",
+    securityGroups: [clusterSecurityGroup],
+    userData,
+  },
+}, providerOpts);
 
 const cp = new aws.ecs.CapacityProvider("capacity-provider", {
-  name: "my-capacity-provider",
   autoScalingGroupProvider: {
-    autoScalingGroupArn: asg.group.arn
-  }
+    autoScalingGroupArn: asg.group.arn,
+  },
+}, providerOpts);
+
+const cluster = new awsx.ecs.Cluster(clusterName, {
+  name: clusterIdentifier,
+  vpc,
+  capacityProviders: [ cp.name ],
+  securityGroups: [clusterSecurityGroup],
 }, providerOpts);
 
 // Create a load balancer on port 80 and spin up two instances of Nginx.

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/package.json
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "@pulumi/aws": "^3.25.1",
         "@pulumi/awsx": "^0.24.0",
-        "@pulumi/pulumi": "^2.0.0"
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/random": "^3.0.3"
     }
 }

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/package.json
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "cluster-default-capacity-provider",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0",
+        "@pulumi/pulumi": "^2.0.0"
+    }
+}

--- a/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/tsconfig.json
+++ b/nodejs/examples/ecs/capacity-provider-service-ec2-custom-strategy/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/.gitignore
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/Pulumi.yaml
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: capacity-provider-service-with-cluster-default-strategies
+runtime: nodejs
+description: Test the CapacityProviderService to use the default capacity provider
+  defined in the cluster

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/index.ts
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/index.ts
@@ -1,0 +1,37 @@
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config("aws");
+const providerOpts = { provider: new aws.Provider("prov", { region: <aws.Region>config.require("envRegion") }) };
+
+const cluster = new awsx.ecs.Cluster("cluster", {
+  capacityProviders: ["FARGATE_SPOT"],
+  defaultCapacityProviderStrategies: [{
+    capacityProvider: "FARGATE_SPOT",
+    weight: 1,
+  }],
+}, providerOpts);
+
+// Create a load balancer on port 80 and spin up two instances of Nginx.
+const lb = new awsx.lb.ApplicationListener("nginx-lb", { port: 80 }, providerOpts);
+
+const fargateTask = new awsx.ecs.FargateTaskDefinition("fargate-task", {
+  containers: {
+      application: {
+          image: "nginx:latest",
+          memory: 128,
+          essential: true,
+          cpu: 512,
+      },
+  },
+}, providerOpts);
+
+const service = new awsx.ecs.CapacityProviderService("my-service", {
+  cluster,
+  taskDefinition: fargateTask,
+  desiredCount: 1,
+}, providerOpts);
+
+// Export the load balancer's address so that it's easy to access.
+export const url = lb.endpoint.hostname;

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/index.ts
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/index.ts
@@ -23,6 +23,7 @@ const fargateTask = new awsx.ecs.FargateTaskDefinition("fargate-task", {
           memory: 128,
           essential: true,
           cpu: 512,
+          portMappings: [lb],
       },
   },
 }, providerOpts);

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/package.json
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "cluster-default-capacity-provider",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0"
+    }
+}

--- a/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/tsconfig.json
+++ b/nodejs/examples/ecs/capacity-provider-service-with-cluster-default-strategies/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
From #599 I  modified @leezen  class name a bit and called it `CapacityProviderService` and you pass the taskDefinition that would either be a FargateTaskDefinition or EC2TaskDefinition. With that, the user would know exactly wich path he is going. Now underlying capacity provider can be anything and we can still leverage the cluster default capacity provider strategy without any extra flag.

Note that I've implemented a different idea before (#643) but as @leezen said, It makes more sense to have a different class for this. Also, from now on you can't define `capacityProviderStrategies` in `FargateService` nor `EC2Service`. In that way, this PR fixes #599.