### PR TITLE
Add additional StorageTypes to awsx.s3.metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+* Add additional StorageTypes to `awsx.s3.metrics`
 
 ## 0.26 (2021-03-25)
 

--- a/nodejs/awsx/s3/metrics.ts
+++ b/nodejs/awsx/s3/metrics.ts
@@ -37,31 +37,74 @@ export namespace metrics {
          * of storage:
          *
          * * StandardStorage - The number of bytes used for objects in the STANDARD storage class.
+         * * IntelligentTieringAAStorage - The number of bytes used for objects in the Archive
+         *   Access tier of INTELLIGENT_TIERING storage class.
+         * * IntelligentTieringDAAStorage - The number of bytes used for objects in the Deep
+         *   Archive Access tier of INTELLIGENT_TIERING storage class.
          * * IntelligentTieringFAStorage - The number of bytes used for objects in the Frequent
          *   Access tier of INTELLIGENT_TIERING storage class.
          * * IntelligentTieringIAStorage - The number of bytes used for objects in the Infrequent
          *   Access tier of INTELLIGENT_TIERING storage class.
-         * * StandardIAStorage - The number of bytes used for objects in the Standard - Infrequent
-         *   Access (STANDARD_IA) storage class.
+         * * StandardIAStorage - The number of bytes used for objects in the Standard-Infrequent
+         *   Access (STANDARD_IA) storage class. This extra data is necessary to identify and
+         *   restore your object. You are charged GLACIER rates for this additional storage.
          * * StandardIASizeOverhead - The number of bytes used for objects smaller than 128 KB in
          *   size in the STANDARD_IA storage class.
-         * * OneZoneIAStorage - The number of bytes used for objects in the OneZone - Infrequent
+         * * IntAAObjectOverhead - For each object in INTELLIGENT_TIERING storage class in the
+         *   Archive Access tier, GLACIER adds 32 KB of storage for index and related metadata.
+         *   This extra data is necessary to identify and restore your object. You are charged
+         *   GLACIER rates for this additional storage.
+         * * IntAAS3ObjectOverhead - For each object in INTELLIGENT_TIERING storage class in the
+         *   Archive Access tier, Amazon S3 uses 8 KB of storage for the name of the object and
+         *   other metadata. You are charged STANDARD rates for this additional storage.
+         * * IntDAAObjectOverhead - For each object in INTELLIGENT_TIERING storage class in the
+         *   Deep Archive Access tier, GLACIER adds 32 KB of storage for index and related
+         *   metadata. This extra data is necessary to identify and restore your object. You are
+         *   charged S3 Glacier Deep Archive storage rates for this additional storage.
+         * * IntDAAS3ObjectOverhead - For each object in INTELLIGENT_TIERING storage class in the
+         *   Deep Archive Access tier, Amazon S3 adds 8 KB of storage for index and related
+         *   metadata. This extra data is necessary to identify and restore your object. You are
+         *   charged STANDARD rates for this additional storage.
+         * * OneZoneIAStorage - The number of bytes used for objects in the OneZone-Infrequent
          *   Access (ONEZONE_IA) storage class.
          * * OneZoneIASizeOverhead - The number of bytes used for objects smaller than 128 KB in
          *   size in the ONEZONE_IA storage class.
          * * ReducedRedundancyStorage - The number of bytes used for objects in the Reduced
          *   Redundancy Storage (RRS) class.
-         * * GlacierStorage - The number of bytes used for objects in the Glacier (GLACIER) storage
-         *   class.
-         * * GlacierStorageOverhead - For each object archived to Glacier, Amazon S3 uses 8 KB of
-         *   storage for the name of the object and other metadata. You are charged standard Amazon
-         *   S3 rates for this additional storage. For each archived object, Glacier adds 32 KB of
-         *   storage for index and related metadata. This extra data is necessary to identify and
-         *   restore your object. You are charged Glacier rates for this additional storage.
+         * * GlacierStorage - The number of bytes used for objects in the GLACIER storage class.
+         * * GlacierStagingStorage - The number of bytes used for parts of Multipart objects
+         *   before the CompleteMultipartUpload request is completed on objects in the GLACIER
+         *   storage class.
+         * * GlacierObjectOverhead - For each archived object, GLACIER adds 32 KB of storage for
+         *   index and related metadata. This extra data is necessary to identify and restore
+         *   your object. You are charged GLACIER rates for this additional storage.
+         * * GlacierS3ObjectOverhead - For each object archived to GLACIER , Amazon S3 uses 8 KB
+         *   of storage for the name of the object and other metadata. You are charged STANDARD
+         *   rates for this additional storage.
+         * * DeepArchiveStorage - The number of bytes used for objects in the S3 Glacier Deep
+         *   Archive storage class.
+         * * DeepArchiveObjectOverhead - For each archived object, S3 Glacier Deep Archive adds
+         *   32 KB of storage for index and related metadata. This extra data is necessary to
+         *   identify and restore your object. You are charged S3 Glacier Deep Archive rates
+         *   for this additional storage.
+         * * DeepArchiveS3ObjectOverhead - For each object archived to S3 Glacier Deep Archive,
+         *   Amazon S3 uses 8 KB of storage for the name of the object and other metadata. You
+         *   are charged STANDARD rates for this additional storage.
+         * * DeepArchiveStagingStorage – The number of bytes used for parts of Multipart objects
+         *   before the CompleteMultipartUpload request is completed on objects in the S3
+         *   Glacier Deep Archive storage class.
+         * * AllStorageTypes - All available storage types, used by NumberOfObjects metric
+         *
+         * For more information, see
+         * [Metrics-and-dimensions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html).
          */
-        storageType?: "StandardStorage" | "IntelligentTieringFAStorage" | "IntelligentTieringIAStorage" |
-            "StandardIAStorage" | "StandardIAStorage" | "StandardIASizeOverhead" | "OneZoneIAStorage" |
-            "OneZoneIASizeOverhead" | "ReducedRedundancyStorage" | "GlacierStorage" | "GlacierStorageOverhead";
+        storageType?: "StandardStorage" | "IntelligentTieringAAStorage" | "IntelligentTieringDAAStorage" |
+            "IntelligentTieringFAStorage" | "IntelligentTieringIAStorage" | "StandardIAStorage" |
+            "StandardIASizeOverhead" | "IntAAObjectOverhead" | "IntAAS3ObjectOverhead" | "IntDAAObjectOverhead" |
+            "IntDAAS3ObjectOverhead" | "OneZoneIAStorage" | "OneZoneIASizeOverhead" | "ReducedRedundancyStorage" |
+            "GlacierStorage" | "GlacierStagingStorage" | "GlacierObjectOverhead" | "GlacierS3ObjectOverhead" |
+            "DeepArchiveStorage" | "DeepArchiveObjectOverhead" | "DeepArchiveS3ObjectOverhead" |
+            "DeepArchiveStagingStorage" | "AllStorageTypes";
 
         /**
          * This dimension filters metrics configurations that you specify for request metrics on a


### PR DESCRIPTION
To use the S3 `numberOfObjects` metric, I needed the `storageType: "AllStorageTypes"`.  When I referenced the AWS documentation, I realized many other storageTypes were missing: https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html#s3-cloudwatch-dimensions

This PR adds the most up-to-date list of storageTypes for S3 metrics.

I'm not sure what to do about lines `149-174` in `nodejs/awsx/s3/metrics.ts`, which repeats storage types, but I wasn't sure if that that was intended to be a limited subset of options.