### PR TITLE
Added pie graph on cloudwatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+* Introduce `PieGraphMetricWidget` on `cloudwatch`, to allow to create graphs with pie view.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/nodejs/awsx/cloudwatch/widget.ts
+++ b/nodejs/awsx/cloudwatch/widget.ts
@@ -28,7 +28,7 @@ import { WidgetJson } from "./widgets_json";
  * 3. [SingleNumberMetricWidget] can be used to make a widget that displays information about a
  *    [Metric] as a single number.
  *
- * 4. [LineGraphMetricWidget] and [StackedAreaGraphMetricWidget] can be used to display a series
+ * 4. [LineGraphMetricWidget], [StackedAreaGraphMetricWidget] and [PieGraphMetricWidget] can be used to display a series
  *    of metric values as a graph.
  */
 export interface Widget {

--- a/nodejs/awsx/cloudwatch/widgets_graph.ts
+++ b/nodejs/awsx/cloudwatch/widgets_graph.ts
@@ -92,3 +92,16 @@ export class SingleNumberMetricWidget extends MetricWidget {
     protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "singleValue";
     protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => undefined;
 }
+
+/**
+ * Displays a set of metrics as a pie graph.
+ */
+export class PieGraphMetricWidget extends MetricWidget { 
+    constructor(args: MetricWidgetArgs) {
+        super(args);
+    }
+
+    protected computedStacked = () => false; 
+    protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "pie";
+    protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => undefined;
+} 

--- a/nodejs/awsx/cloudwatch/widgets_json.ts
+++ b/nodejs/awsx/cloudwatch/widgets_json.ts
@@ -58,7 +58,7 @@ export interface MetricWidgetPropertiesJson {
     period: pulumi.Input<number> | undefined;
     region: pulumi.Input<string | undefined>;
     stat: pulumi.Input<string>;
-    view: pulumi.Input<"timeSeries" | "singleValue" | undefined>;
+    view: pulumi.Input<"timeSeries" | "singleValue" | "pie" | undefined>;
     stacked: pulumi.Input<boolean | undefined>;
     yAxis: pulumi.Input<YAxis> | undefined;
 }

--- a/nodejs/awsx/cloudwatch/widgets_simple.ts
+++ b/nodejs/awsx/cloudwatch/widgets_simple.ts
@@ -281,7 +281,7 @@ export interface WidgetAlarm {
 
 /**
  * Base type for widgets that display data from a set of [Metric]s.  See [LineGraphMetricWidget],
- * [StackedAreaGraphMetricWidget] and [SingleNumberMetricWidget] as concrete [Widget] instances for
+ * [StackedAreaGraphMetricWidget], [PieGraphMetricWidget] and [SingleNumberMetricWidget] as concrete [Widget] instances for
  * displaying [Metric]s.
  */
 export abstract class MetricWidget extends SimpleWidget {

--- a/nodejs/awsx/tests/cloudwatch/cloudwatch.spec.ts
+++ b/nodejs/awsx/tests/cloudwatch/cloudwatch.spec.ts
@@ -22,7 +22,7 @@ import { Metric } from "../../cloudwatch/metric";
 import { Widget } from "../../cloudwatch/widget";
 import { AlarmAnnotation, HorizontalAnnotation, VerticalAnnotation } from "../../cloudwatch/widgets_annotations";
 import { ColumnWidget, RowWidget } from "../../cloudwatch/widgets_flow";
-import { LineGraphMetricWidget, SingleNumberMetricWidget, StackedAreaGraphMetricWidget } from "../../cloudwatch/widgets_graph";
+import { LineGraphMetricWidget, SingleNumberMetricWidget, StackedAreaGraphMetricWidget, PieGraphMetricWidget } from "../../cloudwatch/widgets_graph";
 import { ExpressionWidgetMetric, TextWidget } from "../../cloudwatch/widgets_simple";
 
 async function bodyJson(...widgets: Widget[]) {
@@ -950,6 +950,46 @@ describe("dashboard", () => {
                 "region": "us-east-2",
                 "view": "timeSeries",
                 "stacked": true
+            }
+        }
+    ]
+}`);
+            });
+        });
+
+        describe("pie graph", () => {
+            it("single metric", async () => {
+                const json = await bodyJson(new PieGraphMetricWidget({
+                    metrics: [new Metric({
+                        namespace: "AWS/Lambda",
+                        name: "Invocations",
+                    })],
+                }));
+                assert.equal(json, `{
+    "widgets": [
+        {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [
+                        "AWS/Lambda",
+                        "Invocations",
+                        {
+                            "stat": "Average",
+                            "period": 300,
+                            "visible": true,
+                            "yAxis": "left"
+                        }
+                    ]
+                ],
+                "period": 300,
+                "region": "us-east-2",
+                "view": "pie",
+                "stacked": false
             }
         }
     ]


### PR DESCRIPTION
This PR has the objective to add `PieGraphMetricWidget` on `cloudwatch`, to allow to create graphs with pie view.