### PR TITLE
Refactor API implementation

### DIFF
--- a/nodejs/awsx/apigateway/index.ts
+++ b/nodejs/awsx/apigateway/index.ts
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export * from "./api";
+export {
+    AdditionalRoute, API, APIArgs, BaseRoute, DeploymentArgs, Endpoint, EventHandlerRoute,
+    IntegrationRoute, IntegrationRouteTargetProvider, IntegrationTarget, RawDataRoute, Request,
+    RequestContext, Response, RestApiArgs, Route, StageArgs, StaticRoute,
+    /* createAPI */ // Intentionally not re-exporting this
+} from "./api";
 export * from "./apikey";
 export * from "./cognitoAuthorizer";
 export * from "./lambdaAuthorizer";

--- a/nodejs/awsx/package.json
+++ b/nodejs/awsx/package.json
@@ -19,7 +19,7 @@
         "mime": "^2.0.0"
     },
     "peerDependencies": {
-        "@pulumi/aws": "^4.6.0",
+        "@pulumi/aws": "~4.23.0",
         "@pulumi/pulumi": "^3.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This pulls out the RestAPI resource creation into a function that can be reused in other packages to construct the desired child resource directly parented to another resource.  This is expected to be used in exposing this as a multi-language component.