### PR TITLE
Fix the copyright header for linting

### DIFF
--- a/nodejs/awsx/ecs/capacityProviderService.ts
+++ b/nodejs/awsx/ecs/capacityProviderService.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2018, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nodejs/awsx/tsconfig.json
+++ b/nodejs/awsx/tsconfig.json
@@ -70,6 +70,7 @@
         "ecs/index.ts",
         "ecs/cluster.ts",
         "ecs/container.ts",
+        "ecs/capacityProviderService.ts",
         "ecs/ec2Service.ts",
         "ecs/fargateService.ts",
         "ecs/image.ts",


### PR DESCRIPTION
@stack72 Any chance you know what's going on here? Even locally, with `2016-2018` the linter is fine. With `2016-2021` or even just plain `2021` the linter complains.