### PR TITLE
Insert yAxis on ExpressionWidgetMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+* Introduce `yAxis` on `cloudwatch.ExpressionWidgetMetric`, to allow the metric to also be on the right side if desired.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/nodejs/awsx/cloudwatch/widgets_json.ts
+++ b/nodejs/awsx/cloudwatch/widgets_json.ts
@@ -75,7 +75,7 @@ export type ExpressionMetricJson = [{
     expression: pulumi.Input<string>,
     label: pulumi.Input<string | undefined>,
     id: pulumi.Input<string | undefined>,
-    yAxis: "right" | "left" | undefined,
+    yAxis: pulumi.Input<"right" | "left" | undefined>,
 }];
 
 export type SingleMetricJson = pulumi.Output<(string | RenderingPropertiesJson)[]>;

--- a/nodejs/awsx/cloudwatch/widgets_json.ts
+++ b/nodejs/awsx/cloudwatch/widgets_json.ts
@@ -75,6 +75,7 @@ export type ExpressionMetricJson = [{
     expression: pulumi.Input<string>,
     label: pulumi.Input<string | undefined>,
     id: pulumi.Input<string | undefined>,
+    yAxis: "right" | "left" | undefined,
 }];
 
 export type SingleMetricJson = pulumi.Output<(string | RenderingPropertiesJson)[]>;

--- a/nodejs/awsx/cloudwatch/widgets_simple.ts
+++ b/nodejs/awsx/cloudwatch/widgets_simple.ts
@@ -398,10 +398,12 @@ export class ExpressionWidgetMetric implements WidgetMetric {
      * @param expression The math expression or search expression.
      * @param label The label to display in the graph to represent this time series.
      * @param id The id of this time series. This id can be used as part of a math expression.
+     * @param yAxis Where on the graph to display the y-axis for this metric. The default is left.
      */
     constructor(private readonly expression: pulumi.Input<string>,
                 private readonly label?: pulumi.Input<string>,
-                private readonly id?: pulumi.Input<string>) {
+                private readonly id?: pulumi.Input<string>,
+                private readonly yAxis?: "right" | "left" | undefined) {
     }
 
     /** For internal use only. */
@@ -410,6 +412,7 @@ export class ExpressionWidgetMetric implements WidgetMetric {
             expression: this.expression,
             label: this.label,
             id: this.id,
+            yAxis: this.yAxis
         }];
 
         metrics.push(json);


### PR DESCRIPTION
This PR has the objective to add `yAxis` on `cloudwatch.ExpressionWidgetMetric`, to allow the metric to also be on the right side if desired.
