### PR TITLE
Allow constructing Vpc with no args object

### DIFF
--- a/nodejs/awsx/ec2/vpc.ts
+++ b/nodejs/awsx/ec2/vpc.ts
@@ -267,10 +267,10 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
 
     public readonly vpc: pulumi.Output<aws.ec2.Vpc>;
 
-    constructor(name: string, args: VpcArgs | ExistingVpcArgs | ExistingVpcIdArgs, opts?: pulumi.ComponentResourceOptions);
+    constructor(name: string, args?: VpcArgs | ExistingVpcArgs | ExistingVpcIdArgs, opts?: pulumi.ComponentResourceOptions);
     /** @internal */
     constructor(name: string, args: DefaultVpcArgs, opts?: pulumi.ComponentResourceOptions);
-    constructor(name: string, args: VpcArgs | ExistingVpcArgs | ExistingVpcIdArgs | DefaultVpcArgs, opts: pulumi.ComponentResourceOptions = {}) {
+    constructor(name: string, args: VpcArgs | ExistingVpcArgs | ExistingVpcIdArgs | DefaultVpcArgs = {}, opts: pulumi.ComponentResourceOptions = {}) {
         super("awsx:x:ec2:Vpc", name, { name, args, opts }, opts);
 
         const data = this.getData();


### PR DESCRIPTION
Since all input properties are optional, make the `args` bag itself optional, to align with the code-generation for custom resources with all-optional args bags.

This regressed in https://github.com/pulumi/pulumi-awsx/pull/470.

Because the test infrastructure in this repo currently requires passing explict providers, which means passing an options bag, there is unfortunately no simple way to test this directly.