### PR TITLE
Increase create/delete timeouts for Route resource

### DIFF
--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -102,7 +102,7 @@ export class Subnet extends pulumi.ComponentResource {
                 create: "5m",
                 delete: "5m",
             },
-            ...opts
+            ...opts,
         };
 
         const args = isSubnetRouteProvider(argsOrProvider)

--- a/nodejs/awsx/ec2/subnet.ts
+++ b/nodejs/awsx/ec2/subnet.ts
@@ -96,7 +96,14 @@ export class Subnet extends pulumi.ComponentResource {
             throw new Error("Cannot call [createRoute] on a [Subnet] that doesn't have a [RouteTable]");
         }
 
-        opts = { parent: this, ...opts };
+        opts = {
+            parent: this,
+            customTimeouts: {
+                create: "5m",
+                delete: "5m",
+            },
+            ...opts
+        };
 
         const args = isSubnetRouteProvider(argsOrProvider)
             ? argsOrProvider.route(name, { parent: this })


### PR DESCRIPTION
Increase the timeouts. While we've only been seeing issues with deletes, I'm preemptively doing this for create as well since we'd seen that happen in the past with route table associations where we later saw the need on the create side.

I'm marking as `no-changelog-required` as there's no real user-facing change here in my opinion, but open to the opposite opinion that the timeout change is a behavior change that should be called out.