### PR TITLE
Extend root block device size to fit the new image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+
+* Extend the `volumeSize` of the default root block device in ECS
+  autoscaling launch configuration to 32 GB to accomodate the latest
+  default AMI snapshot size
 
 ## 0.32.0 (2021-09-29)
 

--- a/nodejs/awsx/autoscaling/launchConfiguration.ts
+++ b/nodejs/awsx/autoscaling/launchConfiguration.ts
@@ -138,7 +138,7 @@ async function getEcsAmiId(name: string | undefined, opts: pulumi.InvokeOptions)
 
 
 const defaultRootBlockDevice = {
-    volumeSize: 8, // GiB
+    volumeSize: 32, // GiB
     volumeType: "gp2", // default is "standard"
     deleteOnTermination: true,
 };
@@ -392,7 +392,7 @@ export interface AutoScalingLaunchConfigurationArgs {
      * Customize details about the root block device of the instance. See Block Devices below for
      * details.
      *
-     * If not provided, an 8gb 'gp2' root device will be created.  This device will be deleted upon
+     * If not provided, an 32gb 'gp2' root device will be created.  This device will be deleted upon
      * termination.
      */
     rootBlockDevice?: aws.ec2.LaunchConfigurationArgs["rootBlockDevice"];


### PR DESCRIPTION
Apparently, Amazon has changed the default AMI snapshot and it doesn't fit our default 8 GB anymore. Extend root block device size to fit the new image in test capacity-provider-service-ec2-custom-strategy test.
Fix https://github.com/pulumi/pulumi-awsx/issues/717