### PR TITLE
Insert id property in metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Add multi-lang component support scaffolding.
+* Introduce `id` on `cloudwatch.metric` that takes `string`, to allow identifier in Metric.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx-classic/cloudwatch/metric.ts
+++ b/awsx-classic/cloudwatch/metric.ts
@@ -128,6 +128,11 @@ export class Metric {
     public readonly yAxis: pulumi.Output<"left" | "right">;
 
     /**
+    * The id of this metric. This id can be used as part of a math expression.
+    */
+    public readonly id: pulumi.Output<string | undefined>;
+
+    /**
      * @param resource Optional resource this is a metric for.  This is only used for parenting
      * purposes.  i.e. if an [Alarm] is created from this [Metric], then [resource] will be used as
      * the parent of the alarm by default.
@@ -151,6 +156,7 @@ export class Metric {
         this.label = pulumi.output(args.label);
         this.visible = utils.ifUndefined(args.visible, true);
         this.yAxis = utils.ifUndefined(args.yAxis, "left");
+        this.id = pulumi.output(args.id);
     }
 
     public with(change: MetricChange | undefined) {
@@ -168,6 +174,7 @@ export class Metric {
         result = hasOwnProperty(change, "label") ? result.withLabel(change.label) : result;
         result = hasOwnProperty(change, "visible") ? result.withVisible(change.visible) : result;
         result = hasOwnProperty(change, "yAxis") ? result.withYAxis(change.yAxis) : result;
+        result = hasOwnProperty(change, "id") ? result.withId(change.id) : result;
         return result;
     }
 
@@ -197,6 +204,7 @@ export class Metric {
             label: this.label,
             visible: this.visible,
             yAxis: this.yAxis,
+            id: this.id
         };
     }
 
@@ -235,6 +243,10 @@ export class Metric {
 
     public withYAxis(yAxis: pulumi.Input<"left" | "right"> | undefined) {
         return new Metric({ ...this.spread(), yAxis }, this.resource);
+    }
+
+    public withId(id: pulumi.Input<string> | undefined) {
+        return new Metric({ ...this.spread(), id }, this.resource);
     }
 
     public withStatistic(statistic: pulumi.Input<MetricStatistic> | undefined) {
@@ -316,6 +328,7 @@ export class Metric {
                 period: uw.period,
                 visible: uw.visible,
                 yAxis: uw.yAxis,
+                id: uw.id
             };
 
             result.push(renderingProps);
@@ -486,6 +499,11 @@ export interface MetricChange {
      * Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
      */
     yAxis?: pulumi.Input<"left" | "right">;
+
+    /**
+    * The id of this metric. This id can be used as part of a math expression.
+    */
+    id?: pulumi.Input<string>;
 }
 
 export type AlarmComparisonOperator =
@@ -636,6 +654,11 @@ export interface MetricArgs {
      * Only used if this metric is displayed in a [Dashboard] with a [MetricWidget].
      */
     yAxis?: pulumi.Input<"left" | "right" | undefined>;
+
+    /**
+    * The id of this metric. This id can be used as part of a math expression.
+    */
+    id?: pulumi.Input<string | undefined>;
 }
 
 export type MetricStatistic = "SampleCount" | "Average" | "Sum" | "Minimum" | "Maximum";

--- a/awsx-classic/cloudwatch/widgets_json.ts
+++ b/awsx-classic/cloudwatch/widgets_json.ts
@@ -86,6 +86,7 @@ export interface RenderingPropertiesJson {
     stat: string | undefined;
     visible: boolean | undefined;
     yAxis: "right" | "left" | undefined;
+    id: string | undefined;
 }
 
 export interface BaseHorizontalAnnotationJson {

--- a/awsx-classic/tests/cloudwatch/cloudwatch.spec.ts
+++ b/awsx-classic/tests/cloudwatch/cloudwatch.spec.ts
@@ -872,6 +872,50 @@ describe("dashboard", () => {
 }`);
             });
 
+            it("with id", async () => {
+                const json = await bodyJson(new SingleNumberMetricWidget({
+                    metrics: [new Metric({
+                        namespace: "AWS/Lambda",
+                        name: "Invocations",
+                        id: "m1"
+                    })],
+                }));
+                assert.equal(json, `{
+    "widgets": [
+        {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [
+                        "AWS/Lambda",
+                        "Invocations",
+                        "FunctionName",
+                        "MyFunc",
+                        "Hello",
+                        "world",
+                        {
+                            "stat": "Average",
+                            "period": 300,
+                            "visible": true,
+                            "yAxis": "left",
+                            "id": "m1"
+                        }
+                    ]
+                ],
+                "period": 300,
+                "region": "us-east-2",
+                "view": "singleValue",
+                "stacked": false
+            }
+        }
+    ]
+}`);
+            });
+            
             it("alarm annotation", async () => {
                 const json = await bodyJson(new SingleNumberMetricWidget({
                     metrics: [new Metric({


### PR DESCRIPTION
This PR has the objective to add the identifier in cloudwatch metric to use in expressions.
Ex
const metric = new Metric({ namespace: "AWS/ApplicationELB", name: "HTTPCode_Target_2XX_Count", dimensions: { TargetGroup: targetGroup, LoadBalancer: loadBalancer }, period: 60, statistic: "SampleCount", id: "m2", visible: false, });
const doubleMetric = new ExpressionWidgetMetric("2*m2", "doubleMetric", "m3");