### PR TITLE
Use aws.ec2.getAmi() instead of aws.getAmi()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Add support for Billing CloudWatch metrics and alarms
 * Add support for ECS Service Circuit Breaker and Execute Command
+* Use `aws.ec2.getAmi()` instead of deprecated `aws.getAmi()`
 
 ## 0.30.0 (2021-04-19)
 

--- a/nodejs/awsx/autoscaling/launchConfiguration.ts
+++ b/nodejs/awsx/autoscaling/launchConfiguration.ts
@@ -120,7 +120,7 @@ async function getEcsAmiId(name: string | undefined, opts: pulumi.InvokeOptions)
     }
 
     // Else, if a name was provided, look it up and use that imageId.
-    const result = await aws.getAmi({
+    const result = await aws.ec2.getAmi({
         owners: [
             "591542846629", // Amazon
         ],

--- a/nodejs/examples/alb/ec2Instance/index.ts
+++ b/nodejs/examples/alb/ec2Instance/index.ts
@@ -43,7 +43,7 @@ export = async () => {
     const publicIps: pulumi.Output<string>[] = [];
     const subnets = await vpc.publicSubnets;
     for (let i = 0; i < subnets.length; i++) {
-        const getAmiResult = await aws.getAmi({
+        const getAmiResult = await aws.ec2.getAmi({
             filters: [
                 { name: "name", values: [ "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*" ] },
                 { name: "virtualization-type", values: [ "hvm" ] },

--- a/nodejs/examples/metrics/index.ts
+++ b/nodejs/examples/metrics/index.ts
@@ -95,7 +95,7 @@ const bucket = new aws.s3.Bucket("b", {
 const bucketMetric = awsx.s3.metrics.firstByteLatency({ bucket, unit: "Seconds" });
 const bucketAlarm = bucketMetric.createAlarm("alarm" + alarmIndex++, { threshold: 30 , evaluationPeriods: 2 }, providerOpts);
 
-const ubuntu = pulumi.output(aws.getAmi({
+const ubuntu = pulumi.output(aws.ec2.getAmi({
     filters: [
         { name: "name", values: ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"] },
         { name: "virtualization-type", values: ["hvm"] },


### PR DESCRIPTION
`aws.getAmi()` is being deprecated https://www.pulumi.com/docs/reference/pkg/aws/getami/﻿

Fixes #680 