### PR TITLE
[vpcTopology] Update IPV6 validation rules

### DIFF
--- a/nodejs/awsx/ec2/vpcTopology.ts
+++ b/nodejs/awsx/ec2/vpcTopology.ts
@@ -282,7 +282,7 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
 "Must set [assignGeneratedIpv6CidrBlock] to true on [Vpc] in order to assign ipv6 address to subnet.", this.resource);
                 }
 
-                // Should be of the form: 2600:1f16:110:2600::/56
+                // Can be of the form: 2600:1f16:110:2600::/56 or: 2600:1f18:1744::/56
                 const colonColonIndex = vpcIpv6CidrBlock.indexOf("::");
                 if (colonColonIndex < 0 ||
                     vpcIpv6CidrBlock.substr(colonColonIndex) !== "::/56") {
@@ -291,13 +291,12 @@ ${lastAllocatedIpAddress} > ${lastVpcIpAddress}`);
                 }
 
                 const header = vpcIpv6CidrBlock.substr(0, colonColonIndex);
-                if (!header.endsWith("00")) {
-                    throw new pulumi.ResourceError(`Vpc ipv6 cidr block was not in an expected form: ${vpcIpv6CidrBlock}`, this.resource);
+                if (header.endsWith("00")) {
+                    const prefix = header.substr(0, header.length - 2);
+                    return prefix + index.toString().padStart(2, "0") + "::/64";
                 }
 
-                // trim off the 00, and then add 00, 01, 02, 03, etc.
-                const prefix = header.substr(0, header.length - 2);
-                return prefix + index.toString().padStart(2, "0") + "::/64";
+                return header + ":" + index.toString().padStart(2, "0") + "::/64";
              });
 
         return <pulumi.Output<string>>result;


### PR DESCRIPTION
an IPV6 cidr block can have different formats. Without updated the
validation rules, it causes the VPC to not be able to parse the
cidr block
