### PR TITLE
Add support for GENEVE, UDP and TCP_UDP in awsx.lb.TargetGroup Protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 * Create `CapacityProviderService` to make it possible to use capacity provider strategies solving [#599](https://github.com/pulumi/pulumi-awsx/issues/599).
 * Ensure that `awsx.apigateway.APIArgs` `RestApiArgs` reflect the underlying pulumi-aws library
 * Upgrade to Go1.16
+* Add support for `GENEVE`, `UDP` and `TCP_UDP` in `awsx.lb.TargetGroup` Protocols
 
 ## 0.25.0 (2021-02-12)
 

--- a/nodejs/awsx/lb/listener.ts
+++ b/nodejs/awsx/lb/listener.ts
@@ -317,7 +317,7 @@ type OverwriteShape = utils.Overwrite<aws.lb.ListenerArgs, {
     defaultActions: pulumi.Input<pulumi.Input<ListenerDefaultActionArgs>[]>;
     loadBalancerArn?: never;
     port: pulumi.Input<number>;
-    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS">;
+    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS" | "GENEVE" | "UDP" | "TCP_UDP">;
     sslPolicy?: pulumi.Input<string>;
 }>;
 
@@ -352,7 +352,7 @@ export interface ListenerArgs {
     /**
      * The protocol.
      */
-    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS">;
+    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS" | "GENEVE" | "UDP" | "TCP_UDP">;
 
     /**
      * The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.

--- a/nodejs/awsx/lb/network.ts
+++ b/nodejs/awsx/lb/network.ts
@@ -22,7 +22,7 @@ import * as x from "..";
 
 import * as utils from "../utils";
 
-export type NetworkProtocol = "TCP" | "TLS" | "HTTP" | "HTTPS";
+export type NetworkProtocol = "HTTP" | "HTTPS" | "TCP" | "TLS" | "GENEVE" | "UDP" | "TCP_UDP";
 
 export class NetworkLoadBalancer extends mod.LoadBalancer {
     public readonly listeners: NetworkListener[];

--- a/nodejs/awsx/lb/targetGroup.ts
+++ b/nodejs/awsx/lb/targetGroup.ts
@@ -218,7 +218,7 @@ export interface TargetGroupArgs {
     /**
      * The protocol to use to connect with the target.
      */
-    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS"> | undefined;
+    protocol: pulumi.Input<"HTTP" | "HTTPS" | "TCP" | "TLS" | "GENEVE" | "UDP" | "TCP_UDP"> | undefined;
 
     /**
      * Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See


### PR DESCRIPTION
Fixes: #647