### PR TITLE
Support chaining and shallow plain types in Go SDK

### DIFF
--- a/schemagen/go.mod
+++ b/schemagen/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/pkg/v3 v3.30.1-0.20220429024829-810756e7b968
-	github.com/pulumi/pulumi/sdk/v3 v3.30.1-0.20220429024829-810756e7b968
+	github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220503073946-62a228d9b3f0
+	github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0
 )
 
 require (

--- a/schemagen/go.sum
+++ b/schemagen/go.sum
@@ -562,10 +562,15 @@ github.com/pulumi/pulumi/pkg/v3 v3.30.0 h1:tdhcndy6pc+aV76wC76r+i5Z5E5nUvc78JaNy
 github.com/pulumi/pulumi/pkg/v3 v3.30.0/go.mod h1:U1BGP/1QmebZE35OfFAT96zN2lhexAktkGLAbnAv+lI=
 github.com/pulumi/pulumi/pkg/v3 v3.30.1-0.20220429024829-810756e7b968 h1:u2iB+atQW0hqEfB2MVOcKpf3oA61qjPnhYP42c05uSU=
 github.com/pulumi/pulumi/pkg/v3 v3.30.1-0.20220429024829-810756e7b968/go.mod h1:U1BGP/1QmebZE35OfFAT96zN2lhexAktkGLAbnAv+lI=
+github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220503073946-62a228d9b3f0 h1:LJCL+vfnJr4swUIIThzxxLFj1GJFgXxtBESD2xqjNbk=
+github.com/pulumi/pulumi/pkg/v3 v3.31.1-0.20220503073946-62a228d9b3f0/go.mod h1:bO/BHZJoG2Mm8C3dxP414vLPvjxFfsetPE3Ep7Ffgro=
 github.com/pulumi/pulumi/sdk/v3 v3.30.0 h1:0X5gSUS3x82XzenpCCW8EdJrmOzoQqHSdQd0O6QSMQQ=
 github.com/pulumi/pulumi/sdk/v3 v3.30.0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
 github.com/pulumi/pulumi/sdk/v3 v3.30.1-0.20220429024829-810756e7b968 h1:XaNCfbgmedFUnWLVj+3jvENiwpndSrNmtdh1Ir8sGrQ=
 github.com/pulumi/pulumi/sdk/v3 v3.30.1-0.20220429024829-810756e7b968/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0 h1:KOGdps/mozLqEeLDET2Q2MGW/du+iwKZ8lvNqVls+bA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -6,8 +6,14 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.3.0
-	github.com/pulumi/pulumi/sdk/v3 v3.30.0
+	github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0
 )
+
+// replace (
+//  aws 770b61635bb79e3c4b4a0d78105cf85d13f4d38b
+// pulumi 62a228d9b3f0ff44c6d08aa0c1a5eaeb9c274f36
+
+// )
 
 require (
 	github.com/cheggaaa/pb v1.0.18 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -171,8 +171,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/pulumi/pulumi-aws/sdk/v5 v5.3.0 h1:be0qFqKpS38eERDYDGRVJ/uX95CdV2u/by9aCP88c5U=
 github.com/pulumi/pulumi-aws/sdk/v5 v5.3.0/go.mod h1:5Bl3enkEyJD5oDkNZYfduZP7aP3xFjCf7yaBdNuifEo=
 github.com/pulumi/pulumi/sdk/v3 v3.25.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
-github.com/pulumi/pulumi/sdk/v3 v3.30.0 h1:0X5gSUS3x82XzenpCCW8EdJrmOzoQqHSdQd0O6QSMQQ=
-github.com/pulumi/pulumi/sdk/v3 v3.30.0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0 h1:KOGdps/mozLqEeLDET2Q2MGW/du+iwKZ8lvNqVls+bA=
+github.com/pulumi/pulumi/sdk/v3 v3.31.1-0.20220503073946-62a228d9b3f0/go.mod h1:hGo/+AL1L4sPL9Ukd/i5bNFM3WHs3dHcA+GKEW7M3RA=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/sdk/go/awsx/awsx/pulumiTypes.go
+++ b/sdk/go/awsx/awsx/pulumiTypes.go
@@ -4,9 +4,13 @@
 package awsx
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // The set of arguments for constructing a Bucket resource.
@@ -58,6 +62,489 @@ type Bucket struct {
 	WebsiteEndpoint *string `pulumi:"websiteEndpoint"`
 }
 
+// BucketInput is an input type that accepts BucketArgs and BucketOutput values.
+// You can construct a concrete instance of `BucketInput` via:
+//
+//          BucketArgs{...}
+type BucketInput interface {
+	pulumi.Input
+
+	ToBucketOutput() BucketOutput
+	ToBucketOutputWithContext(context.Context) BucketOutput
+}
+
+// The set of arguments for constructing a Bucket resource.
+type BucketArgs struct {
+	// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+	AccelerationStatus pulumi.StringPtrInput `pulumi:"accelerationStatus"`
+	// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+	Acl pulumi.StringPtrInput `pulumi:"acl"`
+	// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+	Arn pulumi.StringPtrInput `pulumi:"arn"`
+	// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+	Bucket pulumi.StringPtrInput `pulumi:"bucket"`
+	// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+	BucketPrefix pulumi.StringPtrInput `pulumi:"bucketPrefix"`
+	// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+	CorsRules s3.BucketCorsRuleArrayInput `pulumi:"corsRules"`
+	// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+	ForceDestroy pulumi.BoolPtrInput `pulumi:"forceDestroy"`
+	// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+	Grants s3.BucketGrantArrayInput `pulumi:"grants"`
+	// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+	HostedZoneId pulumi.StringPtrInput `pulumi:"hostedZoneId"`
+	// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+	LifecycleRules s3.BucketLifecycleRuleArrayInput `pulumi:"lifecycleRules"`
+	// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+	Loggings s3.BucketLoggingArrayInput `pulumi:"loggings"`
+	// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+	ObjectLockConfiguration s3.BucketObjectLockConfigurationPtrInput `pulumi:"objectLockConfiguration"`
+	// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+	Policy pulumi.StringPtrInput `pulumi:"policy"`
+	// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+	ReplicationConfiguration s3.BucketReplicationConfigurationPtrInput `pulumi:"replicationConfiguration"`
+	// Specifies who should bear the cost of Amazon S3 data transfer.
+	// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+	// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+	// developer guide for more information.
+	RequestPayer pulumi.StringPtrInput `pulumi:"requestPayer"`
+	// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+	ServerSideEncryptionConfiguration s3.BucketServerSideEncryptionConfigurationPtrInput `pulumi:"serverSideEncryptionConfiguration"`
+	// A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+	// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+	Versioning s3.BucketVersioningPtrInput `pulumi:"versioning"`
+	// A website object (documented below).
+	Website s3.BucketWebsitePtrInput `pulumi:"website"`
+	// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+	WebsiteDomain pulumi.StringPtrInput `pulumi:"websiteDomain"`
+	// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
+	WebsiteEndpoint pulumi.StringPtrInput `pulumi:"websiteEndpoint"`
+}
+
+func (BucketArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*Bucket)(nil)).Elem()
+}
+
+func (i BucketArgs) ToBucketOutput() BucketOutput {
+	return i.ToBucketOutputWithContext(context.Background())
+}
+
+func (i BucketArgs) ToBucketOutputWithContext(ctx context.Context) BucketOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BucketOutput)
+}
+
+func (i BucketArgs) ToBucketPtrOutput() BucketPtrOutput {
+	return i.ToBucketPtrOutputWithContext(context.Background())
+}
+
+func (i BucketArgs) ToBucketPtrOutputWithContext(ctx context.Context) BucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BucketOutput).ToBucketPtrOutputWithContext(ctx)
+}
+
+// BucketPtrInput is an input type that accepts BucketArgs, BucketPtr and BucketPtrOutput values.
+// You can construct a concrete instance of `BucketPtrInput` via:
+//
+//          BucketArgs{...}
+//
+//  or:
+//
+//          nil
+type BucketPtrInput interface {
+	pulumi.Input
+
+	ToBucketPtrOutput() BucketPtrOutput
+	ToBucketPtrOutputWithContext(context.Context) BucketPtrOutput
+}
+
+type bucketPtrType BucketArgs
+
+func BucketPtr(v *BucketArgs) BucketPtrInput {
+	return (*bucketPtrType)(v)
+}
+
+func (*bucketPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**Bucket)(nil)).Elem()
+}
+
+func (i *bucketPtrType) ToBucketPtrOutput() BucketPtrOutput {
+	return i.ToBucketPtrOutputWithContext(context.Background())
+}
+
+func (i *bucketPtrType) ToBucketPtrOutputWithContext(ctx context.Context) BucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(BucketPtrOutput)
+}
+
+// The set of arguments for constructing a Bucket resource.
+type BucketOutput struct{ *pulumi.OutputState }
+
+func (BucketOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*Bucket)(nil)).Elem()
+}
+
+func (o BucketOutput) ToBucketOutput() BucketOutput {
+	return o
+}
+
+func (o BucketOutput) ToBucketOutputWithContext(ctx context.Context) BucketOutput {
+	return o
+}
+
+func (o BucketOutput) ToBucketPtrOutput() BucketPtrOutput {
+	return o.ToBucketPtrOutputWithContext(context.Background())
+}
+
+func (o BucketOutput) ToBucketPtrOutputWithContext(ctx context.Context) BucketPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Bucket) *Bucket {
+		return &v
+	}).(BucketPtrOutput)
+}
+
+// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+func (o BucketOutput) AccelerationStatus() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.AccelerationStatus }).(pulumi.StringPtrOutput)
+}
+
+// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+func (o BucketOutput) Acl() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.Acl }).(pulumi.StringPtrOutput)
+}
+
+// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+func (o BucketOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.Arn }).(pulumi.StringPtrOutput)
+}
+
+// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+func (o BucketOutput) Bucket() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.Bucket }).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+func (o BucketOutput) BucketPrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.BucketPrefix }).(pulumi.StringPtrOutput)
+}
+
+// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+func (o BucketOutput) CorsRules() s3.BucketCorsRuleArrayOutput {
+	return o.ApplyT(func(v Bucket) []s3.BucketCorsRule { return v.CorsRules }).(s3.BucketCorsRuleArrayOutput)
+}
+
+// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+func (o BucketOutput) ForceDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v Bucket) *bool { return v.ForceDestroy }).(pulumi.BoolPtrOutput)
+}
+
+// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+func (o BucketOutput) Grants() s3.BucketGrantArrayOutput {
+	return o.ApplyT(func(v Bucket) []s3.BucketGrant { return v.Grants }).(s3.BucketGrantArrayOutput)
+}
+
+// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+func (o BucketOutput) HostedZoneId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.HostedZoneId }).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+func (o BucketOutput) LifecycleRules() s3.BucketLifecycleRuleArrayOutput {
+	return o.ApplyT(func(v Bucket) []s3.BucketLifecycleRule { return v.LifecycleRules }).(s3.BucketLifecycleRuleArrayOutput)
+}
+
+// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+func (o BucketOutput) Loggings() s3.BucketLoggingArrayOutput {
+	return o.ApplyT(func(v Bucket) []s3.BucketLogging { return v.Loggings }).(s3.BucketLoggingArrayOutput)
+}
+
+// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+func (o BucketOutput) ObjectLockConfiguration() s3.BucketObjectLockConfigurationPtrOutput {
+	return o.ApplyT(func(v Bucket) *s3.BucketObjectLockConfiguration { return v.ObjectLockConfiguration }).(s3.BucketObjectLockConfigurationPtrOutput)
+}
+
+// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+func (o BucketOutput) Policy() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.Policy }).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+func (o BucketOutput) ReplicationConfiguration() s3.BucketReplicationConfigurationPtrOutput {
+	return o.ApplyT(func(v Bucket) *s3.BucketReplicationConfiguration { return v.ReplicationConfiguration }).(s3.BucketReplicationConfigurationPtrOutput)
+}
+
+// Specifies who should bear the cost of Amazon S3 data transfer.
+// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+// developer guide for more information.
+func (o BucketOutput) RequestPayer() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.RequestPayer }).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+func (o BucketOutput) ServerSideEncryptionConfiguration() s3.BucketServerSideEncryptionConfigurationPtrOutput {
+	return o.ApplyT(func(v Bucket) *s3.BucketServerSideEncryptionConfiguration { return v.ServerSideEncryptionConfiguration }).(s3.BucketServerSideEncryptionConfigurationPtrOutput)
+}
+
+// A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o BucketOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v Bucket) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+func (o BucketOutput) Versioning() s3.BucketVersioningPtrOutput {
+	return o.ApplyT(func(v Bucket) *s3.BucketVersioning { return v.Versioning }).(s3.BucketVersioningPtrOutput)
+}
+
+// A website object (documented below).
+func (o BucketOutput) Website() s3.BucketWebsitePtrOutput {
+	return o.ApplyT(func(v Bucket) *s3.BucketWebsite { return v.Website }).(s3.BucketWebsitePtrOutput)
+}
+
+// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+func (o BucketOutput) WebsiteDomain() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.WebsiteDomain }).(pulumi.StringPtrOutput)
+}
+
+// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
+func (o BucketOutput) WebsiteEndpoint() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v Bucket) *string { return v.WebsiteEndpoint }).(pulumi.StringPtrOutput)
+}
+
+type BucketPtrOutput struct{ *pulumi.OutputState }
+
+func (BucketPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Bucket)(nil)).Elem()
+}
+
+func (o BucketPtrOutput) ToBucketPtrOutput() BucketPtrOutput {
+	return o
+}
+
+func (o BucketPtrOutput) ToBucketPtrOutputWithContext(ctx context.Context) BucketPtrOutput {
+	return o
+}
+
+func (o BucketPtrOutput) Elem() BucketOutput {
+	return o.ApplyT(func(v *Bucket) Bucket {
+		if v != nil {
+			return *v
+		}
+		var ret Bucket
+		return ret
+	}).(BucketOutput)
+}
+
+// Sets the accelerate configuration of an existing bucket. Can be `Enabled` or `Suspended`.
+func (o BucketPtrOutput) AccelerationStatus() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.AccelerationStatus
+	}).(pulumi.StringPtrOutput)
+}
+
+// The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, and `log-delivery-write`. Defaults to `private`.  Conflicts with `grant`.
+func (o BucketPtrOutput) Acl() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Acl
+	}).(pulumi.StringPtrOutput)
+}
+
+// The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+func (o BucketPtrOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Arn
+	}).(pulumi.StringPtrOutput)
+}
+
+// The name of the bucket. If omitted, this provider will assign a random, unique name. Must be lowercase and less than or equal to 63 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+func (o BucketPtrOutput) Bucket() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Bucket
+	}).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique bucket name beginning with the specified prefix. Conflicts with `bucket`. Must be lowercase and less than or equal to 37 characters in length. A full list of bucket naming rules [may be found here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
+func (o BucketPtrOutput) BucketPrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.BucketPrefix
+	}).(pulumi.StringPtrOutput)
+}
+
+// A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
+func (o BucketPtrOutput) CorsRules() s3.BucketCorsRuleArrayOutput {
+	return o.ApplyT(func(v *Bucket) []s3.BucketCorsRule {
+		if v == nil {
+			return nil
+		}
+		return v.CorsRules
+	}).(s3.BucketCorsRuleArrayOutput)
+}
+
+// A boolean that indicates all objects (including any [locked objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+func (o BucketPtrOutput) ForceDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *Bucket) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.ForceDestroy
+	}).(pulumi.BoolPtrOutput)
+}
+
+// An [ACL policy grant](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) (documented below). Conflicts with `acl`.
+func (o BucketPtrOutput) Grants() s3.BucketGrantArrayOutput {
+	return o.ApplyT(func(v *Bucket) []s3.BucketGrant {
+		if v == nil {
+			return nil
+		}
+		return v.Grants
+	}).(s3.BucketGrantArrayOutput)
+}
+
+// The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
+func (o BucketPtrOutput) HostedZoneId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.HostedZoneId
+	}).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [object lifecycle management](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) (documented below).
+func (o BucketPtrOutput) LifecycleRules() s3.BucketLifecycleRuleArrayOutput {
+	return o.ApplyT(func(v *Bucket) []s3.BucketLifecycleRule {
+		if v == nil {
+			return nil
+		}
+		return v.LifecycleRules
+	}).(s3.BucketLifecycleRuleArrayOutput)
+}
+
+// A settings of [bucket logging](https://docs.aws.amazon.com/AmazonS3/latest/UG/ManagingBucketLogging.html) (documented below).
+func (o BucketPtrOutput) Loggings() s3.BucketLoggingArrayOutput {
+	return o.ApplyT(func(v *Bucket) []s3.BucketLogging {
+		if v == nil {
+			return nil
+		}
+		return v.Loggings
+	}).(s3.BucketLoggingArrayOutput)
+}
+
+// A configuration of [S3 object locking](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) (documented below)
+func (o BucketPtrOutput) ObjectLockConfiguration() s3.BucketObjectLockConfigurationPtrOutput {
+	return o.ApplyT(func(v *Bucket) *s3.BucketObjectLockConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.ObjectLockConfiguration
+	}).(s3.BucketObjectLockConfigurationPtrOutput)
+}
+
+// A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), this provider may view the policy as constantly changing in a `pulumi preview`. In this case, please make sure you use the verbose/specific version of the policy.
+func (o BucketPtrOutput) Policy() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Policy
+	}).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
+func (o BucketPtrOutput) ReplicationConfiguration() s3.BucketReplicationConfigurationPtrOutput {
+	return o.ApplyT(func(v *Bucket) *s3.BucketReplicationConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.ReplicationConfiguration
+	}).(s3.BucketReplicationConfigurationPtrOutput)
+}
+
+// Specifies who should bear the cost of Amazon S3 data transfer.
+// Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
+// the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
+// developer guide for more information.
+func (o BucketPtrOutput) RequestPayer() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.RequestPayer
+	}).(pulumi.StringPtrOutput)
+}
+
+// A configuration of [server-side encryption configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) (documented below)
+func (o BucketPtrOutput) ServerSideEncryptionConfiguration() s3.BucketServerSideEncryptionConfigurationPtrOutput {
+	return o.ApplyT(func(v *Bucket) *s3.BucketServerSideEncryptionConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.ServerSideEncryptionConfiguration
+	}).(s3.BucketServerSideEncryptionConfigurationPtrOutput)
+}
+
+// A map of tags to assign to the bucket. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o BucketPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Bucket) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
+// A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)
+func (o BucketPtrOutput) Versioning() s3.BucketVersioningPtrOutput {
+	return o.ApplyT(func(v *Bucket) *s3.BucketVersioning {
+		if v == nil {
+			return nil
+		}
+		return v.Versioning
+	}).(s3.BucketVersioningPtrOutput)
+}
+
+// A website object (documented below).
+func (o BucketPtrOutput) Website() s3.BucketWebsitePtrOutput {
+	return o.ApplyT(func(v *Bucket) *s3.BucketWebsite {
+		if v == nil {
+			return nil
+		}
+		return v.Website
+	}).(s3.BucketWebsitePtrOutput)
+}
+
+// The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records.
+func (o BucketPtrOutput) WebsiteDomain() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.WebsiteDomain
+	}).(pulumi.StringPtrOutput)
+}
+
+// The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.
+func (o BucketPtrOutput) WebsiteEndpoint() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Bucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.WebsiteEndpoint
+	}).(pulumi.StringPtrOutput)
+}
+
 // Bucket with default setup unless explicitly skipped.
 type DefaultBucket struct {
 	// Arguments to use instead of the default values during creation.
@@ -78,6 +565,174 @@ type DefaultLogGroup struct {
 	Skip *bool `pulumi:"skip"`
 }
 
+// DefaultLogGroupInput is an input type that accepts DefaultLogGroupArgs and DefaultLogGroupOutput values.
+// You can construct a concrete instance of `DefaultLogGroupInput` via:
+//
+//          DefaultLogGroupArgs{...}
+type DefaultLogGroupInput interface {
+	pulumi.Input
+
+	ToDefaultLogGroupOutput() DefaultLogGroupOutput
+	ToDefaultLogGroupOutputWithContext(context.Context) DefaultLogGroupOutput
+}
+
+// Log group with default setup unless explicitly skipped.
+type DefaultLogGroupArgs struct {
+	// Arguments to use instead of the default values during creation.
+	Args *LogGroupArgs `pulumi:"args"`
+	// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+	Existing *ExistingLogGroupArgs `pulumi:"existing"`
+	// Skip creation of the log group.
+	Skip *bool `pulumi:"skip"`
+}
+
+func (DefaultLogGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultLogGroup)(nil)).Elem()
+}
+
+func (i DefaultLogGroupArgs) ToDefaultLogGroupOutput() DefaultLogGroupOutput {
+	return i.ToDefaultLogGroupOutputWithContext(context.Background())
+}
+
+func (i DefaultLogGroupArgs) ToDefaultLogGroupOutputWithContext(ctx context.Context) DefaultLogGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultLogGroupOutput)
+}
+
+func (i DefaultLogGroupArgs) ToDefaultLogGroupPtrOutput() DefaultLogGroupPtrOutput {
+	return i.ToDefaultLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i DefaultLogGroupArgs) ToDefaultLogGroupPtrOutputWithContext(ctx context.Context) DefaultLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultLogGroupOutput).ToDefaultLogGroupPtrOutputWithContext(ctx)
+}
+
+// DefaultLogGroupPtrInput is an input type that accepts DefaultLogGroupArgs, DefaultLogGroupPtr and DefaultLogGroupPtrOutput values.
+// You can construct a concrete instance of `DefaultLogGroupPtrInput` via:
+//
+//          DefaultLogGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type DefaultLogGroupPtrInput interface {
+	pulumi.Input
+
+	ToDefaultLogGroupPtrOutput() DefaultLogGroupPtrOutput
+	ToDefaultLogGroupPtrOutputWithContext(context.Context) DefaultLogGroupPtrOutput
+}
+
+type defaultLogGroupPtrType DefaultLogGroupArgs
+
+func DefaultLogGroupPtr(v *DefaultLogGroupArgs) DefaultLogGroupPtrInput {
+	return (*defaultLogGroupPtrType)(v)
+}
+
+func (*defaultLogGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultLogGroup)(nil)).Elem()
+}
+
+func (i *defaultLogGroupPtrType) ToDefaultLogGroupPtrOutput() DefaultLogGroupPtrOutput {
+	return i.ToDefaultLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *defaultLogGroupPtrType) ToDefaultLogGroupPtrOutputWithContext(ctx context.Context) DefaultLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultLogGroupPtrOutput)
+}
+
+// Log group with default setup unless explicitly skipped.
+type DefaultLogGroupOutput struct{ *pulumi.OutputState }
+
+func (DefaultLogGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultLogGroup)(nil)).Elem()
+}
+
+func (o DefaultLogGroupOutput) ToDefaultLogGroupOutput() DefaultLogGroupOutput {
+	return o
+}
+
+func (o DefaultLogGroupOutput) ToDefaultLogGroupOutputWithContext(ctx context.Context) DefaultLogGroupOutput {
+	return o
+}
+
+func (o DefaultLogGroupOutput) ToDefaultLogGroupPtrOutput() DefaultLogGroupPtrOutput {
+	return o.ToDefaultLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (o DefaultLogGroupOutput) ToDefaultLogGroupPtrOutputWithContext(ctx context.Context) DefaultLogGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v DefaultLogGroup) *DefaultLogGroup {
+		return &v
+	}).(DefaultLogGroupPtrOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o DefaultLogGroupOutput) Args() LogGroupPtrOutput {
+	return o.ApplyT(func(v DefaultLogGroup) *LogGroup { return v.Args }).(LogGroupPtrOutput)
+}
+
+// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+func (o DefaultLogGroupOutput) Existing() ExistingLogGroupPtrOutput {
+	return o.ApplyT(func(v DefaultLogGroup) *ExistingLogGroup { return v.Existing }).(ExistingLogGroupPtrOutput)
+}
+
+// Skip creation of the log group.
+func (o DefaultLogGroupOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v DefaultLogGroup) *bool { return v.Skip }).(pulumi.BoolPtrOutput)
+}
+
+type DefaultLogGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (DefaultLogGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultLogGroup)(nil)).Elem()
+}
+
+func (o DefaultLogGroupPtrOutput) ToDefaultLogGroupPtrOutput() DefaultLogGroupPtrOutput {
+	return o
+}
+
+func (o DefaultLogGroupPtrOutput) ToDefaultLogGroupPtrOutputWithContext(ctx context.Context) DefaultLogGroupPtrOutput {
+	return o
+}
+
+func (o DefaultLogGroupPtrOutput) Elem() DefaultLogGroupOutput {
+	return o.ApplyT(func(v *DefaultLogGroup) DefaultLogGroup {
+		if v != nil {
+			return *v
+		}
+		var ret DefaultLogGroup
+		return ret
+	}).(DefaultLogGroupOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o DefaultLogGroupPtrOutput) Args() LogGroupPtrOutput {
+	return o.ApplyT(func(v *DefaultLogGroup) *LogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(LogGroupPtrOutput)
+}
+
+// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+func (o DefaultLogGroupPtrOutput) Existing() ExistingLogGroupPtrOutput {
+	return o.ApplyT(func(v *DefaultLogGroup) *ExistingLogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.Existing
+	}).(ExistingLogGroupPtrOutput)
+}
+
+// Skip creation of the log group.
+func (o DefaultLogGroupPtrOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *DefaultLogGroup) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Skip
+	}).(pulumi.BoolPtrOutput)
+}
+
 // Role and policy attachments with default setup unless explicitly skipped or an existing role ARN provided.
 type DefaultRoleWithPolicy struct {
 	// Args to use when creating the role and policies. Can't be specified if `roleArn` is used.
@@ -86,6 +741,174 @@ type DefaultRoleWithPolicy struct {
 	RoleArn *string `pulumi:"roleArn"`
 	// Skips creation of the role if set to `true`.
 	Skip *bool `pulumi:"skip"`
+}
+
+// DefaultRoleWithPolicyInput is an input type that accepts DefaultRoleWithPolicyArgs and DefaultRoleWithPolicyOutput values.
+// You can construct a concrete instance of `DefaultRoleWithPolicyInput` via:
+//
+//          DefaultRoleWithPolicyArgs{...}
+type DefaultRoleWithPolicyInput interface {
+	pulumi.Input
+
+	ToDefaultRoleWithPolicyOutput() DefaultRoleWithPolicyOutput
+	ToDefaultRoleWithPolicyOutputWithContext(context.Context) DefaultRoleWithPolicyOutput
+}
+
+// Role and policy attachments with default setup unless explicitly skipped or an existing role ARN provided.
+type DefaultRoleWithPolicyArgs struct {
+	// Args to use when creating the role and policies. Can't be specified if `roleArn` is used.
+	Args *RoleWithPolicyArgs `pulumi:"args"`
+	// ARN of existing role to use instead of creating a new role. Cannot be used in combination with `args` or `opts`.
+	RoleArn pulumi.StringPtrInput `pulumi:"roleArn"`
+	// Skips creation of the role if set to `true`.
+	Skip *bool `pulumi:"skip"`
+}
+
+func (DefaultRoleWithPolicyArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultRoleWithPolicy)(nil)).Elem()
+}
+
+func (i DefaultRoleWithPolicyArgs) ToDefaultRoleWithPolicyOutput() DefaultRoleWithPolicyOutput {
+	return i.ToDefaultRoleWithPolicyOutputWithContext(context.Background())
+}
+
+func (i DefaultRoleWithPolicyArgs) ToDefaultRoleWithPolicyOutputWithContext(ctx context.Context) DefaultRoleWithPolicyOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultRoleWithPolicyOutput)
+}
+
+func (i DefaultRoleWithPolicyArgs) ToDefaultRoleWithPolicyPtrOutput() DefaultRoleWithPolicyPtrOutput {
+	return i.ToDefaultRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (i DefaultRoleWithPolicyArgs) ToDefaultRoleWithPolicyPtrOutputWithContext(ctx context.Context) DefaultRoleWithPolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultRoleWithPolicyOutput).ToDefaultRoleWithPolicyPtrOutputWithContext(ctx)
+}
+
+// DefaultRoleWithPolicyPtrInput is an input type that accepts DefaultRoleWithPolicyArgs, DefaultRoleWithPolicyPtr and DefaultRoleWithPolicyPtrOutput values.
+// You can construct a concrete instance of `DefaultRoleWithPolicyPtrInput` via:
+//
+//          DefaultRoleWithPolicyArgs{...}
+//
+//  or:
+//
+//          nil
+type DefaultRoleWithPolicyPtrInput interface {
+	pulumi.Input
+
+	ToDefaultRoleWithPolicyPtrOutput() DefaultRoleWithPolicyPtrOutput
+	ToDefaultRoleWithPolicyPtrOutputWithContext(context.Context) DefaultRoleWithPolicyPtrOutput
+}
+
+type defaultRoleWithPolicyPtrType DefaultRoleWithPolicyArgs
+
+func DefaultRoleWithPolicyPtr(v *DefaultRoleWithPolicyArgs) DefaultRoleWithPolicyPtrInput {
+	return (*defaultRoleWithPolicyPtrType)(v)
+}
+
+func (*defaultRoleWithPolicyPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultRoleWithPolicy)(nil)).Elem()
+}
+
+func (i *defaultRoleWithPolicyPtrType) ToDefaultRoleWithPolicyPtrOutput() DefaultRoleWithPolicyPtrOutput {
+	return i.ToDefaultRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (i *defaultRoleWithPolicyPtrType) ToDefaultRoleWithPolicyPtrOutputWithContext(ctx context.Context) DefaultRoleWithPolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultRoleWithPolicyPtrOutput)
+}
+
+// Role and policy attachments with default setup unless explicitly skipped or an existing role ARN provided.
+type DefaultRoleWithPolicyOutput struct{ *pulumi.OutputState }
+
+func (DefaultRoleWithPolicyOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultRoleWithPolicy)(nil)).Elem()
+}
+
+func (o DefaultRoleWithPolicyOutput) ToDefaultRoleWithPolicyOutput() DefaultRoleWithPolicyOutput {
+	return o
+}
+
+func (o DefaultRoleWithPolicyOutput) ToDefaultRoleWithPolicyOutputWithContext(ctx context.Context) DefaultRoleWithPolicyOutput {
+	return o
+}
+
+func (o DefaultRoleWithPolicyOutput) ToDefaultRoleWithPolicyPtrOutput() DefaultRoleWithPolicyPtrOutput {
+	return o.ToDefaultRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (o DefaultRoleWithPolicyOutput) ToDefaultRoleWithPolicyPtrOutputWithContext(ctx context.Context) DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v DefaultRoleWithPolicy) *DefaultRoleWithPolicy {
+		return &v
+	}).(DefaultRoleWithPolicyPtrOutput)
+}
+
+// Args to use when creating the role and policies. Can't be specified if `roleArn` is used.
+func (o DefaultRoleWithPolicyOutput) Args() RoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v DefaultRoleWithPolicy) *RoleWithPolicy { return v.Args }).(RoleWithPolicyPtrOutput)
+}
+
+// ARN of existing role to use instead of creating a new role. Cannot be used in combination with `args` or `opts`.
+func (o DefaultRoleWithPolicyOutput) RoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v DefaultRoleWithPolicy) *string { return v.RoleArn }).(pulumi.StringPtrOutput)
+}
+
+// Skips creation of the role if set to `true`.
+func (o DefaultRoleWithPolicyOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v DefaultRoleWithPolicy) *bool { return v.Skip }).(pulumi.BoolPtrOutput)
+}
+
+type DefaultRoleWithPolicyPtrOutput struct{ *pulumi.OutputState }
+
+func (DefaultRoleWithPolicyPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultRoleWithPolicy)(nil)).Elem()
+}
+
+func (o DefaultRoleWithPolicyPtrOutput) ToDefaultRoleWithPolicyPtrOutput() DefaultRoleWithPolicyPtrOutput {
+	return o
+}
+
+func (o DefaultRoleWithPolicyPtrOutput) ToDefaultRoleWithPolicyPtrOutputWithContext(ctx context.Context) DefaultRoleWithPolicyPtrOutput {
+	return o
+}
+
+func (o DefaultRoleWithPolicyPtrOutput) Elem() DefaultRoleWithPolicyOutput {
+	return o.ApplyT(func(v *DefaultRoleWithPolicy) DefaultRoleWithPolicy {
+		if v != nil {
+			return *v
+		}
+		var ret DefaultRoleWithPolicy
+		return ret
+	}).(DefaultRoleWithPolicyOutput)
+}
+
+// Args to use when creating the role and policies. Can't be specified if `roleArn` is used.
+func (o DefaultRoleWithPolicyPtrOutput) Args() RoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v *DefaultRoleWithPolicy) *RoleWithPolicy {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(RoleWithPolicyPtrOutput)
+}
+
+// ARN of existing role to use instead of creating a new role. Cannot be used in combination with `args` or `opts`.
+func (o DefaultRoleWithPolicyPtrOutput) RoleArn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DefaultRoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.RoleArn
+	}).(pulumi.StringPtrOutput)
+}
+
+// Skips creation of the role if set to `true`.
+func (o DefaultRoleWithPolicyPtrOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *DefaultRoleWithPolicy) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Skip
+	}).(pulumi.BoolPtrOutput)
 }
 
 // Security Group with default setup unless explicitly skipped or an existing security group id provided.
@@ -109,12 +932,341 @@ func (val *DefaultSecurityGroup) Defaults() *DefaultSecurityGroup {
 	return &tmp
 }
 
+// DefaultSecurityGroupInput is an input type that accepts DefaultSecurityGroupArgs and DefaultSecurityGroupOutput values.
+// You can construct a concrete instance of `DefaultSecurityGroupInput` via:
+//
+//          DefaultSecurityGroupArgs{...}
+type DefaultSecurityGroupInput interface {
+	pulumi.Input
+
+	ToDefaultSecurityGroupOutput() DefaultSecurityGroupOutput
+	ToDefaultSecurityGroupOutputWithContext(context.Context) DefaultSecurityGroupOutput
+}
+
+// Security Group with default setup unless explicitly skipped or an existing security group id provided.
+type DefaultSecurityGroupArgs struct {
+	// Args to use when creating the security group. Can't be specified if `securityGroupId` is used.
+	Args *SecurityGroupArgs `pulumi:"args"`
+	// Id of existing security group to use instead of creating a new security group. Cannot be used in combination with `args` or `opts`.
+	SecurityGroupId pulumi.StringPtrInput `pulumi:"securityGroupId"`
+	// Skips creation of the security group if set to `true`.
+	Skip *bool `pulumi:"skip"`
+}
+
+// Defaults sets the appropriate defaults for DefaultSecurityGroupArgs
+func (val *DefaultSecurityGroupArgs) Defaults() *DefaultSecurityGroupArgs {
+	if val == nil {
+		return nil
+	}
+	tmp := *val
+	tmp.Args = tmp.Args.Defaults()
+
+	return &tmp
+}
+func (DefaultSecurityGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultSecurityGroup)(nil)).Elem()
+}
+
+func (i DefaultSecurityGroupArgs) ToDefaultSecurityGroupOutput() DefaultSecurityGroupOutput {
+	return i.ToDefaultSecurityGroupOutputWithContext(context.Background())
+}
+
+func (i DefaultSecurityGroupArgs) ToDefaultSecurityGroupOutputWithContext(ctx context.Context) DefaultSecurityGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultSecurityGroupOutput)
+}
+
+func (i DefaultSecurityGroupArgs) ToDefaultSecurityGroupPtrOutput() DefaultSecurityGroupPtrOutput {
+	return i.ToDefaultSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (i DefaultSecurityGroupArgs) ToDefaultSecurityGroupPtrOutputWithContext(ctx context.Context) DefaultSecurityGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultSecurityGroupOutput).ToDefaultSecurityGroupPtrOutputWithContext(ctx)
+}
+
+// DefaultSecurityGroupPtrInput is an input type that accepts DefaultSecurityGroupArgs, DefaultSecurityGroupPtr and DefaultSecurityGroupPtrOutput values.
+// You can construct a concrete instance of `DefaultSecurityGroupPtrInput` via:
+//
+//          DefaultSecurityGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type DefaultSecurityGroupPtrInput interface {
+	pulumi.Input
+
+	ToDefaultSecurityGroupPtrOutput() DefaultSecurityGroupPtrOutput
+	ToDefaultSecurityGroupPtrOutputWithContext(context.Context) DefaultSecurityGroupPtrOutput
+}
+
+type defaultSecurityGroupPtrType DefaultSecurityGroupArgs
+
+func DefaultSecurityGroupPtr(v *DefaultSecurityGroupArgs) DefaultSecurityGroupPtrInput {
+	return (*defaultSecurityGroupPtrType)(v)
+}
+
+func (*defaultSecurityGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultSecurityGroup)(nil)).Elem()
+}
+
+func (i *defaultSecurityGroupPtrType) ToDefaultSecurityGroupPtrOutput() DefaultSecurityGroupPtrOutput {
+	return i.ToDefaultSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *defaultSecurityGroupPtrType) ToDefaultSecurityGroupPtrOutputWithContext(ctx context.Context) DefaultSecurityGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(DefaultSecurityGroupPtrOutput)
+}
+
+// Security Group with default setup unless explicitly skipped or an existing security group id provided.
+type DefaultSecurityGroupOutput struct{ *pulumi.OutputState }
+
+func (DefaultSecurityGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*DefaultSecurityGroup)(nil)).Elem()
+}
+
+func (o DefaultSecurityGroupOutput) ToDefaultSecurityGroupOutput() DefaultSecurityGroupOutput {
+	return o
+}
+
+func (o DefaultSecurityGroupOutput) ToDefaultSecurityGroupOutputWithContext(ctx context.Context) DefaultSecurityGroupOutput {
+	return o
+}
+
+func (o DefaultSecurityGroupOutput) ToDefaultSecurityGroupPtrOutput() DefaultSecurityGroupPtrOutput {
+	return o.ToDefaultSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (o DefaultSecurityGroupOutput) ToDefaultSecurityGroupPtrOutputWithContext(ctx context.Context) DefaultSecurityGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v DefaultSecurityGroup) *DefaultSecurityGroup {
+		return &v
+	}).(DefaultSecurityGroupPtrOutput)
+}
+
+// Args to use when creating the security group. Can't be specified if `securityGroupId` is used.
+func (o DefaultSecurityGroupOutput) Args() SecurityGroupPtrOutput {
+	return o.ApplyT(func(v DefaultSecurityGroup) *SecurityGroup { return v.Args }).(SecurityGroupPtrOutput)
+}
+
+// Id of existing security group to use instead of creating a new security group. Cannot be used in combination with `args` or `opts`.
+func (o DefaultSecurityGroupOutput) SecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v DefaultSecurityGroup) *string { return v.SecurityGroupId }).(pulumi.StringPtrOutput)
+}
+
+// Skips creation of the security group if set to `true`.
+func (o DefaultSecurityGroupOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v DefaultSecurityGroup) *bool { return v.Skip }).(pulumi.BoolPtrOutput)
+}
+
+type DefaultSecurityGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (DefaultSecurityGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**DefaultSecurityGroup)(nil)).Elem()
+}
+
+func (o DefaultSecurityGroupPtrOutput) ToDefaultSecurityGroupPtrOutput() DefaultSecurityGroupPtrOutput {
+	return o
+}
+
+func (o DefaultSecurityGroupPtrOutput) ToDefaultSecurityGroupPtrOutputWithContext(ctx context.Context) DefaultSecurityGroupPtrOutput {
+	return o
+}
+
+func (o DefaultSecurityGroupPtrOutput) Elem() DefaultSecurityGroupOutput {
+	return o.ApplyT(func(v *DefaultSecurityGroup) DefaultSecurityGroup {
+		if v != nil {
+			return *v
+		}
+		var ret DefaultSecurityGroup
+		return ret
+	}).(DefaultSecurityGroupOutput)
+}
+
+// Args to use when creating the security group. Can't be specified if `securityGroupId` is used.
+func (o DefaultSecurityGroupPtrOutput) Args() SecurityGroupPtrOutput {
+	return o.ApplyT(func(v *DefaultSecurityGroup) *SecurityGroup {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(SecurityGroupPtrOutput)
+}
+
+// Id of existing security group to use instead of creating a new security group. Cannot be used in combination with `args` or `opts`.
+func (o DefaultSecurityGroupPtrOutput) SecurityGroupId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *DefaultSecurityGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.SecurityGroupId
+	}).(pulumi.StringPtrOutput)
+}
+
+// Skips creation of the security group if set to `true`.
+func (o DefaultSecurityGroupPtrOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *DefaultSecurityGroup) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Skip
+	}).(pulumi.BoolPtrOutput)
+}
+
 // Reference to an existing bucket.
 type ExistingBucket struct {
 	// Arn of the bucket. Only one of [arn] or [name] can be specified.
 	Arn *string `pulumi:"arn"`
 	// Name of the bucket. Only one of [arn] or [name] can be specified.
 	Name *string `pulumi:"name"`
+}
+
+// ExistingBucketInput is an input type that accepts ExistingBucketArgs and ExistingBucketOutput values.
+// You can construct a concrete instance of `ExistingBucketInput` via:
+//
+//          ExistingBucketArgs{...}
+type ExistingBucketInput interface {
+	pulumi.Input
+
+	ToExistingBucketOutput() ExistingBucketOutput
+	ToExistingBucketOutputWithContext(context.Context) ExistingBucketOutput
+}
+
+// Reference to an existing bucket.
+type ExistingBucketArgs struct {
+	// Arn of the bucket. Only one of [arn] or [name] can be specified.
+	Arn pulumi.StringPtrInput `pulumi:"arn"`
+	// Name of the bucket. Only one of [arn] or [name] can be specified.
+	Name pulumi.StringPtrInput `pulumi:"name"`
+}
+
+func (ExistingBucketArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ExistingBucket)(nil)).Elem()
+}
+
+func (i ExistingBucketArgs) ToExistingBucketOutput() ExistingBucketOutput {
+	return i.ToExistingBucketOutputWithContext(context.Background())
+}
+
+func (i ExistingBucketArgs) ToExistingBucketOutputWithContext(ctx context.Context) ExistingBucketOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingBucketOutput)
+}
+
+func (i ExistingBucketArgs) ToExistingBucketPtrOutput() ExistingBucketPtrOutput {
+	return i.ToExistingBucketPtrOutputWithContext(context.Background())
+}
+
+func (i ExistingBucketArgs) ToExistingBucketPtrOutputWithContext(ctx context.Context) ExistingBucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingBucketOutput).ToExistingBucketPtrOutputWithContext(ctx)
+}
+
+// ExistingBucketPtrInput is an input type that accepts ExistingBucketArgs, ExistingBucketPtr and ExistingBucketPtrOutput values.
+// You can construct a concrete instance of `ExistingBucketPtrInput` via:
+//
+//          ExistingBucketArgs{...}
+//
+//  or:
+//
+//          nil
+type ExistingBucketPtrInput interface {
+	pulumi.Input
+
+	ToExistingBucketPtrOutput() ExistingBucketPtrOutput
+	ToExistingBucketPtrOutputWithContext(context.Context) ExistingBucketPtrOutput
+}
+
+type existingBucketPtrType ExistingBucketArgs
+
+func ExistingBucketPtr(v *ExistingBucketArgs) ExistingBucketPtrInput {
+	return (*existingBucketPtrType)(v)
+}
+
+func (*existingBucketPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**ExistingBucket)(nil)).Elem()
+}
+
+func (i *existingBucketPtrType) ToExistingBucketPtrOutput() ExistingBucketPtrOutput {
+	return i.ToExistingBucketPtrOutputWithContext(context.Background())
+}
+
+func (i *existingBucketPtrType) ToExistingBucketPtrOutputWithContext(ctx context.Context) ExistingBucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingBucketPtrOutput)
+}
+
+// Reference to an existing bucket.
+type ExistingBucketOutput struct{ *pulumi.OutputState }
+
+func (ExistingBucketOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ExistingBucket)(nil)).Elem()
+}
+
+func (o ExistingBucketOutput) ToExistingBucketOutput() ExistingBucketOutput {
+	return o
+}
+
+func (o ExistingBucketOutput) ToExistingBucketOutputWithContext(ctx context.Context) ExistingBucketOutput {
+	return o
+}
+
+func (o ExistingBucketOutput) ToExistingBucketPtrOutput() ExistingBucketPtrOutput {
+	return o.ToExistingBucketPtrOutputWithContext(context.Background())
+}
+
+func (o ExistingBucketOutput) ToExistingBucketPtrOutputWithContext(ctx context.Context) ExistingBucketPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v ExistingBucket) *ExistingBucket {
+		return &v
+	}).(ExistingBucketPtrOutput)
+}
+
+// Arn of the bucket. Only one of [arn] or [name] can be specified.
+func (o ExistingBucketOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ExistingBucket) *string { return v.Arn }).(pulumi.StringPtrOutput)
+}
+
+// Name of the bucket. Only one of [arn] or [name] can be specified.
+func (o ExistingBucketOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ExistingBucket) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+type ExistingBucketPtrOutput struct{ *pulumi.OutputState }
+
+func (ExistingBucketPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**ExistingBucket)(nil)).Elem()
+}
+
+func (o ExistingBucketPtrOutput) ToExistingBucketPtrOutput() ExistingBucketPtrOutput {
+	return o
+}
+
+func (o ExistingBucketPtrOutput) ToExistingBucketPtrOutputWithContext(ctx context.Context) ExistingBucketPtrOutput {
+	return o
+}
+
+func (o ExistingBucketPtrOutput) Elem() ExistingBucketOutput {
+	return o.ApplyT(func(v *ExistingBucket) ExistingBucket {
+		if v != nil {
+			return *v
+		}
+		var ret ExistingBucket
+		return ret
+	}).(ExistingBucketOutput)
+}
+
+// Arn of the bucket. Only one of [arn] or [name] can be specified.
+func (o ExistingBucketPtrOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ExistingBucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Arn
+	}).(pulumi.StringPtrOutput)
+}
+
+// Name of the bucket. Only one of [arn] or [name] can be specified.
+func (o ExistingBucketPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ExistingBucket) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
 }
 
 // Reference to an existing log group.
@@ -125,6 +1277,174 @@ type ExistingLogGroup struct {
 	Name *string `pulumi:"name"`
 	// Region of the log group. If not specified, the provider region will be used.
 	Region *string `pulumi:"region"`
+}
+
+// ExistingLogGroupInput is an input type that accepts ExistingLogGroupArgs and ExistingLogGroupOutput values.
+// You can construct a concrete instance of `ExistingLogGroupInput` via:
+//
+//          ExistingLogGroupArgs{...}
+type ExistingLogGroupInput interface {
+	pulumi.Input
+
+	ToExistingLogGroupOutput() ExistingLogGroupOutput
+	ToExistingLogGroupOutputWithContext(context.Context) ExistingLogGroupOutput
+}
+
+// Reference to an existing log group.
+type ExistingLogGroupArgs struct {
+	// Arn of the log group. Only one of [arn] or [name] can be specified.
+	Arn pulumi.StringPtrInput `pulumi:"arn"`
+	// Name of the log group. Only one of [arn] or [name] can be specified.
+	Name pulumi.StringPtrInput `pulumi:"name"`
+	// Region of the log group. If not specified, the provider region will be used.
+	Region pulumi.StringPtrInput `pulumi:"region"`
+}
+
+func (ExistingLogGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*ExistingLogGroup)(nil)).Elem()
+}
+
+func (i ExistingLogGroupArgs) ToExistingLogGroupOutput() ExistingLogGroupOutput {
+	return i.ToExistingLogGroupOutputWithContext(context.Background())
+}
+
+func (i ExistingLogGroupArgs) ToExistingLogGroupOutputWithContext(ctx context.Context) ExistingLogGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingLogGroupOutput)
+}
+
+func (i ExistingLogGroupArgs) ToExistingLogGroupPtrOutput() ExistingLogGroupPtrOutput {
+	return i.ToExistingLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i ExistingLogGroupArgs) ToExistingLogGroupPtrOutputWithContext(ctx context.Context) ExistingLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingLogGroupOutput).ToExistingLogGroupPtrOutputWithContext(ctx)
+}
+
+// ExistingLogGroupPtrInput is an input type that accepts ExistingLogGroupArgs, ExistingLogGroupPtr and ExistingLogGroupPtrOutput values.
+// You can construct a concrete instance of `ExistingLogGroupPtrInput` via:
+//
+//          ExistingLogGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type ExistingLogGroupPtrInput interface {
+	pulumi.Input
+
+	ToExistingLogGroupPtrOutput() ExistingLogGroupPtrOutput
+	ToExistingLogGroupPtrOutputWithContext(context.Context) ExistingLogGroupPtrOutput
+}
+
+type existingLogGroupPtrType ExistingLogGroupArgs
+
+func ExistingLogGroupPtr(v *ExistingLogGroupArgs) ExistingLogGroupPtrInput {
+	return (*existingLogGroupPtrType)(v)
+}
+
+func (*existingLogGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**ExistingLogGroup)(nil)).Elem()
+}
+
+func (i *existingLogGroupPtrType) ToExistingLogGroupPtrOutput() ExistingLogGroupPtrOutput {
+	return i.ToExistingLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *existingLogGroupPtrType) ToExistingLogGroupPtrOutputWithContext(ctx context.Context) ExistingLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ExistingLogGroupPtrOutput)
+}
+
+// Reference to an existing log group.
+type ExistingLogGroupOutput struct{ *pulumi.OutputState }
+
+func (ExistingLogGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*ExistingLogGroup)(nil)).Elem()
+}
+
+func (o ExistingLogGroupOutput) ToExistingLogGroupOutput() ExistingLogGroupOutput {
+	return o
+}
+
+func (o ExistingLogGroupOutput) ToExistingLogGroupOutputWithContext(ctx context.Context) ExistingLogGroupOutput {
+	return o
+}
+
+func (o ExistingLogGroupOutput) ToExistingLogGroupPtrOutput() ExistingLogGroupPtrOutput {
+	return o.ToExistingLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (o ExistingLogGroupOutput) ToExistingLogGroupPtrOutputWithContext(ctx context.Context) ExistingLogGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v ExistingLogGroup) *ExistingLogGroup {
+		return &v
+	}).(ExistingLogGroupPtrOutput)
+}
+
+// Arn of the log group. Only one of [arn] or [name] can be specified.
+func (o ExistingLogGroupOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ExistingLogGroup) *string { return v.Arn }).(pulumi.StringPtrOutput)
+}
+
+// Name of the log group. Only one of [arn] or [name] can be specified.
+func (o ExistingLogGroupOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ExistingLogGroup) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// Region of the log group. If not specified, the provider region will be used.
+func (o ExistingLogGroupOutput) Region() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v ExistingLogGroup) *string { return v.Region }).(pulumi.StringPtrOutput)
+}
+
+type ExistingLogGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (ExistingLogGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**ExistingLogGroup)(nil)).Elem()
+}
+
+func (o ExistingLogGroupPtrOutput) ToExistingLogGroupPtrOutput() ExistingLogGroupPtrOutput {
+	return o
+}
+
+func (o ExistingLogGroupPtrOutput) ToExistingLogGroupPtrOutputWithContext(ctx context.Context) ExistingLogGroupPtrOutput {
+	return o
+}
+
+func (o ExistingLogGroupPtrOutput) Elem() ExistingLogGroupOutput {
+	return o.ApplyT(func(v *ExistingLogGroup) ExistingLogGroup {
+		if v != nil {
+			return *v
+		}
+		var ret ExistingLogGroup
+		return ret
+	}).(ExistingLogGroupOutput)
+}
+
+// Arn of the log group. Only one of [arn] or [name] can be specified.
+func (o ExistingLogGroupPtrOutput) Arn() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ExistingLogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Arn
+	}).(pulumi.StringPtrOutput)
+}
+
+// Name of the log group. Only one of [arn] or [name] can be specified.
+func (o ExistingLogGroupPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ExistingLogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
+}
+
+// Region of the log group. If not specified, the provider region will be used.
+func (o ExistingLogGroupPtrOutput) Region() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ExistingLogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Region
+	}).(pulumi.StringPtrOutput)
 }
 
 // The set of arguments for constructing a LogGroup resource.
@@ -145,6 +1465,220 @@ type LogGroup struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
+// LogGroupInput is an input type that accepts LogGroupArgs and LogGroupOutput values.
+// You can construct a concrete instance of `LogGroupInput` via:
+//
+//          LogGroupArgs{...}
+type LogGroupInput interface {
+	pulumi.Input
+
+	ToLogGroupOutput() LogGroupOutput
+	ToLogGroupOutputWithContext(context.Context) LogGroupOutput
+}
+
+// The set of arguments for constructing a LogGroup resource.
+type LogGroupArgs struct {
+	// The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
+	// AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
+	// permissions for the CMK whenever the encrypted data is requested.
+	KmsKeyId pulumi.StringPtrInput `pulumi:"kmsKeyId"`
+	// The name of the log group. If omitted, this provider will assign a random, unique name.
+	Name pulumi.StringPtrInput `pulumi:"name"`
+	// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+	NamePrefix pulumi.StringPtrInput `pulumi:"namePrefix"`
+	// Specifies the number of days
+	// you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+	// If you select 0, the events in the log group are always retained and never expire.
+	RetentionInDays pulumi.IntPtrInput `pulumi:"retentionInDays"`
+	// A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+}
+
+func (LogGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*LogGroup)(nil)).Elem()
+}
+
+func (i LogGroupArgs) ToLogGroupOutput() LogGroupOutput {
+	return i.ToLogGroupOutputWithContext(context.Background())
+}
+
+func (i LogGroupArgs) ToLogGroupOutputWithContext(ctx context.Context) LogGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LogGroupOutput)
+}
+
+func (i LogGroupArgs) ToLogGroupPtrOutput() LogGroupPtrOutput {
+	return i.ToLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i LogGroupArgs) ToLogGroupPtrOutputWithContext(ctx context.Context) LogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LogGroupOutput).ToLogGroupPtrOutputWithContext(ctx)
+}
+
+// LogGroupPtrInput is an input type that accepts LogGroupArgs, LogGroupPtr and LogGroupPtrOutput values.
+// You can construct a concrete instance of `LogGroupPtrInput` via:
+//
+//          LogGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type LogGroupPtrInput interface {
+	pulumi.Input
+
+	ToLogGroupPtrOutput() LogGroupPtrOutput
+	ToLogGroupPtrOutputWithContext(context.Context) LogGroupPtrOutput
+}
+
+type logGroupPtrType LogGroupArgs
+
+func LogGroupPtr(v *LogGroupArgs) LogGroupPtrInput {
+	return (*logGroupPtrType)(v)
+}
+
+func (*logGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**LogGroup)(nil)).Elem()
+}
+
+func (i *logGroupPtrType) ToLogGroupPtrOutput() LogGroupPtrOutput {
+	return i.ToLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *logGroupPtrType) ToLogGroupPtrOutputWithContext(ctx context.Context) LogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LogGroupPtrOutput)
+}
+
+// The set of arguments for constructing a LogGroup resource.
+type LogGroupOutput struct{ *pulumi.OutputState }
+
+func (LogGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*LogGroup)(nil)).Elem()
+}
+
+func (o LogGroupOutput) ToLogGroupOutput() LogGroupOutput {
+	return o
+}
+
+func (o LogGroupOutput) ToLogGroupOutputWithContext(ctx context.Context) LogGroupOutput {
+	return o
+}
+
+func (o LogGroupOutput) ToLogGroupPtrOutput() LogGroupPtrOutput {
+	return o.ToLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (o LogGroupOutput) ToLogGroupPtrOutputWithContext(ctx context.Context) LogGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v LogGroup) *LogGroup {
+		return &v
+	}).(LogGroupPtrOutput)
+}
+
+// The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
+// AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
+// permissions for the CMK whenever the encrypted data is requested.
+func (o LogGroupOutput) KmsKeyId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v LogGroup) *string { return v.KmsKeyId }).(pulumi.StringPtrOutput)
+}
+
+// The name of the log group. If omitted, this provider will assign a random, unique name.
+func (o LogGroupOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v LogGroup) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+func (o LogGroupOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v LogGroup) *string { return v.NamePrefix }).(pulumi.StringPtrOutput)
+}
+
+// Specifies the number of days
+// you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+// If you select 0, the events in the log group are always retained and never expire.
+func (o LogGroupOutput) RetentionInDays() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v LogGroup) *int { return v.RetentionInDays }).(pulumi.IntPtrOutput)
+}
+
+// A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o LogGroupOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v LogGroup) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+type LogGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (LogGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**LogGroup)(nil)).Elem()
+}
+
+func (o LogGroupPtrOutput) ToLogGroupPtrOutput() LogGroupPtrOutput {
+	return o
+}
+
+func (o LogGroupPtrOutput) ToLogGroupPtrOutputWithContext(ctx context.Context) LogGroupPtrOutput {
+	return o
+}
+
+func (o LogGroupPtrOutput) Elem() LogGroupOutput {
+	return o.ApplyT(func(v *LogGroup) LogGroup {
+		if v != nil {
+			return *v
+		}
+		var ret LogGroup
+		return ret
+	}).(LogGroupOutput)
+}
+
+// The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
+// AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
+// permissions for the CMK whenever the encrypted data is requested.
+func (o LogGroupPtrOutput) KmsKeyId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *LogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.KmsKeyId
+	}).(pulumi.StringPtrOutput)
+}
+
+// The name of the log group. If omitted, this provider will assign a random, unique name.
+func (o LogGroupPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *LogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+func (o LogGroupPtrOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *LogGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NamePrefix
+	}).(pulumi.StringPtrOutput)
+}
+
+// Specifies the number of days
+// you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+// If you select 0, the events in the log group are always retained and never expire.
+func (o LogGroupPtrOutput) RetentionInDays() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *LogGroup) *int {
+		if v == nil {
+			return nil
+		}
+		return v.RetentionInDays
+	}).(pulumi.IntPtrOutput)
+}
+
+// A map of tags to assign to the resource. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o LogGroupPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *LogGroup) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
 // Log group which is only created if enabled.
 type OptionalLogGroup struct {
 	// Arguments to use instead of the default values during creation.
@@ -155,12 +1689,331 @@ type OptionalLogGroup struct {
 	Existing *ExistingLogGroup `pulumi:"existing"`
 }
 
+// OptionalLogGroupInput is an input type that accepts OptionalLogGroupArgs and OptionalLogGroupOutput values.
+// You can construct a concrete instance of `OptionalLogGroupInput` via:
+//
+//          OptionalLogGroupArgs{...}
+type OptionalLogGroupInput interface {
+	pulumi.Input
+
+	ToOptionalLogGroupOutput() OptionalLogGroupOutput
+	ToOptionalLogGroupOutputWithContext(context.Context) OptionalLogGroupOutput
+}
+
+// Log group which is only created if enabled.
+type OptionalLogGroupArgs struct {
+	// Arguments to use instead of the default values during creation.
+	Args *LogGroupArgs `pulumi:"args"`
+	// Enable creation of the log group.
+	Enable *bool `pulumi:"enable"`
+	// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+	Existing *ExistingLogGroupArgs `pulumi:"existing"`
+}
+
+func (OptionalLogGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*OptionalLogGroup)(nil)).Elem()
+}
+
+func (i OptionalLogGroupArgs) ToOptionalLogGroupOutput() OptionalLogGroupOutput {
+	return i.ToOptionalLogGroupOutputWithContext(context.Background())
+}
+
+func (i OptionalLogGroupArgs) ToOptionalLogGroupOutputWithContext(ctx context.Context) OptionalLogGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(OptionalLogGroupOutput)
+}
+
+func (i OptionalLogGroupArgs) ToOptionalLogGroupPtrOutput() OptionalLogGroupPtrOutput {
+	return i.ToOptionalLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i OptionalLogGroupArgs) ToOptionalLogGroupPtrOutputWithContext(ctx context.Context) OptionalLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(OptionalLogGroupOutput).ToOptionalLogGroupPtrOutputWithContext(ctx)
+}
+
+// OptionalLogGroupPtrInput is an input type that accepts OptionalLogGroupArgs, OptionalLogGroupPtr and OptionalLogGroupPtrOutput values.
+// You can construct a concrete instance of `OptionalLogGroupPtrInput` via:
+//
+//          OptionalLogGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type OptionalLogGroupPtrInput interface {
+	pulumi.Input
+
+	ToOptionalLogGroupPtrOutput() OptionalLogGroupPtrOutput
+	ToOptionalLogGroupPtrOutputWithContext(context.Context) OptionalLogGroupPtrOutput
+}
+
+type optionalLogGroupPtrType OptionalLogGroupArgs
+
+func OptionalLogGroupPtr(v *OptionalLogGroupArgs) OptionalLogGroupPtrInput {
+	return (*optionalLogGroupPtrType)(v)
+}
+
+func (*optionalLogGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**OptionalLogGroup)(nil)).Elem()
+}
+
+func (i *optionalLogGroupPtrType) ToOptionalLogGroupPtrOutput() OptionalLogGroupPtrOutput {
+	return i.ToOptionalLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *optionalLogGroupPtrType) ToOptionalLogGroupPtrOutputWithContext(ctx context.Context) OptionalLogGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(OptionalLogGroupPtrOutput)
+}
+
+// Log group which is only created if enabled.
+type OptionalLogGroupOutput struct{ *pulumi.OutputState }
+
+func (OptionalLogGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*OptionalLogGroup)(nil)).Elem()
+}
+
+func (o OptionalLogGroupOutput) ToOptionalLogGroupOutput() OptionalLogGroupOutput {
+	return o
+}
+
+func (o OptionalLogGroupOutput) ToOptionalLogGroupOutputWithContext(ctx context.Context) OptionalLogGroupOutput {
+	return o
+}
+
+func (o OptionalLogGroupOutput) ToOptionalLogGroupPtrOutput() OptionalLogGroupPtrOutput {
+	return o.ToOptionalLogGroupPtrOutputWithContext(context.Background())
+}
+
+func (o OptionalLogGroupOutput) ToOptionalLogGroupPtrOutputWithContext(ctx context.Context) OptionalLogGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v OptionalLogGroup) *OptionalLogGroup {
+		return &v
+	}).(OptionalLogGroupPtrOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o OptionalLogGroupOutput) Args() LogGroupPtrOutput {
+	return o.ApplyT(func(v OptionalLogGroup) *LogGroup { return v.Args }).(LogGroupPtrOutput)
+}
+
+// Enable creation of the log group.
+func (o OptionalLogGroupOutput) Enable() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v OptionalLogGroup) *bool { return v.Enable }).(pulumi.BoolPtrOutput)
+}
+
+// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+func (o OptionalLogGroupOutput) Existing() ExistingLogGroupPtrOutput {
+	return o.ApplyT(func(v OptionalLogGroup) *ExistingLogGroup { return v.Existing }).(ExistingLogGroupPtrOutput)
+}
+
+type OptionalLogGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (OptionalLogGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**OptionalLogGroup)(nil)).Elem()
+}
+
+func (o OptionalLogGroupPtrOutput) ToOptionalLogGroupPtrOutput() OptionalLogGroupPtrOutput {
+	return o
+}
+
+func (o OptionalLogGroupPtrOutput) ToOptionalLogGroupPtrOutputWithContext(ctx context.Context) OptionalLogGroupPtrOutput {
+	return o
+}
+
+func (o OptionalLogGroupPtrOutput) Elem() OptionalLogGroupOutput {
+	return o.ApplyT(func(v *OptionalLogGroup) OptionalLogGroup {
+		if v != nil {
+			return *v
+		}
+		var ret OptionalLogGroup
+		return ret
+	}).(OptionalLogGroupOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o OptionalLogGroupPtrOutput) Args() LogGroupPtrOutput {
+	return o.ApplyT(func(v *OptionalLogGroup) *LogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(LogGroupPtrOutput)
+}
+
+// Enable creation of the log group.
+func (o OptionalLogGroupPtrOutput) Enable() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *OptionalLogGroup) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Enable
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Identity of an existing log group to use. Cannot be used in combination with `args` or `opts`.
+func (o OptionalLogGroupPtrOutput) Existing() ExistingLogGroupPtrOutput {
+	return o.ApplyT(func(v *OptionalLogGroup) *ExistingLogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.Existing
+	}).(ExistingLogGroupPtrOutput)
+}
+
 // Bucket with default setup.
 type RequiredBucket struct {
 	// Arguments to use instead of the default values during creation.
 	Args *Bucket `pulumi:"args"`
 	// Identity of an existing bucket to use. Cannot be used in combination with `args`.
 	Existing *ExistingBucket `pulumi:"existing"`
+}
+
+// RequiredBucketInput is an input type that accepts RequiredBucketArgs and RequiredBucketOutput values.
+// You can construct a concrete instance of `RequiredBucketInput` via:
+//
+//          RequiredBucketArgs{...}
+type RequiredBucketInput interface {
+	pulumi.Input
+
+	ToRequiredBucketOutput() RequiredBucketOutput
+	ToRequiredBucketOutputWithContext(context.Context) RequiredBucketOutput
+}
+
+// Bucket with default setup.
+type RequiredBucketArgs struct {
+	// Arguments to use instead of the default values during creation.
+	Args *BucketArgs `pulumi:"args"`
+	// Identity of an existing bucket to use. Cannot be used in combination with `args`.
+	Existing *ExistingBucketArgs `pulumi:"existing"`
+}
+
+func (RequiredBucketArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*RequiredBucket)(nil)).Elem()
+}
+
+func (i RequiredBucketArgs) ToRequiredBucketOutput() RequiredBucketOutput {
+	return i.ToRequiredBucketOutputWithContext(context.Background())
+}
+
+func (i RequiredBucketArgs) ToRequiredBucketOutputWithContext(ctx context.Context) RequiredBucketOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RequiredBucketOutput)
+}
+
+func (i RequiredBucketArgs) ToRequiredBucketPtrOutput() RequiredBucketPtrOutput {
+	return i.ToRequiredBucketPtrOutputWithContext(context.Background())
+}
+
+func (i RequiredBucketArgs) ToRequiredBucketPtrOutputWithContext(ctx context.Context) RequiredBucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RequiredBucketOutput).ToRequiredBucketPtrOutputWithContext(ctx)
+}
+
+// RequiredBucketPtrInput is an input type that accepts RequiredBucketArgs, RequiredBucketPtr and RequiredBucketPtrOutput values.
+// You can construct a concrete instance of `RequiredBucketPtrInput` via:
+//
+//          RequiredBucketArgs{...}
+//
+//  or:
+//
+//          nil
+type RequiredBucketPtrInput interface {
+	pulumi.Input
+
+	ToRequiredBucketPtrOutput() RequiredBucketPtrOutput
+	ToRequiredBucketPtrOutputWithContext(context.Context) RequiredBucketPtrOutput
+}
+
+type requiredBucketPtrType RequiredBucketArgs
+
+func RequiredBucketPtr(v *RequiredBucketArgs) RequiredBucketPtrInput {
+	return (*requiredBucketPtrType)(v)
+}
+
+func (*requiredBucketPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**RequiredBucket)(nil)).Elem()
+}
+
+func (i *requiredBucketPtrType) ToRequiredBucketPtrOutput() RequiredBucketPtrOutput {
+	return i.ToRequiredBucketPtrOutputWithContext(context.Background())
+}
+
+func (i *requiredBucketPtrType) ToRequiredBucketPtrOutputWithContext(ctx context.Context) RequiredBucketPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RequiredBucketPtrOutput)
+}
+
+// Bucket with default setup.
+type RequiredBucketOutput struct{ *pulumi.OutputState }
+
+func (RequiredBucketOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*RequiredBucket)(nil)).Elem()
+}
+
+func (o RequiredBucketOutput) ToRequiredBucketOutput() RequiredBucketOutput {
+	return o
+}
+
+func (o RequiredBucketOutput) ToRequiredBucketOutputWithContext(ctx context.Context) RequiredBucketOutput {
+	return o
+}
+
+func (o RequiredBucketOutput) ToRequiredBucketPtrOutput() RequiredBucketPtrOutput {
+	return o.ToRequiredBucketPtrOutputWithContext(context.Background())
+}
+
+func (o RequiredBucketOutput) ToRequiredBucketPtrOutputWithContext(ctx context.Context) RequiredBucketPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v RequiredBucket) *RequiredBucket {
+		return &v
+	}).(RequiredBucketPtrOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o RequiredBucketOutput) Args() BucketPtrOutput {
+	return o.ApplyT(func(v RequiredBucket) *Bucket { return v.Args }).(BucketPtrOutput)
+}
+
+// Identity of an existing bucket to use. Cannot be used in combination with `args`.
+func (o RequiredBucketOutput) Existing() ExistingBucketPtrOutput {
+	return o.ApplyT(func(v RequiredBucket) *ExistingBucket { return v.Existing }).(ExistingBucketPtrOutput)
+}
+
+type RequiredBucketPtrOutput struct{ *pulumi.OutputState }
+
+func (RequiredBucketPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**RequiredBucket)(nil)).Elem()
+}
+
+func (o RequiredBucketPtrOutput) ToRequiredBucketPtrOutput() RequiredBucketPtrOutput {
+	return o
+}
+
+func (o RequiredBucketPtrOutput) ToRequiredBucketPtrOutputWithContext(ctx context.Context) RequiredBucketPtrOutput {
+	return o
+}
+
+func (o RequiredBucketPtrOutput) Elem() RequiredBucketOutput {
+	return o.ApplyT(func(v *RequiredBucket) RequiredBucket {
+		if v != nil {
+			return *v
+		}
+		var ret RequiredBucket
+		return ret
+	}).(RequiredBucketOutput)
+}
+
+// Arguments to use instead of the default values during creation.
+func (o RequiredBucketPtrOutput) Args() BucketPtrOutput {
+	return o.ApplyT(func(v *RequiredBucket) *Bucket {
+		if v == nil {
+			return nil
+		}
+		return v.Args
+	}).(BucketPtrOutput)
+}
+
+// Identity of an existing bucket to use. Cannot be used in combination with `args`.
+func (o RequiredBucketPtrOutput) Existing() ExistingBucketPtrOutput {
+	return o.ApplyT(func(v *RequiredBucket) *ExistingBucket {
+		if v == nil {
+			return nil
+		}
+		return v.Existing
+	}).(ExistingBucketPtrOutput)
 }
 
 // Log group with default setup.
@@ -197,6 +2050,310 @@ type RoleWithPolicy struct {
 	Tags map[string]string `pulumi:"tags"`
 }
 
+// RoleWithPolicyInput is an input type that accepts RoleWithPolicyArgs and RoleWithPolicyOutput values.
+// You can construct a concrete instance of `RoleWithPolicyInput` via:
+//
+//          RoleWithPolicyArgs{...}
+type RoleWithPolicyInput interface {
+	pulumi.Input
+
+	ToRoleWithPolicyOutput() RoleWithPolicyOutput
+	ToRoleWithPolicyOutputWithContext(context.Context) RoleWithPolicyOutput
+}
+
+// The set of arguments for constructing a Role resource and Policy attachments.
+type RoleWithPolicyArgs struct {
+	// Description of the role.
+	Description pulumi.StringPtrInput `pulumi:"description"`
+	// Whether to force detaching any policies the role has before destroying it. Defaults to `false`.
+	ForceDetachPolicies pulumi.BoolPtrInput `pulumi:"forceDetachPolicies"`
+	// Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, this provider will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause the provider to remove _all_ inline policies added out of band on `apply`.
+	InlinePolicies iam.RoleInlinePolicyArrayInput `pulumi:"inlinePolicies"`
+	// Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, this provider will ignore policy attachments to this resource. When configured, the provider will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., `managed_policy_arns = []`) will cause the provider to remove _all_ managed policy attachments.
+	ManagedPolicyArns pulumi.StringArrayInput `pulumi:"managedPolicyArns"`
+	// Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+	MaxSessionDuration pulumi.IntPtrInput `pulumi:"maxSessionDuration"`
+	// Name of the role policy.
+	Name pulumi.StringPtrInput `pulumi:"name"`
+	// Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
+	NamePrefix pulumi.StringPtrInput `pulumi:"namePrefix"`
+	// Path to the role. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
+	Path pulumi.StringPtrInput `pulumi:"path"`
+	// ARN of the policy that is used to set the permissions boundary for the role.
+	PermissionsBoundary pulumi.StringPtrInput `pulumi:"permissionsBoundary"`
+	// ARNs of the policies to attach to the created role.
+	PolicyArns []string `pulumi:"policyArns"`
+	// Key-value mapping of tags for the IAM role. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+}
+
+func (RoleWithPolicyArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*RoleWithPolicy)(nil)).Elem()
+}
+
+func (i RoleWithPolicyArgs) ToRoleWithPolicyOutput() RoleWithPolicyOutput {
+	return i.ToRoleWithPolicyOutputWithContext(context.Background())
+}
+
+func (i RoleWithPolicyArgs) ToRoleWithPolicyOutputWithContext(ctx context.Context) RoleWithPolicyOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RoleWithPolicyOutput)
+}
+
+func (i RoleWithPolicyArgs) ToRoleWithPolicyPtrOutput() RoleWithPolicyPtrOutput {
+	return i.ToRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (i RoleWithPolicyArgs) ToRoleWithPolicyPtrOutputWithContext(ctx context.Context) RoleWithPolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RoleWithPolicyOutput).ToRoleWithPolicyPtrOutputWithContext(ctx)
+}
+
+// RoleWithPolicyPtrInput is an input type that accepts RoleWithPolicyArgs, RoleWithPolicyPtr and RoleWithPolicyPtrOutput values.
+// You can construct a concrete instance of `RoleWithPolicyPtrInput` via:
+//
+//          RoleWithPolicyArgs{...}
+//
+//  or:
+//
+//          nil
+type RoleWithPolicyPtrInput interface {
+	pulumi.Input
+
+	ToRoleWithPolicyPtrOutput() RoleWithPolicyPtrOutput
+	ToRoleWithPolicyPtrOutputWithContext(context.Context) RoleWithPolicyPtrOutput
+}
+
+type roleWithPolicyPtrType RoleWithPolicyArgs
+
+func RoleWithPolicyPtr(v *RoleWithPolicyArgs) RoleWithPolicyPtrInput {
+	return (*roleWithPolicyPtrType)(v)
+}
+
+func (*roleWithPolicyPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**RoleWithPolicy)(nil)).Elem()
+}
+
+func (i *roleWithPolicyPtrType) ToRoleWithPolicyPtrOutput() RoleWithPolicyPtrOutput {
+	return i.ToRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (i *roleWithPolicyPtrType) ToRoleWithPolicyPtrOutputWithContext(ctx context.Context) RoleWithPolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RoleWithPolicyPtrOutput)
+}
+
+// The set of arguments for constructing a Role resource and Policy attachments.
+type RoleWithPolicyOutput struct{ *pulumi.OutputState }
+
+func (RoleWithPolicyOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*RoleWithPolicy)(nil)).Elem()
+}
+
+func (o RoleWithPolicyOutput) ToRoleWithPolicyOutput() RoleWithPolicyOutput {
+	return o
+}
+
+func (o RoleWithPolicyOutput) ToRoleWithPolicyOutputWithContext(ctx context.Context) RoleWithPolicyOutput {
+	return o
+}
+
+func (o RoleWithPolicyOutput) ToRoleWithPolicyPtrOutput() RoleWithPolicyPtrOutput {
+	return o.ToRoleWithPolicyPtrOutputWithContext(context.Background())
+}
+
+func (o RoleWithPolicyOutput) ToRoleWithPolicyPtrOutputWithContext(ctx context.Context) RoleWithPolicyPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v RoleWithPolicy) *RoleWithPolicy {
+		return &v
+	}).(RoleWithPolicyPtrOutput)
+}
+
+// Description of the role.
+func (o RoleWithPolicyOutput) Description() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *string { return v.Description }).(pulumi.StringPtrOutput)
+}
+
+// Whether to force detaching any policies the role has before destroying it. Defaults to `false`.
+func (o RoleWithPolicyOutput) ForceDetachPolicies() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *bool { return v.ForceDetachPolicies }).(pulumi.BoolPtrOutput)
+}
+
+// Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, this provider will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause the provider to remove _all_ inline policies added out of band on `apply`.
+func (o RoleWithPolicyOutput) InlinePolicies() iam.RoleInlinePolicyArrayOutput {
+	return o.ApplyT(func(v RoleWithPolicy) []iam.RoleInlinePolicy { return v.InlinePolicies }).(iam.RoleInlinePolicyArrayOutput)
+}
+
+// Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, this provider will ignore policy attachments to this resource. When configured, the provider will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., `managed_policy_arns = []`) will cause the provider to remove _all_ managed policy attachments.
+func (o RoleWithPolicyOutput) ManagedPolicyArns() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v RoleWithPolicy) []string { return v.ManagedPolicyArns }).(pulumi.StringArrayOutput)
+}
+
+// Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+func (o RoleWithPolicyOutput) MaxSessionDuration() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *int { return v.MaxSessionDuration }).(pulumi.IntPtrOutput)
+}
+
+// Name of the role policy.
+func (o RoleWithPolicyOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
+func (o RoleWithPolicyOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *string { return v.NamePrefix }).(pulumi.StringPtrOutput)
+}
+
+// Path to the role. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
+func (o RoleWithPolicyOutput) Path() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *string { return v.Path }).(pulumi.StringPtrOutput)
+}
+
+// ARN of the policy that is used to set the permissions boundary for the role.
+func (o RoleWithPolicyOutput) PermissionsBoundary() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RoleWithPolicy) *string { return v.PermissionsBoundary }).(pulumi.StringPtrOutput)
+}
+
+// ARNs of the policies to attach to the created role.
+func (o RoleWithPolicyOutput) PolicyArns() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v RoleWithPolicy) []string { return v.PolicyArns }).(pulumi.StringArrayOutput)
+}
+
+// Key-value mapping of tags for the IAM role. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o RoleWithPolicyOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v RoleWithPolicy) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+type RoleWithPolicyPtrOutput struct{ *pulumi.OutputState }
+
+func (RoleWithPolicyPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**RoleWithPolicy)(nil)).Elem()
+}
+
+func (o RoleWithPolicyPtrOutput) ToRoleWithPolicyPtrOutput() RoleWithPolicyPtrOutput {
+	return o
+}
+
+func (o RoleWithPolicyPtrOutput) ToRoleWithPolicyPtrOutputWithContext(ctx context.Context) RoleWithPolicyPtrOutput {
+	return o
+}
+
+func (o RoleWithPolicyPtrOutput) Elem() RoleWithPolicyOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) RoleWithPolicy {
+		if v != nil {
+			return *v
+		}
+		var ret RoleWithPolicy
+		return ret
+	}).(RoleWithPolicyOutput)
+}
+
+// Description of the role.
+func (o RoleWithPolicyPtrOutput) Description() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Description
+	}).(pulumi.StringPtrOutput)
+}
+
+// Whether to force detaching any policies the role has before destroying it. Defaults to `false`.
+func (o RoleWithPolicyPtrOutput) ForceDetachPolicies() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.ForceDetachPolicies
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, this provider will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause the provider to remove _all_ inline policies added out of band on `apply`.
+func (o RoleWithPolicyPtrOutput) InlinePolicies() iam.RoleInlinePolicyArrayOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) []iam.RoleInlinePolicy {
+		if v == nil {
+			return nil
+		}
+		return v.InlinePolicies
+	}).(iam.RoleInlinePolicyArrayOutput)
+}
+
+// Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, this provider will ignore policy attachments to this resource. When configured, the provider will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., `managed_policy_arns = []`) will cause the provider to remove _all_ managed policy attachments.
+func (o RoleWithPolicyPtrOutput) ManagedPolicyArns() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) []string {
+		if v == nil {
+			return nil
+		}
+		return v.ManagedPolicyArns
+	}).(pulumi.StringArrayOutput)
+}
+
+// Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+func (o RoleWithPolicyPtrOutput) MaxSessionDuration() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *int {
+		if v == nil {
+			return nil
+		}
+		return v.MaxSessionDuration
+	}).(pulumi.IntPtrOutput)
+}
+
+// Name of the role policy.
+func (o RoleWithPolicyPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
+func (o RoleWithPolicyPtrOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NamePrefix
+	}).(pulumi.StringPtrOutput)
+}
+
+// Path to the role. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
+func (o RoleWithPolicyPtrOutput) Path() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Path
+	}).(pulumi.StringPtrOutput)
+}
+
+// ARN of the policy that is used to set the permissions boundary for the role.
+func (o RoleWithPolicyPtrOutput) PermissionsBoundary() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) *string {
+		if v == nil {
+			return nil
+		}
+		return v.PermissionsBoundary
+	}).(pulumi.StringPtrOutput)
+}
+
+// ARNs of the policies to attach to the created role.
+func (o RoleWithPolicyPtrOutput) PolicyArns() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) []string {
+		if v == nil {
+			return nil
+		}
+		return v.PolicyArns
+	}).(pulumi.StringArrayOutput)
+}
+
+// Key-value mapping of tags for the IAM role. .If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+func (o RoleWithPolicyPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *RoleWithPolicy) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
 // The set of arguments for constructing a Security Group resource.
 type SecurityGroup struct {
 	// Description of this egress rule.
@@ -229,5 +2386,314 @@ func (val *SecurityGroup) Defaults() *SecurityGroup {
 	}
 	return &tmp
 }
+
+// SecurityGroupInput is an input type that accepts SecurityGroupArgs and SecurityGroupOutput values.
+// You can construct a concrete instance of `SecurityGroupInput` via:
+//
+//          SecurityGroupArgs{...}
+type SecurityGroupInput interface {
+	pulumi.Input
+
+	ToSecurityGroupOutput() SecurityGroupOutput
+	ToSecurityGroupOutputWithContext(context.Context) SecurityGroupOutput
+}
+
+// The set of arguments for constructing a Security Group resource.
+type SecurityGroupArgs struct {
+	// Description of this egress rule.
+	Description pulumi.StringPtrInput `pulumi:"description"`
+	// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below.
+	Egress ec2.SecurityGroupEgressArrayInput `pulumi:"egress"`
+	// Configuration block for egress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below.
+	Ingress ec2.SecurityGroupIngressArrayInput `pulumi:"ingress"`
+	// Name of the security group. If omitted, this provider will assign a random, unique name.
+	Name pulumi.StringPtrInput `pulumi:"name"`
+	// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+	NamePrefix pulumi.StringPtrInput `pulumi:"namePrefix"`
+	// Instruct this provider to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+	RevokeRulesOnDelete pulumi.BoolPtrInput `pulumi:"revokeRulesOnDelete"`
+	// Map of tags to assign to the resource.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+	// VPC ID.
+	VpcId pulumi.StringPtrInput `pulumi:"vpcId"`
+}
+
+// Defaults sets the appropriate defaults for SecurityGroupArgs
+func (val *SecurityGroupArgs) Defaults() *SecurityGroupArgs {
+	if val == nil {
+		return nil
+	}
+	tmp := *val
+	if isZero(tmp.Description) {
+		tmp.Description = pulumi.StringPtr("Managed by Pulumi")
+	}
+	return &tmp
+}
+func (SecurityGroupArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*SecurityGroup)(nil)).Elem()
+}
+
+func (i SecurityGroupArgs) ToSecurityGroupOutput() SecurityGroupOutput {
+	return i.ToSecurityGroupOutputWithContext(context.Background())
+}
+
+func (i SecurityGroupArgs) ToSecurityGroupOutputWithContext(ctx context.Context) SecurityGroupOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(SecurityGroupOutput)
+}
+
+func (i SecurityGroupArgs) ToSecurityGroupPtrOutput() SecurityGroupPtrOutput {
+	return i.ToSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (i SecurityGroupArgs) ToSecurityGroupPtrOutputWithContext(ctx context.Context) SecurityGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(SecurityGroupOutput).ToSecurityGroupPtrOutputWithContext(ctx)
+}
+
+// SecurityGroupPtrInput is an input type that accepts SecurityGroupArgs, SecurityGroupPtr and SecurityGroupPtrOutput values.
+// You can construct a concrete instance of `SecurityGroupPtrInput` via:
+//
+//          SecurityGroupArgs{...}
+//
+//  or:
+//
+//          nil
+type SecurityGroupPtrInput interface {
+	pulumi.Input
+
+	ToSecurityGroupPtrOutput() SecurityGroupPtrOutput
+	ToSecurityGroupPtrOutputWithContext(context.Context) SecurityGroupPtrOutput
+}
+
+type securityGroupPtrType SecurityGroupArgs
+
+func SecurityGroupPtr(v *SecurityGroupArgs) SecurityGroupPtrInput {
+	return (*securityGroupPtrType)(v)
+}
+
+func (*securityGroupPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**SecurityGroup)(nil)).Elem()
+}
+
+func (i *securityGroupPtrType) ToSecurityGroupPtrOutput() SecurityGroupPtrOutput {
+	return i.ToSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (i *securityGroupPtrType) ToSecurityGroupPtrOutputWithContext(ctx context.Context) SecurityGroupPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(SecurityGroupPtrOutput)
+}
+
+// The set of arguments for constructing a Security Group resource.
+type SecurityGroupOutput struct{ *pulumi.OutputState }
+
+func (SecurityGroupOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*SecurityGroup)(nil)).Elem()
+}
+
+func (o SecurityGroupOutput) ToSecurityGroupOutput() SecurityGroupOutput {
+	return o
+}
+
+func (o SecurityGroupOutput) ToSecurityGroupOutputWithContext(ctx context.Context) SecurityGroupOutput {
+	return o
+}
+
+func (o SecurityGroupOutput) ToSecurityGroupPtrOutput() SecurityGroupPtrOutput {
+	return o.ToSecurityGroupPtrOutputWithContext(context.Background())
+}
+
+func (o SecurityGroupOutput) ToSecurityGroupPtrOutputWithContext(ctx context.Context) SecurityGroupPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v SecurityGroup) *SecurityGroup {
+		return &v
+	}).(SecurityGroupPtrOutput)
+}
+
+// Description of this egress rule.
+func (o SecurityGroupOutput) Description() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SecurityGroup) *string { return v.Description }).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below.
+func (o SecurityGroupOutput) Egress() ec2.SecurityGroupEgressArrayOutput {
+	return o.ApplyT(func(v SecurityGroup) []ec2.SecurityGroupEgress { return v.Egress }).(ec2.SecurityGroupEgressArrayOutput)
+}
+
+// Configuration block for egress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below.
+func (o SecurityGroupOutput) Ingress() ec2.SecurityGroupIngressArrayOutput {
+	return o.ApplyT(func(v SecurityGroup) []ec2.SecurityGroupIngress { return v.Ingress }).(ec2.SecurityGroupIngressArrayOutput)
+}
+
+// Name of the security group. If omitted, this provider will assign a random, unique name.
+func (o SecurityGroupOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SecurityGroup) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+func (o SecurityGroupOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SecurityGroup) *string { return v.NamePrefix }).(pulumi.StringPtrOutput)
+}
+
+// Instruct this provider to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+func (o SecurityGroupOutput) RevokeRulesOnDelete() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v SecurityGroup) *bool { return v.RevokeRulesOnDelete }).(pulumi.BoolPtrOutput)
+}
+
+// Map of tags to assign to the resource.
+func (o SecurityGroupOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v SecurityGroup) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+// VPC ID.
+func (o SecurityGroupOutput) VpcId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SecurityGroup) *string { return v.VpcId }).(pulumi.StringPtrOutput)
+}
+
+type SecurityGroupPtrOutput struct{ *pulumi.OutputState }
+
+func (SecurityGroupPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**SecurityGroup)(nil)).Elem()
+}
+
+func (o SecurityGroupPtrOutput) ToSecurityGroupPtrOutput() SecurityGroupPtrOutput {
+	return o
+}
+
+func (o SecurityGroupPtrOutput) ToSecurityGroupPtrOutputWithContext(ctx context.Context) SecurityGroupPtrOutput {
+	return o
+}
+
+func (o SecurityGroupPtrOutput) Elem() SecurityGroupOutput {
+	return o.ApplyT(func(v *SecurityGroup) SecurityGroup {
+		if v != nil {
+			return *v
+		}
+		var ret SecurityGroup
+		return ret
+	}).(SecurityGroupOutput)
+}
+
+// Description of this egress rule.
+func (o SecurityGroupPtrOutput) Description() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SecurityGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Description
+	}).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below.
+func (o SecurityGroupPtrOutput) Egress() ec2.SecurityGroupEgressArrayOutput {
+	return o.ApplyT(func(v *SecurityGroup) []ec2.SecurityGroupEgress {
+		if v == nil {
+			return nil
+		}
+		return v.Egress
+	}).(ec2.SecurityGroupEgressArrayOutput)
+}
+
+// Configuration block for egress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below.
+func (o SecurityGroupPtrOutput) Ingress() ec2.SecurityGroupIngressArrayOutput {
+	return o.ApplyT(func(v *SecurityGroup) []ec2.SecurityGroupIngress {
+		if v == nil {
+			return nil
+		}
+		return v.Ingress
+	}).(ec2.SecurityGroupIngressArrayOutput)
+}
+
+// Name of the security group. If omitted, this provider will assign a random, unique name.
+func (o SecurityGroupPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SecurityGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
+}
+
+// Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+func (o SecurityGroupPtrOutput) NamePrefix() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SecurityGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NamePrefix
+	}).(pulumi.StringPtrOutput)
+}
+
+// Instruct this provider to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+func (o SecurityGroupPtrOutput) RevokeRulesOnDelete() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *SecurityGroup) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.RevokeRulesOnDelete
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Map of tags to assign to the resource.
+func (o SecurityGroupPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *SecurityGroup) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
+// VPC ID.
+func (o SecurityGroupPtrOutput) VpcId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *SecurityGroup) *string {
+		if v == nil {
+			return nil
+		}
+		return v.VpcId
+	}).(pulumi.StringPtrOutput)
+}
+
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*BucketInput)(nil)).Elem(), BucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*BucketPtrInput)(nil)).Elem(), BucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultLogGroupInput)(nil)).Elem(), DefaultLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultLogGroupPtrInput)(nil)).Elem(), DefaultLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultRoleWithPolicyInput)(nil)).Elem(), DefaultRoleWithPolicyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultRoleWithPolicyPtrInput)(nil)).Elem(), DefaultRoleWithPolicyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultSecurityGroupInput)(nil)).Elem(), DefaultSecurityGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*DefaultSecurityGroupPtrInput)(nil)).Elem(), DefaultSecurityGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ExistingBucketInput)(nil)).Elem(), ExistingBucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ExistingBucketPtrInput)(nil)).Elem(), ExistingBucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ExistingLogGroupInput)(nil)).Elem(), ExistingLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*ExistingLogGroupPtrInput)(nil)).Elem(), ExistingLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LogGroupInput)(nil)).Elem(), LogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LogGroupPtrInput)(nil)).Elem(), LogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*OptionalLogGroupInput)(nil)).Elem(), OptionalLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*OptionalLogGroupPtrInput)(nil)).Elem(), OptionalLogGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RequiredBucketInput)(nil)).Elem(), RequiredBucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RequiredBucketPtrInput)(nil)).Elem(), RequiredBucketArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleWithPolicyInput)(nil)).Elem(), RoleWithPolicyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*RoleWithPolicyPtrInput)(nil)).Elem(), RoleWithPolicyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecurityGroupInput)(nil)).Elem(), SecurityGroupArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SecurityGroupPtrInput)(nil)).Elem(), SecurityGroupArgs{})
+	pulumi.RegisterOutputType(BucketOutput{})
+	pulumi.RegisterOutputType(BucketPtrOutput{})
+	pulumi.RegisterOutputType(DefaultLogGroupOutput{})
+	pulumi.RegisterOutputType(DefaultLogGroupPtrOutput{})
+	pulumi.RegisterOutputType(DefaultRoleWithPolicyOutput{})
+	pulumi.RegisterOutputType(DefaultRoleWithPolicyPtrOutput{})
+	pulumi.RegisterOutputType(DefaultSecurityGroupOutput{})
+	pulumi.RegisterOutputType(DefaultSecurityGroupPtrOutput{})
+	pulumi.RegisterOutputType(ExistingBucketOutput{})
+	pulumi.RegisterOutputType(ExistingBucketPtrOutput{})
+	pulumi.RegisterOutputType(ExistingLogGroupOutput{})
+	pulumi.RegisterOutputType(ExistingLogGroupPtrOutput{})
+	pulumi.RegisterOutputType(LogGroupOutput{})
+	pulumi.RegisterOutputType(LogGroupPtrOutput{})
+	pulumi.RegisterOutputType(OptionalLogGroupOutput{})
+	pulumi.RegisterOutputType(OptionalLogGroupPtrOutput{})
+	pulumi.RegisterOutputType(RequiredBucketOutput{})
+	pulumi.RegisterOutputType(RequiredBucketPtrOutput{})
+	pulumi.RegisterOutputType(RoleWithPolicyOutput{})
+	pulumi.RegisterOutputType(RoleWithPolicyPtrOutput{})
+	pulumi.RegisterOutputType(SecurityGroupOutput{})
+	pulumi.RegisterOutputType(SecurityGroupPtrOutput{})
 }

--- a/sdk/go/awsx/cloudtrail/trail.go
+++ b/sdk/go/awsx/cloudtrail/trail.go
@@ -78,7 +78,7 @@ type TrailArgs struct {
 	// Specifies an advanced event selector for enabling data event logging. Fields documented below. Conflicts with `event_selector`.
 	AdvancedEventSelectors cloudtrail.TrailAdvancedEventSelectorArrayInput
 	// Log group to which CloudTrail logs will be delivered.
-	CloudWatchLogsGroup *awsx.OptionalLogGroup
+	CloudWatchLogsGroup *awsx.OptionalLogGroupArgs
 	// Whether log file integrity validation is enabled. Defaults to `false`.
 	EnableLogFileValidation pulumi.BoolPtrInput
 	// Enables logging for the trail. Defaults to `true`. Setting this to `false` will pause logging.
@@ -98,7 +98,7 @@ type TrailArgs struct {
 	// Specifies the name of the advanced event selector.
 	Name pulumi.StringPtrInput
 	// S3 bucket designated for publishing log files.
-	S3Bucket *awsx.RequiredBucket
+	S3Bucket *awsx.RequiredBucketArgs
 	// S3 key prefix that follows the name of the bucket you have designated for log file delivery.
 	S3KeyPrefix pulumi.StringPtrInput
 	// Name of the Amazon SNS topic defined for notification of log file delivery.
@@ -192,6 +192,21 @@ func (o TrailOutput) ToTrailOutput() TrailOutput {
 
 func (o TrailOutput) ToTrailOutputWithContext(ctx context.Context) TrailOutput {
 	return o
+}
+
+// The managed S3 Bucket where the Trail will place its logs.
+func (o TrailOutput) Bucket() s3.BucketOutput {
+	return o.ApplyT(func(v *Trail) s3.BucketOutput { return v.Bucket }).(s3.BucketOutput)
+}
+
+// The managed Cloudwatch Log Group.
+func (o TrailOutput) LogGroup() cloudwatch.LogGroupOutput {
+	return o.ApplyT(func(v *Trail) cloudwatch.LogGroupOutput { return v.LogGroup }).(cloudwatch.LogGroupOutput)
+}
+
+// The CloudTrail Trail.
+func (o TrailOutput) Trail() cloudtrail.TrailOutput {
+	return o.ApplyT(func(v *Trail) cloudtrail.TrailOutput { return v.Trail }).(cloudtrail.TrailOutput)
 }
 
 type TrailArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ec2/defaultVpc.go
+++ b/sdk/go/awsx/ec2/defaultVpc.go
@@ -129,6 +129,19 @@ func (o DefaultVpcOutput) ToDefaultVpcOutputWithContext(ctx context.Context) Def
 	return o
 }
 
+func (o DefaultVpcOutput) PrivateSubnetIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *DefaultVpc) pulumi.StringArrayOutput { return v.PrivateSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+func (o DefaultVpcOutput) PublicSubnetIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *DefaultVpc) pulumi.StringArrayOutput { return v.PublicSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+// The VPC ID for the default VPC
+func (o DefaultVpcOutput) VpcId() pulumi.StringOutput {
+	return o.ApplyT(func(v *DefaultVpc) pulumi.StringOutput { return v.VpcId }).(pulumi.StringOutput)
+}
+
 type DefaultVpcArrayOutput struct{ *pulumi.OutputState }
 
 func (DefaultVpcArrayOutput) ElementType() reflect.Type {

--- a/sdk/go/awsx/ec2/pulumiEnums.go
+++ b/sdk/go/awsx/ec2/pulumiEnums.go
@@ -3,6 +3,13 @@
 
 package ec2
 
+import (
+	"context"
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
 // A strategy for creating NAT Gateways for private subnets within a VPC.
 type NatGatewayStrategy string
 
@@ -14,6 +21,163 @@ const (
 	// Create a NAT Gateway in each availability zone. This is the recommended configuration for production infrastructure.
 	NatGatewayStrategyOnePerAz = NatGatewayStrategy("OnePerAz")
 )
+
+func (NatGatewayStrategy) ElementType() reflect.Type {
+	return reflect.TypeOf((*NatGatewayStrategy)(nil)).Elem()
+}
+
+func (e NatGatewayStrategy) ToNatGatewayStrategyOutput() NatGatewayStrategyOutput {
+	return pulumi.ToOutput(e).(NatGatewayStrategyOutput)
+}
+
+func (e NatGatewayStrategy) ToNatGatewayStrategyOutputWithContext(ctx context.Context) NatGatewayStrategyOutput {
+	return pulumi.ToOutputWithContext(ctx, e).(NatGatewayStrategyOutput)
+}
+
+func (e NatGatewayStrategy) ToNatGatewayStrategyPtrOutput() NatGatewayStrategyPtrOutput {
+	return e.ToNatGatewayStrategyPtrOutputWithContext(context.Background())
+}
+
+func (e NatGatewayStrategy) ToNatGatewayStrategyPtrOutputWithContext(ctx context.Context) NatGatewayStrategyPtrOutput {
+	return NatGatewayStrategy(e).ToNatGatewayStrategyOutputWithContext(ctx).ToNatGatewayStrategyPtrOutputWithContext(ctx)
+}
+
+func (e NatGatewayStrategy) ToStringOutput() pulumi.StringOutput {
+	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e NatGatewayStrategy) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e NatGatewayStrategy) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
+}
+
+func (e NatGatewayStrategy) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
+}
+
+type NatGatewayStrategyOutput struct{ *pulumi.OutputState }
+
+func (NatGatewayStrategyOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*NatGatewayStrategy)(nil)).Elem()
+}
+
+func (o NatGatewayStrategyOutput) ToNatGatewayStrategyOutput() NatGatewayStrategyOutput {
+	return o
+}
+
+func (o NatGatewayStrategyOutput) ToNatGatewayStrategyOutputWithContext(ctx context.Context) NatGatewayStrategyOutput {
+	return o
+}
+
+func (o NatGatewayStrategyOutput) ToNatGatewayStrategyPtrOutput() NatGatewayStrategyPtrOutput {
+	return o.ToNatGatewayStrategyPtrOutputWithContext(context.Background())
+}
+
+func (o NatGatewayStrategyOutput) ToNatGatewayStrategyPtrOutputWithContext(ctx context.Context) NatGatewayStrategyPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v NatGatewayStrategy) *NatGatewayStrategy {
+		return &v
+	}).(NatGatewayStrategyPtrOutput)
+}
+
+func (o NatGatewayStrategyOutput) ToStringOutput() pulumi.StringOutput {
+	return o.ToStringOutputWithContext(context.Background())
+}
+
+func (o NatGatewayStrategyOutput) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e NatGatewayStrategy) string {
+		return string(e)
+	}).(pulumi.StringOutput)
+}
+
+func (o NatGatewayStrategyOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return o.ToStringPtrOutputWithContext(context.Background())
+}
+
+func (o NatGatewayStrategyOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e NatGatewayStrategy) *string {
+		v := string(e)
+		return &v
+	}).(pulumi.StringPtrOutput)
+}
+
+type NatGatewayStrategyPtrOutput struct{ *pulumi.OutputState }
+
+func (NatGatewayStrategyPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**NatGatewayStrategy)(nil)).Elem()
+}
+
+func (o NatGatewayStrategyPtrOutput) ToNatGatewayStrategyPtrOutput() NatGatewayStrategyPtrOutput {
+	return o
+}
+
+func (o NatGatewayStrategyPtrOutput) ToNatGatewayStrategyPtrOutputWithContext(ctx context.Context) NatGatewayStrategyPtrOutput {
+	return o
+}
+
+func (o NatGatewayStrategyPtrOutput) Elem() NatGatewayStrategyOutput {
+	return o.ApplyT(func(v *NatGatewayStrategy) NatGatewayStrategy {
+		if v != nil {
+			return *v
+		}
+		var ret NatGatewayStrategy
+		return ret
+	}).(NatGatewayStrategyOutput)
+}
+
+func (o NatGatewayStrategyPtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return o.ToStringPtrOutputWithContext(context.Background())
+}
+
+func (o NatGatewayStrategyPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e *NatGatewayStrategy) *string {
+		if e == nil {
+			return nil
+		}
+		v := string(*e)
+		return &v
+	}).(pulumi.StringPtrOutput)
+}
+
+// NatGatewayStrategyInput is an input type that accepts NatGatewayStrategyArgs and NatGatewayStrategyOutput values.
+// You can construct a concrete instance of `NatGatewayStrategyInput` via:
+//
+//          NatGatewayStrategyArgs{...}
+type NatGatewayStrategyInput interface {
+	pulumi.Input
+
+	ToNatGatewayStrategyOutput() NatGatewayStrategyOutput
+	ToNatGatewayStrategyOutputWithContext(context.Context) NatGatewayStrategyOutput
+}
+
+var natGatewayStrategyPtrType = reflect.TypeOf((**NatGatewayStrategy)(nil)).Elem()
+
+type NatGatewayStrategyPtrInput interface {
+	pulumi.Input
+
+	ToNatGatewayStrategyPtrOutput() NatGatewayStrategyPtrOutput
+	ToNatGatewayStrategyPtrOutputWithContext(context.Context) NatGatewayStrategyPtrOutput
+}
+
+type natGatewayStrategyPtr string
+
+func NatGatewayStrategyPtr(v string) NatGatewayStrategyPtrInput {
+	return (*natGatewayStrategyPtr)(&v)
+}
+
+func (*natGatewayStrategyPtr) ElementType() reflect.Type {
+	return natGatewayStrategyPtrType
+}
+
+func (in *natGatewayStrategyPtr) ToNatGatewayStrategyPtrOutput() NatGatewayStrategyPtrOutput {
+	return pulumi.ToOutput(in).(NatGatewayStrategyPtrOutput)
+}
+
+func (in *natGatewayStrategyPtr) ToNatGatewayStrategyPtrOutputWithContext(ctx context.Context) NatGatewayStrategyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, in).(NatGatewayStrategyPtrOutput)
+}
 
 // A type of subnet within a VPC.
 type SubnetType string
@@ -27,5 +191,170 @@ const (
 	SubnetTypeIsolated = SubnetType("Isolated")
 )
 
+func (SubnetType) ElementType() reflect.Type {
+	return reflect.TypeOf((*SubnetType)(nil)).Elem()
+}
+
+func (e SubnetType) ToSubnetTypeOutput() SubnetTypeOutput {
+	return pulumi.ToOutput(e).(SubnetTypeOutput)
+}
+
+func (e SubnetType) ToSubnetTypeOutputWithContext(ctx context.Context) SubnetTypeOutput {
+	return pulumi.ToOutputWithContext(ctx, e).(SubnetTypeOutput)
+}
+
+func (e SubnetType) ToSubnetTypePtrOutput() SubnetTypePtrOutput {
+	return e.ToSubnetTypePtrOutputWithContext(context.Background())
+}
+
+func (e SubnetType) ToSubnetTypePtrOutputWithContext(ctx context.Context) SubnetTypePtrOutput {
+	return SubnetType(e).ToSubnetTypeOutputWithContext(ctx).ToSubnetTypePtrOutputWithContext(ctx)
+}
+
+func (e SubnetType) ToStringOutput() pulumi.StringOutput {
+	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e SubnetType) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e SubnetType) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
+}
+
+func (e SubnetType) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
+}
+
+type SubnetTypeOutput struct{ *pulumi.OutputState }
+
+func (SubnetTypeOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*SubnetType)(nil)).Elem()
+}
+
+func (o SubnetTypeOutput) ToSubnetTypeOutput() SubnetTypeOutput {
+	return o
+}
+
+func (o SubnetTypeOutput) ToSubnetTypeOutputWithContext(ctx context.Context) SubnetTypeOutput {
+	return o
+}
+
+func (o SubnetTypeOutput) ToSubnetTypePtrOutput() SubnetTypePtrOutput {
+	return o.ToSubnetTypePtrOutputWithContext(context.Background())
+}
+
+func (o SubnetTypeOutput) ToSubnetTypePtrOutputWithContext(ctx context.Context) SubnetTypePtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v SubnetType) *SubnetType {
+		return &v
+	}).(SubnetTypePtrOutput)
+}
+
+func (o SubnetTypeOutput) ToStringOutput() pulumi.StringOutput {
+	return o.ToStringOutputWithContext(context.Background())
+}
+
+func (o SubnetTypeOutput) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e SubnetType) string {
+		return string(e)
+	}).(pulumi.StringOutput)
+}
+
+func (o SubnetTypeOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return o.ToStringPtrOutputWithContext(context.Background())
+}
+
+func (o SubnetTypeOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e SubnetType) *string {
+		v := string(e)
+		return &v
+	}).(pulumi.StringPtrOutput)
+}
+
+type SubnetTypePtrOutput struct{ *pulumi.OutputState }
+
+func (SubnetTypePtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**SubnetType)(nil)).Elem()
+}
+
+func (o SubnetTypePtrOutput) ToSubnetTypePtrOutput() SubnetTypePtrOutput {
+	return o
+}
+
+func (o SubnetTypePtrOutput) ToSubnetTypePtrOutputWithContext(ctx context.Context) SubnetTypePtrOutput {
+	return o
+}
+
+func (o SubnetTypePtrOutput) Elem() SubnetTypeOutput {
+	return o.ApplyT(func(v *SubnetType) SubnetType {
+		if v != nil {
+			return *v
+		}
+		var ret SubnetType
+		return ret
+	}).(SubnetTypeOutput)
+}
+
+func (o SubnetTypePtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return o.ToStringPtrOutputWithContext(context.Background())
+}
+
+func (o SubnetTypePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e *SubnetType) *string {
+		if e == nil {
+			return nil
+		}
+		v := string(*e)
+		return &v
+	}).(pulumi.StringPtrOutput)
+}
+
+// SubnetTypeInput is an input type that accepts SubnetTypeArgs and SubnetTypeOutput values.
+// You can construct a concrete instance of `SubnetTypeInput` via:
+//
+//          SubnetTypeArgs{...}
+type SubnetTypeInput interface {
+	pulumi.Input
+
+	ToSubnetTypeOutput() SubnetTypeOutput
+	ToSubnetTypeOutputWithContext(context.Context) SubnetTypeOutput
+}
+
+var subnetTypePtrType = reflect.TypeOf((**SubnetType)(nil)).Elem()
+
+type SubnetTypePtrInput interface {
+	pulumi.Input
+
+	ToSubnetTypePtrOutput() SubnetTypePtrOutput
+	ToSubnetTypePtrOutputWithContext(context.Context) SubnetTypePtrOutput
+}
+
+type subnetTypePtr string
+
+func SubnetTypePtr(v string) SubnetTypePtrInput {
+	return (*subnetTypePtr)(&v)
+}
+
+func (*subnetTypePtr) ElementType() reflect.Type {
+	return subnetTypePtrType
+}
+
+func (in *subnetTypePtr) ToSubnetTypePtrOutput() SubnetTypePtrOutput {
+	return pulumi.ToOutput(in).(SubnetTypePtrOutput)
+}
+
+func (in *subnetTypePtr) ToSubnetTypePtrOutputWithContext(ctx context.Context) SubnetTypePtrOutput {
+	return pulumi.ToOutputWithContext(ctx, in).(SubnetTypePtrOutput)
+}
+
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NatGatewayStrategyInput)(nil)).Elem(), NatGatewayStrategy("None"))
+	pulumi.RegisterInputType(reflect.TypeOf((*NatGatewayStrategyPtrInput)(nil)).Elem(), NatGatewayStrategy("None"))
+	pulumi.RegisterInputType(reflect.TypeOf((*SubnetTypeInput)(nil)).Elem(), SubnetType("Public"))
+	pulumi.RegisterInputType(reflect.TypeOf((*SubnetTypePtrInput)(nil)).Elem(), SubnetType("Public"))
+	pulumi.RegisterOutputType(NatGatewayStrategyOutput{})
+	pulumi.RegisterOutputType(NatGatewayStrategyPtrOutput{})
+	pulumi.RegisterOutputType(SubnetTypeOutput{})
+	pulumi.RegisterOutputType(SubnetTypePtrOutput{})
 }

--- a/sdk/go/awsx/ec2/pulumiTypes.go
+++ b/sdk/go/awsx/ec2/pulumiTypes.go
@@ -3,12 +3,170 @@
 
 package ec2
 
+import (
+	"context"
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
 // Configuration for NAT Gateways.
 type NatGatewayConfiguration struct {
 	// A list of EIP allocation IDs to assign to the NAT Gateways. Optional. If specified, the number of supplied values must match the chosen strategy (either one, or the number of availability zones).
 	ElasticIpAllocationIds []string `pulumi:"elasticIpAllocationIds"`
 	// The strategy for deploying NAT Gateways.
 	Strategy NatGatewayStrategy `pulumi:"strategy"`
+}
+
+// NatGatewayConfigurationInput is an input type that accepts NatGatewayConfigurationArgs and NatGatewayConfigurationOutput values.
+// You can construct a concrete instance of `NatGatewayConfigurationInput` via:
+//
+//          NatGatewayConfigurationArgs{...}
+type NatGatewayConfigurationInput interface {
+	pulumi.Input
+
+	ToNatGatewayConfigurationOutput() NatGatewayConfigurationOutput
+	ToNatGatewayConfigurationOutputWithContext(context.Context) NatGatewayConfigurationOutput
+}
+
+// Configuration for NAT Gateways.
+type NatGatewayConfigurationArgs struct {
+	// A list of EIP allocation IDs to assign to the NAT Gateways. Optional. If specified, the number of supplied values must match the chosen strategy (either one, or the number of availability zones).
+	ElasticIpAllocationIds []pulumi.StringInput `pulumi:"elasticIpAllocationIds"`
+	// The strategy for deploying NAT Gateways.
+	Strategy NatGatewayStrategy `pulumi:"strategy"`
+}
+
+func (NatGatewayConfigurationArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*NatGatewayConfiguration)(nil)).Elem()
+}
+
+func (i NatGatewayConfigurationArgs) ToNatGatewayConfigurationOutput() NatGatewayConfigurationOutput {
+	return i.ToNatGatewayConfigurationOutputWithContext(context.Background())
+}
+
+func (i NatGatewayConfigurationArgs) ToNatGatewayConfigurationOutputWithContext(ctx context.Context) NatGatewayConfigurationOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(NatGatewayConfigurationOutput)
+}
+
+func (i NatGatewayConfigurationArgs) ToNatGatewayConfigurationPtrOutput() NatGatewayConfigurationPtrOutput {
+	return i.ToNatGatewayConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i NatGatewayConfigurationArgs) ToNatGatewayConfigurationPtrOutputWithContext(ctx context.Context) NatGatewayConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(NatGatewayConfigurationOutput).ToNatGatewayConfigurationPtrOutputWithContext(ctx)
+}
+
+// NatGatewayConfigurationPtrInput is an input type that accepts NatGatewayConfigurationArgs, NatGatewayConfigurationPtr and NatGatewayConfigurationPtrOutput values.
+// You can construct a concrete instance of `NatGatewayConfigurationPtrInput` via:
+//
+//          NatGatewayConfigurationArgs{...}
+//
+//  or:
+//
+//          nil
+type NatGatewayConfigurationPtrInput interface {
+	pulumi.Input
+
+	ToNatGatewayConfigurationPtrOutput() NatGatewayConfigurationPtrOutput
+	ToNatGatewayConfigurationPtrOutputWithContext(context.Context) NatGatewayConfigurationPtrOutput
+}
+
+type natGatewayConfigurationPtrType NatGatewayConfigurationArgs
+
+func NatGatewayConfigurationPtr(v *NatGatewayConfigurationArgs) NatGatewayConfigurationPtrInput {
+	return (*natGatewayConfigurationPtrType)(v)
+}
+
+func (*natGatewayConfigurationPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**NatGatewayConfiguration)(nil)).Elem()
+}
+
+func (i *natGatewayConfigurationPtrType) ToNatGatewayConfigurationPtrOutput() NatGatewayConfigurationPtrOutput {
+	return i.ToNatGatewayConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i *natGatewayConfigurationPtrType) ToNatGatewayConfigurationPtrOutputWithContext(ctx context.Context) NatGatewayConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(NatGatewayConfigurationPtrOutput)
+}
+
+// Configuration for NAT Gateways.
+type NatGatewayConfigurationOutput struct{ *pulumi.OutputState }
+
+func (NatGatewayConfigurationOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*NatGatewayConfiguration)(nil)).Elem()
+}
+
+func (o NatGatewayConfigurationOutput) ToNatGatewayConfigurationOutput() NatGatewayConfigurationOutput {
+	return o
+}
+
+func (o NatGatewayConfigurationOutput) ToNatGatewayConfigurationOutputWithContext(ctx context.Context) NatGatewayConfigurationOutput {
+	return o
+}
+
+func (o NatGatewayConfigurationOutput) ToNatGatewayConfigurationPtrOutput() NatGatewayConfigurationPtrOutput {
+	return o.ToNatGatewayConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (o NatGatewayConfigurationOutput) ToNatGatewayConfigurationPtrOutputWithContext(ctx context.Context) NatGatewayConfigurationPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v NatGatewayConfiguration) *NatGatewayConfiguration {
+		return &v
+	}).(NatGatewayConfigurationPtrOutput)
+}
+
+// A list of EIP allocation IDs to assign to the NAT Gateways. Optional. If specified, the number of supplied values must match the chosen strategy (either one, or the number of availability zones).
+func (o NatGatewayConfigurationOutput) ElasticIpAllocationIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v NatGatewayConfiguration) []string { return v.ElasticIpAllocationIds }).(pulumi.StringArrayOutput)
+}
+
+// The strategy for deploying NAT Gateways.
+func (o NatGatewayConfigurationOutput) Strategy() NatGatewayStrategyOutput {
+	return o.ApplyT(func(v NatGatewayConfiguration) NatGatewayStrategy { return v.Strategy }).(NatGatewayStrategyOutput)
+}
+
+type NatGatewayConfigurationPtrOutput struct{ *pulumi.OutputState }
+
+func (NatGatewayConfigurationPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**NatGatewayConfiguration)(nil)).Elem()
+}
+
+func (o NatGatewayConfigurationPtrOutput) ToNatGatewayConfigurationPtrOutput() NatGatewayConfigurationPtrOutput {
+	return o
+}
+
+func (o NatGatewayConfigurationPtrOutput) ToNatGatewayConfigurationPtrOutputWithContext(ctx context.Context) NatGatewayConfigurationPtrOutput {
+	return o
+}
+
+func (o NatGatewayConfigurationPtrOutput) Elem() NatGatewayConfigurationOutput {
+	return o.ApplyT(func(v *NatGatewayConfiguration) NatGatewayConfiguration {
+		if v != nil {
+			return *v
+		}
+		var ret NatGatewayConfiguration
+		return ret
+	}).(NatGatewayConfigurationOutput)
+}
+
+// A list of EIP allocation IDs to assign to the NAT Gateways. Optional. If specified, the number of supplied values must match the chosen strategy (either one, or the number of availability zones).
+func (o NatGatewayConfigurationPtrOutput) ElasticIpAllocationIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *NatGatewayConfiguration) []string {
+		if v == nil {
+			return nil
+		}
+		return v.ElasticIpAllocationIds
+	}).(pulumi.StringArrayOutput)
+}
+
+// The strategy for deploying NAT Gateways.
+func (o NatGatewayConfigurationPtrOutput) Strategy() NatGatewayStrategyPtrOutput {
+	return o.ApplyT(func(v *NatGatewayConfiguration) *NatGatewayStrategy {
+		if v == nil {
+			return nil
+		}
+		return &v.Strategy
+	}).(NatGatewayStrategyPtrOutput)
 }
 
 // Configuration for a VPC subnet.
@@ -21,5 +179,121 @@ type SubnetSpec struct {
 	Type SubnetType `pulumi:"type"`
 }
 
+// SubnetSpecInput is an input type that accepts SubnetSpecArgs and SubnetSpecOutput values.
+// You can construct a concrete instance of `SubnetSpecInput` via:
+//
+//          SubnetSpecArgs{...}
+type SubnetSpecInput interface {
+	pulumi.Input
+
+	ToSubnetSpecOutput() SubnetSpecOutput
+	ToSubnetSpecOutputWithContext(context.Context) SubnetSpecOutput
+}
+
+// Configuration for a VPC subnet.
+type SubnetSpecArgs struct {
+	// The bitmask for the subnet's CIDR block.
+	CidrMask int `pulumi:"cidrMask"`
+	// The subnet's name. Will be templated upon creation.
+	Name *string `pulumi:"name"`
+	// The type of subnet.
+	Type SubnetType `pulumi:"type"`
+}
+
+func (SubnetSpecArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*SubnetSpec)(nil)).Elem()
+}
+
+func (i SubnetSpecArgs) ToSubnetSpecOutput() SubnetSpecOutput {
+	return i.ToSubnetSpecOutputWithContext(context.Background())
+}
+
+func (i SubnetSpecArgs) ToSubnetSpecOutputWithContext(ctx context.Context) SubnetSpecOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(SubnetSpecOutput)
+}
+
+// SubnetSpecArrayInput is an input type that accepts SubnetSpecArray and SubnetSpecArrayOutput values.
+// You can construct a concrete instance of `SubnetSpecArrayInput` via:
+//
+//          SubnetSpecArray{ SubnetSpecArgs{...} }
+type SubnetSpecArrayInput interface {
+	pulumi.Input
+
+	ToSubnetSpecArrayOutput() SubnetSpecArrayOutput
+	ToSubnetSpecArrayOutputWithContext(context.Context) SubnetSpecArrayOutput
+}
+
+type SubnetSpecArray []SubnetSpecInput
+
+func (SubnetSpecArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]SubnetSpec)(nil)).Elem()
+}
+
+func (i SubnetSpecArray) ToSubnetSpecArrayOutput() SubnetSpecArrayOutput {
+	return i.ToSubnetSpecArrayOutputWithContext(context.Background())
+}
+
+func (i SubnetSpecArray) ToSubnetSpecArrayOutputWithContext(ctx context.Context) SubnetSpecArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(SubnetSpecArrayOutput)
+}
+
+// Configuration for a VPC subnet.
+type SubnetSpecOutput struct{ *pulumi.OutputState }
+
+func (SubnetSpecOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*SubnetSpec)(nil)).Elem()
+}
+
+func (o SubnetSpecOutput) ToSubnetSpecOutput() SubnetSpecOutput {
+	return o
+}
+
+func (o SubnetSpecOutput) ToSubnetSpecOutputWithContext(ctx context.Context) SubnetSpecOutput {
+	return o
+}
+
+// The bitmask for the subnet's CIDR block.
+func (o SubnetSpecOutput) CidrMask() pulumi.IntOutput {
+	return o.ApplyT(func(v SubnetSpec) int { return v.CidrMask }).(pulumi.IntOutput)
+}
+
+// The subnet's name. Will be templated upon creation.
+func (o SubnetSpecOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v SubnetSpec) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// The type of subnet.
+func (o SubnetSpecOutput) Type() SubnetTypeOutput {
+	return o.ApplyT(func(v SubnetSpec) SubnetType { return v.Type }).(SubnetTypeOutput)
+}
+
+type SubnetSpecArrayOutput struct{ *pulumi.OutputState }
+
+func (SubnetSpecArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]SubnetSpec)(nil)).Elem()
+}
+
+func (o SubnetSpecArrayOutput) ToSubnetSpecArrayOutput() SubnetSpecArrayOutput {
+	return o
+}
+
+func (o SubnetSpecArrayOutput) ToSubnetSpecArrayOutputWithContext(ctx context.Context) SubnetSpecArrayOutput {
+	return o
+}
+
+func (o SubnetSpecArrayOutput) Index(i pulumi.IntInput) SubnetSpecOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SubnetSpec {
+		return vs[0].([]SubnetSpec)[vs[1].(int)]
+	}).(SubnetSpecOutput)
+}
+
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*NatGatewayConfigurationInput)(nil)).Elem(), NatGatewayConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*NatGatewayConfigurationPtrInput)(nil)).Elem(), NatGatewayConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubnetSpecInput)(nil)).Elem(), SubnetSpecArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*SubnetSpecArrayInput)(nil)).Elem(), SubnetSpecArray{})
+	pulumi.RegisterOutputType(NatGatewayConfigurationOutput{})
+	pulumi.RegisterOutputType(NatGatewayConfigurationPtrOutput{})
+	pulumi.RegisterOutputType(SubnetSpecOutput{})
+	pulumi.RegisterOutputType(SubnetSpecArrayOutput{})
 }

--- a/sdk/go/awsx/ec2/vpc.go
+++ b/sdk/go/awsx/ec2/vpc.go
@@ -127,11 +127,11 @@ type VpcArgs struct {
 	// Netmask length to request from IPAM Pool. Conflicts with `ipv6_cidr_block`. This can be omitted if IPAM pool as a `allocation_default_netmask_length` set. Valid values: `56`.
 	Ipv6NetmaskLength pulumi.IntPtrInput
 	// Configuration for NAT Gateways. Optional. If private and public subnets are both specified, defaults to one gateway per availability zone. Otherwise, no gateways will be created.
-	NatGateways *NatGatewayConfiguration
+	NatGateways *NatGatewayConfigurationArgs
 	// A number of availability zones to which the subnets defined in subnetSpecs will be deployed. Optional, defaults to the first 3 AZs in the current region.
 	NumberOfAvailabilityZones *int
 	// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
-	SubnetSpecs []SubnetSpec
+	SubnetSpecs []SubnetSpecArgs
 	// A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput
 }
@@ -221,6 +221,62 @@ func (o VpcOutput) ToVpcOutput() VpcOutput {
 
 func (o VpcOutput) ToVpcOutputWithContext(ctx context.Context) VpcOutput {
 	return o
+}
+
+// The EIPs for any NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
+func (o VpcOutput) Eips() ec2.EipArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.EipArrayOutput { return v.Eips }).(ec2.EipArrayOutput)
+}
+
+// The Internet Gateway for the VPC.
+func (o VpcOutput) InternetGateway() ec2.InternetGatewayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.InternetGatewayOutput { return v.InternetGateway }).(ec2.InternetGatewayOutput)
+}
+
+func (o VpcOutput) IsolatedSubnetIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.IsolatedSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+// The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
+func (o VpcOutput) NatGateways() ec2.NatGatewayArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.NatGatewayArrayOutput { return v.NatGateways }).(ec2.NatGatewayArrayOutput)
+}
+
+func (o VpcOutput) PrivateSubnetIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PrivateSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+func (o VpcOutput) PublicSubnetIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PublicSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+// The Route Table Associations for the VPC.
+func (o VpcOutput) RouteTableAssociations() ec2.RouteTableAssociationArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.RouteTableAssociationArrayOutput { return v.RouteTableAssociations }).(ec2.RouteTableAssociationArrayOutput)
+}
+
+// The Route Tables for the VPC.
+func (o VpcOutput) RouteTables() ec2.RouteTableArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.RouteTableArrayOutput { return v.RouteTables }).(ec2.RouteTableArrayOutput)
+}
+
+// The Routes for the VPC.
+func (o VpcOutput) Routes() ec2.RouteArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.RouteArrayOutput { return v.Routes }).(ec2.RouteArrayOutput)
+}
+
+// The VPC's subnets.
+func (o VpcOutput) Subnets() ec2.SubnetArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.SubnetArrayOutput { return v.Subnets }).(ec2.SubnetArrayOutput)
+}
+
+// The VPC.
+func (o VpcOutput) Vpc() ec2.VpcOutput {
+	return o.ApplyT(func(v *Vpc) ec2.VpcOutput { return v.Vpc }).(ec2.VpcOutput)
+}
+
+func (o VpcOutput) VpcId() pulumi.StringOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringOutput { return v.VpcId }).(pulumi.StringOutput)
 }
 
 type VpcArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -163,6 +163,11 @@ func (o ImageOutput) ToImageOutputWithContext(ctx context.Context) ImageOutput {
 	return o
 }
 
+// Unique identifier of the pushed image
+func (o ImageOutput) ImageUri() pulumi.StringOutput {
+	return o.ApplyT(func(v *Image) pulumi.StringOutput { return v.ImageUri }).(pulumi.StringOutput)
+}
+
 type ImageArrayOutput struct{ *pulumi.OutputState }
 
 func (ImageArrayOutput) ElementType() reflect.Type {

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -36,6 +36,157 @@ type LifecyclePolicy struct {
 	Skip *bool `pulumi:"skip"`
 }
 
+// LifecyclePolicyInput is an input type that accepts LifecyclePolicyArgs and LifecyclePolicyOutput values.
+// You can construct a concrete instance of `LifecyclePolicyInput` via:
+//
+//          LifecyclePolicyArgs{...}
+type LifecyclePolicyInput interface {
+	pulumi.Input
+
+	ToLifecyclePolicyOutput() LifecyclePolicyOutput
+	ToLifecyclePolicyOutputWithContext(context.Context) LifecyclePolicyOutput
+}
+
+// Simplified lifecycle policy model consisting of one or more rules that determine which images in a repository should be expired. See https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html for more details.
+type LifecyclePolicyArgs struct {
+	// Specifies the rules to determine how images should be retired from this repository. Rules are ordered from lowest priority to highest.  If there is a rule with a `selection` value of `any`, then it will have the highest priority.
+	Rules LifecyclePolicyRuleArrayInput `pulumi:"rules"`
+	// Skips creation of the policy if set to `true`.
+	Skip *bool `pulumi:"skip"`
+}
+
+func (LifecyclePolicyArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*LifecyclePolicy)(nil)).Elem()
+}
+
+func (i LifecyclePolicyArgs) ToLifecyclePolicyOutput() LifecyclePolicyOutput {
+	return i.ToLifecyclePolicyOutputWithContext(context.Background())
+}
+
+func (i LifecyclePolicyArgs) ToLifecyclePolicyOutputWithContext(ctx context.Context) LifecyclePolicyOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LifecyclePolicyOutput)
+}
+
+func (i LifecyclePolicyArgs) ToLifecyclePolicyPtrOutput() LifecyclePolicyPtrOutput {
+	return i.ToLifecyclePolicyPtrOutputWithContext(context.Background())
+}
+
+func (i LifecyclePolicyArgs) ToLifecyclePolicyPtrOutputWithContext(ctx context.Context) LifecyclePolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LifecyclePolicyOutput).ToLifecyclePolicyPtrOutputWithContext(ctx)
+}
+
+// LifecyclePolicyPtrInput is an input type that accepts LifecyclePolicyArgs, LifecyclePolicyPtr and LifecyclePolicyPtrOutput values.
+// You can construct a concrete instance of `LifecyclePolicyPtrInput` via:
+//
+//          LifecyclePolicyArgs{...}
+//
+//  or:
+//
+//          nil
+type LifecyclePolicyPtrInput interface {
+	pulumi.Input
+
+	ToLifecyclePolicyPtrOutput() LifecyclePolicyPtrOutput
+	ToLifecyclePolicyPtrOutputWithContext(context.Context) LifecyclePolicyPtrOutput
+}
+
+type lifecyclePolicyPtrType LifecyclePolicyArgs
+
+func LifecyclePolicyPtr(v *LifecyclePolicyArgs) LifecyclePolicyPtrInput {
+	return (*lifecyclePolicyPtrType)(v)
+}
+
+func (*lifecyclePolicyPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**LifecyclePolicy)(nil)).Elem()
+}
+
+func (i *lifecyclePolicyPtrType) ToLifecyclePolicyPtrOutput() LifecyclePolicyPtrOutput {
+	return i.ToLifecyclePolicyPtrOutputWithContext(context.Background())
+}
+
+func (i *lifecyclePolicyPtrType) ToLifecyclePolicyPtrOutputWithContext(ctx context.Context) LifecyclePolicyPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(LifecyclePolicyPtrOutput)
+}
+
+// Simplified lifecycle policy model consisting of one or more rules that determine which images in a repository should be expired. See https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html for more details.
+type LifecyclePolicyOutput struct{ *pulumi.OutputState }
+
+func (LifecyclePolicyOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*LifecyclePolicy)(nil)).Elem()
+}
+
+func (o LifecyclePolicyOutput) ToLifecyclePolicyOutput() LifecyclePolicyOutput {
+	return o
+}
+
+func (o LifecyclePolicyOutput) ToLifecyclePolicyOutputWithContext(ctx context.Context) LifecyclePolicyOutput {
+	return o
+}
+
+func (o LifecyclePolicyOutput) ToLifecyclePolicyPtrOutput() LifecyclePolicyPtrOutput {
+	return o.ToLifecyclePolicyPtrOutputWithContext(context.Background())
+}
+
+func (o LifecyclePolicyOutput) ToLifecyclePolicyPtrOutputWithContext(ctx context.Context) LifecyclePolicyPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v LifecyclePolicy) *LifecyclePolicy {
+		return &v
+	}).(LifecyclePolicyPtrOutput)
+}
+
+// Specifies the rules to determine how images should be retired from this repository. Rules are ordered from lowest priority to highest.  If there is a rule with a `selection` value of `any`, then it will have the highest priority.
+func (o LifecyclePolicyOutput) Rules() LifecyclePolicyRuleArrayOutput {
+	return o.ApplyT(func(v LifecyclePolicy) []LifecyclePolicyRule { return v.Rules }).(LifecyclePolicyRuleArrayOutput)
+}
+
+// Skips creation of the policy if set to `true`.
+func (o LifecyclePolicyOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v LifecyclePolicy) *bool { return v.Skip }).(pulumi.BoolPtrOutput)
+}
+
+type LifecyclePolicyPtrOutput struct{ *pulumi.OutputState }
+
+func (LifecyclePolicyPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**LifecyclePolicy)(nil)).Elem()
+}
+
+func (o LifecyclePolicyPtrOutput) ToLifecyclePolicyPtrOutput() LifecyclePolicyPtrOutput {
+	return o
+}
+
+func (o LifecyclePolicyPtrOutput) ToLifecyclePolicyPtrOutputWithContext(ctx context.Context) LifecyclePolicyPtrOutput {
+	return o
+}
+
+func (o LifecyclePolicyPtrOutput) Elem() LifecyclePolicyOutput {
+	return o.ApplyT(func(v *LifecyclePolicy) LifecyclePolicy {
+		if v != nil {
+			return *v
+		}
+		var ret LifecyclePolicy
+		return ret
+	}).(LifecyclePolicyOutput)
+}
+
+// Specifies the rules to determine how images should be retired from this repository. Rules are ordered from lowest priority to highest.  If there is a rule with a `selection` value of `any`, then it will have the highest priority.
+func (o LifecyclePolicyPtrOutput) Rules() LifecyclePolicyRuleArrayOutput {
+	return o.ApplyT(func(v *LifecyclePolicy) []LifecyclePolicyRule {
+		if v == nil {
+			return nil
+		}
+		return v.Rules
+	}).(LifecyclePolicyRuleArrayOutput)
+}
+
+// Skips creation of the policy if set to `true`.
+func (o LifecyclePolicyPtrOutput) Skip() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *LifecyclePolicy) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Skip
+	}).(pulumi.BoolPtrOutput)
+}
+
 // A lifecycle policy rule that determine which images in a repository should be expired.
 type LifecyclePolicyRule struct {
 	// Describes the purpose of a rule within a lifecycle policy.
@@ -173,8 +324,12 @@ func (o LifecyclePolicyRuleArrayOutput) Index(i pulumi.IntInput) LifecyclePolicy
 }
 
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*LifecyclePolicyInput)(nil)).Elem(), LifecyclePolicyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*LifecyclePolicyPtrInput)(nil)).Elem(), LifecyclePolicyArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*LifecyclePolicyRuleInput)(nil)).Elem(), LifecyclePolicyRuleArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*LifecyclePolicyRuleArrayInput)(nil)).Elem(), LifecyclePolicyRuleArray{})
+	pulumi.RegisterOutputType(LifecyclePolicyOutput{})
+	pulumi.RegisterOutputType(LifecyclePolicyPtrOutput{})
 	pulumi.RegisterOutputType(LifecyclePolicyRuleOutput{})
 	pulumi.RegisterOutputType(LifecyclePolicyRuleArrayOutput{})
 }

--- a/sdk/go/awsx/ecr/repository.go
+++ b/sdk/go/awsx/ecr/repository.go
@@ -64,7 +64,7 @@ type RepositoryArgs struct {
 	// The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`. Defaults to `MUTABLE`.
 	ImageTagMutability pulumi.StringPtrInput
 	// A lifecycle policy consists of one or more rules that determine which images in a repository should be expired. If not provided, this will default to untagged images expiring after 1 day.
-	LifecyclePolicy *LifecyclePolicy
+	LifecyclePolicy *LifecyclePolicyArgs
 	// Name of the repository.
 	Name pulumi.StringPtrInput
 	// A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
@@ -156,6 +156,21 @@ func (o RepositoryOutput) ToRepositoryOutput() RepositoryOutput {
 
 func (o RepositoryOutput) ToRepositoryOutputWithContext(ctx context.Context) RepositoryOutput {
 	return o
+}
+
+// Underlying repository lifecycle policy
+func (o RepositoryOutput) LifecyclePolicy() ecr.LifecyclePolicyOutput {
+	return o.ApplyT(func(v *Repository) ecr.LifecyclePolicyOutput { return v.LifecyclePolicy }).(ecr.LifecyclePolicyOutput)
+}
+
+// Underlying Repository resource
+func (o RepositoryOutput) Repository() ecr.RepositoryOutput {
+	return o.ApplyT(func(v *Repository) ecr.RepositoryOutput { return v.Repository }).(ecr.RepositoryOutput)
+}
+
+// The URL of the repository (in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName).
+func (o RepositoryOutput) Url() pulumi.StringOutput {
+	return o.ApplyT(func(v *Repository) pulumi.StringOutput { return v.Url }).(pulumi.StringOutput)
 }
 
 type RepositoryArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecs/ec2service.go
+++ b/sdk/go/awsx/ecs/ec2service.go
@@ -141,7 +141,7 @@ type EC2ServiceArgs struct {
 	// Family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. Either [taskDefinition] or [taskDefinitionArgs] must be provided.
 	TaskDefinition pulumi.StringPtrInput
 	// The args of task definition that you want to run in your service. Either [taskDefinition] or [taskDefinitionArgs] must be provided.
-	TaskDefinitionArgs *EC2ServiceTaskDefinition
+	TaskDefinitionArgs *EC2ServiceTaskDefinitionArgs
 }
 
 func (EC2ServiceArgs) ElementType() reflect.Type {
@@ -229,6 +229,16 @@ func (o EC2ServiceOutput) ToEC2ServiceOutput() EC2ServiceOutput {
 
 func (o EC2ServiceOutput) ToEC2ServiceOutputWithContext(ctx context.Context) EC2ServiceOutput {
 	return o
+}
+
+// Underlying ECS Service resource
+func (o EC2ServiceOutput) Service() ecs.ServiceOutput {
+	return o.ApplyT(func(v *EC2Service) ecs.ServiceOutput { return v.Service }).(ecs.ServiceOutput)
+}
+
+// Underlying EC2 Task definition component resource if created from args
+func (o EC2ServiceOutput) TaskDefinition() ecs.TaskDefinitionOutput {
+	return o.ApplyT(func(v *EC2Service) ecs.TaskDefinitionOutput { return v.TaskDefinition }).(ecs.TaskDefinitionOutput)
 }
 
 type EC2ServiceArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecs/ec2taskDefinition.go
+++ b/sdk/go/awsx/ecs/ec2taskDefinition.go
@@ -102,19 +102,19 @@ type EC2TaskDefinitionArgs struct {
 	// multiple containers, especially when creating a TaskDefinition to call [run] on.
 	//
 	// Either [container] or [containers] must be provided.
-	Container *TaskDefinitionContainerDefinition
+	Container *TaskDefinitionContainerDefinitionArgs
 	// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
 	// contain many containers within.
 	//
 	// Either [container] or [containers] must be provided.
-	Containers map[string]TaskDefinitionContainerDefinition
+	Containers map[string]TaskDefinitionContainerDefinitionArgs
 	// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
 	Cpu pulumi.StringPtrInput
 	// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
 	EphemeralStorage ecs.TaskDefinitionEphemeralStoragePtrInput
 	// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
 	// Will be created automatically if not defined.
-	ExecutionRole *awsx.DefaultRoleWithPolicy
+	ExecutionRole *awsx.DefaultRoleWithPolicyArgs
 	// An optional unique name for your task definition. If not specified, then a default will be created.
 	Family pulumi.StringPtrInput
 	// Configuration block(s) with Inference Accelerators settings. Detailed below.
@@ -122,7 +122,7 @@ type EC2TaskDefinitionArgs struct {
 	// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
 	IpcMode pulumi.StringPtrInput
 	// A set of volume blocks that containers in your task may use.
-	LogGroup *awsx.DefaultLogGroup
+	LogGroup *awsx.DefaultLogGroupArgs
 	// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
 	// based on the cumulative needs specified by [containerDefinitions]
 	Memory pulumi.StringPtrInput
@@ -141,7 +141,7 @@ type EC2TaskDefinitionArgs struct {
 	Tags pulumi.StringMapInput
 	// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 	// Will be created automatically if not defined.
-	TaskRole *awsx.DefaultRoleWithPolicy
+	TaskRole *awsx.DefaultRoleWithPolicyArgs
 	// Configuration block for volumes that containers in your task may use. Detailed below.
 	Volumes ecs.TaskDefinitionVolumeArrayInput
 }
@@ -231,6 +231,31 @@ func (o EC2TaskDefinitionOutput) ToEC2TaskDefinitionOutput() EC2TaskDefinitionOu
 
 func (o EC2TaskDefinitionOutput) ToEC2TaskDefinitionOutputWithContext(ctx context.Context) EC2TaskDefinitionOutput {
 	return o
+}
+
+// Auto-created IAM task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+func (o EC2TaskDefinitionOutput) ExecutionRole() iam.RoleOutput {
+	return o.ApplyT(func(v *EC2TaskDefinition) iam.RoleOutput { return v.ExecutionRole }).(iam.RoleOutput)
+}
+
+// Computed load balancers from target groups specified of container port mappings.
+func (o EC2TaskDefinitionOutput) LoadBalancers() ecs.ServiceLoadBalancerArrayOutput {
+	return o.ApplyT(func(v *EC2TaskDefinition) ecs.ServiceLoadBalancerArrayOutput { return v.LoadBalancers }).(ecs.ServiceLoadBalancerArrayOutput)
+}
+
+// Auto-created Log Group resource for use by containers.
+func (o EC2TaskDefinitionOutput) LogGroup() cloudwatch.LogGroupOutput {
+	return o.ApplyT(func(v *EC2TaskDefinition) cloudwatch.LogGroupOutput { return v.LogGroup }).(cloudwatch.LogGroupOutput)
+}
+
+// Underlying ECS Task Definition resource
+func (o EC2TaskDefinitionOutput) TaskDefinition() ecs.TaskDefinitionOutput {
+	return o.ApplyT(func(v *EC2TaskDefinition) ecs.TaskDefinitionOutput { return v.TaskDefinition }).(ecs.TaskDefinitionOutput)
+}
+
+// Auto-created IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+func (o EC2TaskDefinitionOutput) TaskRole() iam.RoleOutput {
+	return o.ApplyT(func(v *EC2TaskDefinition) iam.RoleOutput { return v.TaskRole }).(iam.RoleOutput)
 }
 
 type EC2TaskDefinitionArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecs/fargateService.go
+++ b/sdk/go/awsx/ecs/fargateService.go
@@ -133,7 +133,7 @@ type FargateServiceArgs struct {
 	// Family and revision (`family:revision`) or full ARN of the task definition that you want to run in your service. Either [taskDefinition] or [taskDefinitionArgs] must be provided.
 	TaskDefinition pulumi.StringPtrInput
 	// The args of task definition that you want to run in your service. Either [taskDefinition] or [taskDefinitionArgs] must be provided.
-	TaskDefinitionArgs *FargateServiceTaskDefinition
+	TaskDefinitionArgs *FargateServiceTaskDefinitionArgs
 }
 
 func (FargateServiceArgs) ElementType() reflect.Type {
@@ -221,6 +221,16 @@ func (o FargateServiceOutput) ToFargateServiceOutput() FargateServiceOutput {
 
 func (o FargateServiceOutput) ToFargateServiceOutputWithContext(ctx context.Context) FargateServiceOutput {
 	return o
+}
+
+// Underlying ECS Service resource
+func (o FargateServiceOutput) Service() ecs.ServiceOutput {
+	return o.ApplyT(func(v *FargateService) ecs.ServiceOutput { return v.Service }).(ecs.ServiceOutput)
+}
+
+// Underlying Fargate component resource if created from args
+func (o FargateServiceOutput) TaskDefinition() ecs.TaskDefinitionOutput {
+	return o.ApplyT(func(v *FargateService) ecs.TaskDefinitionOutput { return v.TaskDefinition }).(ecs.TaskDefinitionOutput)
 }
 
 type FargateServiceArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecs/fargateTaskDefinition.go
+++ b/sdk/go/awsx/ecs/fargateTaskDefinition.go
@@ -100,19 +100,19 @@ type FargateTaskDefinitionArgs struct {
 	// multiple containers, especially when creating a TaskDefinition to call [run] on.
 	//
 	// Either [container] or [containers] must be provided.
-	Container *TaskDefinitionContainerDefinition
+	Container *TaskDefinitionContainerDefinitionArgs
 	// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
 	// contain many containers within.
 	//
 	// Either [container] or [containers] must be provided.
-	Containers map[string]TaskDefinitionContainerDefinition
+	Containers map[string]TaskDefinitionContainerDefinitionArgs
 	// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
 	Cpu pulumi.StringPtrInput
 	// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
 	EphemeralStorage ecs.TaskDefinitionEphemeralStoragePtrInput
 	// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
 	// Will be created automatically if not defined.
-	ExecutionRole *awsx.DefaultRoleWithPolicy
+	ExecutionRole *awsx.DefaultRoleWithPolicyArgs
 	// An optional unique name for your task definition. If not specified, then a default will be created.
 	Family pulumi.StringPtrInput
 	// Configuration block(s) with Inference Accelerators settings. Detailed below.
@@ -120,7 +120,7 @@ type FargateTaskDefinitionArgs struct {
 	// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
 	IpcMode pulumi.StringPtrInput
 	// A set of volume blocks that containers in your task may use.
-	LogGroup *awsx.DefaultLogGroup
+	LogGroup *awsx.DefaultLogGroupArgs
 	// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
 	// based on the cumulative needs specified by [containerDefinitions]
 	Memory pulumi.StringPtrInput
@@ -137,7 +137,7 @@ type FargateTaskDefinitionArgs struct {
 	Tags pulumi.StringMapInput
 	// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 	// Will be created automatically if not defined.
-	TaskRole *awsx.DefaultRoleWithPolicy
+	TaskRole *awsx.DefaultRoleWithPolicyArgs
 	// Configuration block for volumes that containers in your task may use. Detailed below.
 	Volumes ecs.TaskDefinitionVolumeArrayInput
 }
@@ -227,6 +227,31 @@ func (o FargateTaskDefinitionOutput) ToFargateTaskDefinitionOutput() FargateTask
 
 func (o FargateTaskDefinitionOutput) ToFargateTaskDefinitionOutputWithContext(ctx context.Context) FargateTaskDefinitionOutput {
 	return o
+}
+
+// Auto-created IAM task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+func (o FargateTaskDefinitionOutput) ExecutionRole() iam.RoleOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) iam.RoleOutput { return v.ExecutionRole }).(iam.RoleOutput)
+}
+
+// Computed load balancers from target groups specified of container port mappings.
+func (o FargateTaskDefinitionOutput) LoadBalancers() ecs.ServiceLoadBalancerArrayOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) ecs.ServiceLoadBalancerArrayOutput { return v.LoadBalancers }).(ecs.ServiceLoadBalancerArrayOutput)
+}
+
+// Auto-created Log Group resource for use by containers.
+func (o FargateTaskDefinitionOutput) LogGroup() cloudwatch.LogGroupOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) cloudwatch.LogGroupOutput { return v.LogGroup }).(cloudwatch.LogGroupOutput)
+}
+
+// Underlying ECS Task Definition resource
+func (o FargateTaskDefinitionOutput) TaskDefinition() ecs.TaskDefinitionOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) ecs.TaskDefinitionOutput { return v.TaskDefinition }).(ecs.TaskDefinitionOutput)
+}
+
+// Auto-created IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+func (o FargateTaskDefinitionOutput) TaskRole() iam.RoleOutput {
+	return o.ApplyT(func(v *FargateTaskDefinition) iam.RoleOutput { return v.TaskRole }).(iam.RoleOutput)
 }
 
 type FargateTaskDefinitionArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/ecs/pulumiTypes.go
+++ b/sdk/go/awsx/ecs/pulumiTypes.go
@@ -4,9 +4,13 @@
 package ecs
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // Create a TaskDefinition resource with the given unique name, arguments, and options.
@@ -61,6 +65,478 @@ type EC2ServiceTaskDefinition struct {
 	Volumes []ecs.TaskDefinitionVolume `pulumi:"volumes"`
 }
 
+// EC2ServiceTaskDefinitionInput is an input type that accepts EC2ServiceTaskDefinitionArgs and EC2ServiceTaskDefinitionOutput values.
+// You can construct a concrete instance of `EC2ServiceTaskDefinitionInput` via:
+//
+//          EC2ServiceTaskDefinitionArgs{...}
+type EC2ServiceTaskDefinitionInput interface {
+	pulumi.Input
+
+	ToEC2ServiceTaskDefinitionOutput() EC2ServiceTaskDefinitionOutput
+	ToEC2ServiceTaskDefinitionOutputWithContext(context.Context) EC2ServiceTaskDefinitionOutput
+}
+
+// Create a TaskDefinition resource with the given unique name, arguments, and options.
+// Creates required log-group and task & execution roles.
+// Presents required Service load balancers if target group included in port mappings.
+type EC2ServiceTaskDefinitionArgs struct {
+	// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+	// multiple containers, especially when creating a TaskDefinition to call [run] on.
+	//
+	// Either [container] or [containers] must be provided.
+	Container *TaskDefinitionContainerDefinitionArgs `pulumi:"container"`
+	// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+	// contain many containers within.
+	//
+	// Either [container] or [containers] must be provided.
+	Containers map[string]TaskDefinitionContainerDefinitionArgs `pulumi:"containers"`
+	// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+	Cpu pulumi.StringPtrInput `pulumi:"cpu"`
+	// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+	EphemeralStorage ecs.TaskDefinitionEphemeralStoragePtrInput `pulumi:"ephemeralStorage"`
+	// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+	// Will be created automatically if not defined.
+	ExecutionRole *awsx.DefaultRoleWithPolicyArgs `pulumi:"executionRole"`
+	// An optional unique name for your task definition. If not specified, then a default will be created.
+	Family pulumi.StringPtrInput `pulumi:"family"`
+	// Configuration block(s) with Inference Accelerators settings. Detailed below.
+	InferenceAccelerators ecs.TaskDefinitionInferenceAcceleratorArrayInput `pulumi:"inferenceAccelerators"`
+	// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+	IpcMode pulumi.StringPtrInput `pulumi:"ipcMode"`
+	// A set of volume blocks that containers in your task may use.
+	LogGroup *awsx.DefaultLogGroupArgs `pulumi:"logGroup"`
+	// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+	// based on the cumulative needs specified by [containerDefinitions]
+	Memory pulumi.StringPtrInput `pulumi:"memory"`
+	// Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
+	NetworkMode pulumi.StringPtrInput `pulumi:"networkMode"`
+	// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+	PidMode pulumi.StringPtrInput `pulumi:"pidMode"`
+	// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+	PlacementConstraints ecs.TaskDefinitionPlacementConstraintArrayInput `pulumi:"placementConstraints"`
+	// Configuration block for the App Mesh proxy. Detailed below.
+	ProxyConfiguration ecs.TaskDefinitionProxyConfigurationPtrInput `pulumi:"proxyConfiguration"`
+	// Configuration block for runtime_platform that containers in your task may use.
+	RuntimePlatform ecs.TaskDefinitionRuntimePlatformPtrInput `pulumi:"runtimePlatform"`
+	SkipDestroy     pulumi.BoolPtrInput                       `pulumi:"skipDestroy"`
+	// Key-value map of resource tags.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+	// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+	// Will be created automatically if not defined.
+	TaskRole *awsx.DefaultRoleWithPolicyArgs `pulumi:"taskRole"`
+	// Configuration block for volumes that containers in your task may use. Detailed below.
+	Volumes ecs.TaskDefinitionVolumeArrayInput `pulumi:"volumes"`
+}
+
+func (EC2ServiceTaskDefinitionArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*EC2ServiceTaskDefinition)(nil)).Elem()
+}
+
+func (i EC2ServiceTaskDefinitionArgs) ToEC2ServiceTaskDefinitionOutput() EC2ServiceTaskDefinitionOutput {
+	return i.ToEC2ServiceTaskDefinitionOutputWithContext(context.Background())
+}
+
+func (i EC2ServiceTaskDefinitionArgs) ToEC2ServiceTaskDefinitionOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(EC2ServiceTaskDefinitionOutput)
+}
+
+func (i EC2ServiceTaskDefinitionArgs) ToEC2ServiceTaskDefinitionPtrOutput() EC2ServiceTaskDefinitionPtrOutput {
+	return i.ToEC2ServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i EC2ServiceTaskDefinitionArgs) ToEC2ServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(EC2ServiceTaskDefinitionOutput).ToEC2ServiceTaskDefinitionPtrOutputWithContext(ctx)
+}
+
+// EC2ServiceTaskDefinitionPtrInput is an input type that accepts EC2ServiceTaskDefinitionArgs, EC2ServiceTaskDefinitionPtr and EC2ServiceTaskDefinitionPtrOutput values.
+// You can construct a concrete instance of `EC2ServiceTaskDefinitionPtrInput` via:
+//
+//          EC2ServiceTaskDefinitionArgs{...}
+//
+//  or:
+//
+//          nil
+type EC2ServiceTaskDefinitionPtrInput interface {
+	pulumi.Input
+
+	ToEC2ServiceTaskDefinitionPtrOutput() EC2ServiceTaskDefinitionPtrOutput
+	ToEC2ServiceTaskDefinitionPtrOutputWithContext(context.Context) EC2ServiceTaskDefinitionPtrOutput
+}
+
+type ec2serviceTaskDefinitionPtrType EC2ServiceTaskDefinitionArgs
+
+func EC2ServiceTaskDefinitionPtr(v *EC2ServiceTaskDefinitionArgs) EC2ServiceTaskDefinitionPtrInput {
+	return (*ec2serviceTaskDefinitionPtrType)(v)
+}
+
+func (*ec2serviceTaskDefinitionPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**EC2ServiceTaskDefinition)(nil)).Elem()
+}
+
+func (i *ec2serviceTaskDefinitionPtrType) ToEC2ServiceTaskDefinitionPtrOutput() EC2ServiceTaskDefinitionPtrOutput {
+	return i.ToEC2ServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i *ec2serviceTaskDefinitionPtrType) ToEC2ServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(EC2ServiceTaskDefinitionPtrOutput)
+}
+
+// Create a TaskDefinition resource with the given unique name, arguments, and options.
+// Creates required log-group and task & execution roles.
+// Presents required Service load balancers if target group included in port mappings.
+type EC2ServiceTaskDefinitionOutput struct{ *pulumi.OutputState }
+
+func (EC2ServiceTaskDefinitionOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*EC2ServiceTaskDefinition)(nil)).Elem()
+}
+
+func (o EC2ServiceTaskDefinitionOutput) ToEC2ServiceTaskDefinitionOutput() EC2ServiceTaskDefinitionOutput {
+	return o
+}
+
+func (o EC2ServiceTaskDefinitionOutput) ToEC2ServiceTaskDefinitionOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionOutput {
+	return o
+}
+
+func (o EC2ServiceTaskDefinitionOutput) ToEC2ServiceTaskDefinitionPtrOutput() EC2ServiceTaskDefinitionPtrOutput {
+	return o.ToEC2ServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (o EC2ServiceTaskDefinitionOutput) ToEC2ServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v EC2ServiceTaskDefinition) *EC2ServiceTaskDefinition {
+		return &v
+	}).(EC2ServiceTaskDefinitionPtrOutput)
+}
+
+// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+// multiple containers, especially when creating a TaskDefinition to call [run] on.
+//
+// Either [container] or [containers] must be provided.
+func (o EC2ServiceTaskDefinitionOutput) Container() TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *TaskDefinitionContainerDefinition { return v.Container }).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+// contain many containers within.
+//
+// Either [container] or [containers] must be provided.
+func (o EC2ServiceTaskDefinitionOutput) Containers() TaskDefinitionContainerDefinitionMapOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) map[string]TaskDefinitionContainerDefinition { return v.Containers }).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+func (o EC2ServiceTaskDefinitionOutput) Cpu() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.Cpu }).(pulumi.StringPtrOutput)
+}
+
+// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+func (o EC2ServiceTaskDefinitionOutput) EphemeralStorage() ecs.TaskDefinitionEphemeralStoragePtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *ecs.TaskDefinitionEphemeralStorage { return v.EphemeralStorage }).(ecs.TaskDefinitionEphemeralStoragePtrOutput)
+}
+
+// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+// Will be created automatically if not defined.
+func (o EC2ServiceTaskDefinitionOutput) ExecutionRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *awsx.DefaultRoleWithPolicy { return v.ExecutionRole }).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// An optional unique name for your task definition. If not specified, then a default will be created.
+func (o EC2ServiceTaskDefinitionOutput) Family() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.Family }).(pulumi.StringPtrOutput)
+}
+
+// Configuration block(s) with Inference Accelerators settings. Detailed below.
+func (o EC2ServiceTaskDefinitionOutput) InferenceAccelerators() ecs.TaskDefinitionInferenceAcceleratorArrayOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) []ecs.TaskDefinitionInferenceAccelerator {
+		return v.InferenceAccelerators
+	}).(ecs.TaskDefinitionInferenceAcceleratorArrayOutput)
+}
+
+// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+func (o EC2ServiceTaskDefinitionOutput) IpcMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.IpcMode }).(pulumi.StringPtrOutput)
+}
+
+// A set of volume blocks that containers in your task may use.
+func (o EC2ServiceTaskDefinitionOutput) LogGroup() awsx.DefaultLogGroupPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *awsx.DefaultLogGroup { return v.LogGroup }).(awsx.DefaultLogGroupPtrOutput)
+}
+
+// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+// based on the cumulative needs specified by [containerDefinitions]
+func (o EC2ServiceTaskDefinitionOutput) Memory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.Memory }).(pulumi.StringPtrOutput)
+}
+
+// Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
+func (o EC2ServiceTaskDefinitionOutput) NetworkMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.NetworkMode }).(pulumi.StringPtrOutput)
+}
+
+// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+func (o EC2ServiceTaskDefinitionOutput) PidMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *string { return v.PidMode }).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+func (o EC2ServiceTaskDefinitionOutput) PlacementConstraints() ecs.TaskDefinitionPlacementConstraintArrayOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) []ecs.TaskDefinitionPlacementConstraint {
+		return v.PlacementConstraints
+	}).(ecs.TaskDefinitionPlacementConstraintArrayOutput)
+}
+
+// Configuration block for the App Mesh proxy. Detailed below.
+func (o EC2ServiceTaskDefinitionOutput) ProxyConfiguration() ecs.TaskDefinitionProxyConfigurationPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *ecs.TaskDefinitionProxyConfiguration { return v.ProxyConfiguration }).(ecs.TaskDefinitionProxyConfigurationPtrOutput)
+}
+
+// Configuration block for runtime_platform that containers in your task may use.
+func (o EC2ServiceTaskDefinitionOutput) RuntimePlatform() ecs.TaskDefinitionRuntimePlatformPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *ecs.TaskDefinitionRuntimePlatform { return v.RuntimePlatform }).(ecs.TaskDefinitionRuntimePlatformPtrOutput)
+}
+
+func (o EC2ServiceTaskDefinitionOutput) SkipDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *bool { return v.SkipDestroy }).(pulumi.BoolPtrOutput)
+}
+
+// Key-value map of resource tags.
+func (o EC2ServiceTaskDefinitionOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+// Will be created automatically if not defined.
+func (o EC2ServiceTaskDefinitionOutput) TaskRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) *awsx.DefaultRoleWithPolicy { return v.TaskRole }).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// Configuration block for volumes that containers in your task may use. Detailed below.
+func (o EC2ServiceTaskDefinitionOutput) Volumes() ecs.TaskDefinitionVolumeArrayOutput {
+	return o.ApplyT(func(v EC2ServiceTaskDefinition) []ecs.TaskDefinitionVolume { return v.Volumes }).(ecs.TaskDefinitionVolumeArrayOutput)
+}
+
+type EC2ServiceTaskDefinitionPtrOutput struct{ *pulumi.OutputState }
+
+func (EC2ServiceTaskDefinitionPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**EC2ServiceTaskDefinition)(nil)).Elem()
+}
+
+func (o EC2ServiceTaskDefinitionPtrOutput) ToEC2ServiceTaskDefinitionPtrOutput() EC2ServiceTaskDefinitionPtrOutput {
+	return o
+}
+
+func (o EC2ServiceTaskDefinitionPtrOutput) ToEC2ServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) EC2ServiceTaskDefinitionPtrOutput {
+	return o
+}
+
+func (o EC2ServiceTaskDefinitionPtrOutput) Elem() EC2ServiceTaskDefinitionOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) EC2ServiceTaskDefinition {
+		if v != nil {
+			return *v
+		}
+		var ret EC2ServiceTaskDefinition
+		return ret
+	}).(EC2ServiceTaskDefinitionOutput)
+}
+
+// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+// multiple containers, especially when creating a TaskDefinition to call [run] on.
+//
+// Either [container] or [containers] must be provided.
+func (o EC2ServiceTaskDefinitionPtrOutput) Container() TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *TaskDefinitionContainerDefinition {
+		if v == nil {
+			return nil
+		}
+		return v.Container
+	}).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+// contain many containers within.
+//
+// Either [container] or [containers] must be provided.
+func (o EC2ServiceTaskDefinitionPtrOutput) Containers() TaskDefinitionContainerDefinitionMapOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) map[string]TaskDefinitionContainerDefinition {
+		if v == nil {
+			return nil
+		}
+		return v.Containers
+	}).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+func (o EC2ServiceTaskDefinitionPtrOutput) Cpu() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Cpu
+	}).(pulumi.StringPtrOutput)
+}
+
+// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+func (o EC2ServiceTaskDefinitionPtrOutput) EphemeralStorage() ecs.TaskDefinitionEphemeralStoragePtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *ecs.TaskDefinitionEphemeralStorage {
+		if v == nil {
+			return nil
+		}
+		return v.EphemeralStorage
+	}).(ecs.TaskDefinitionEphemeralStoragePtrOutput)
+}
+
+// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+// Will be created automatically if not defined.
+func (o EC2ServiceTaskDefinitionPtrOutput) ExecutionRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *awsx.DefaultRoleWithPolicy {
+		if v == nil {
+			return nil
+		}
+		return v.ExecutionRole
+	}).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// An optional unique name for your task definition. If not specified, then a default will be created.
+func (o EC2ServiceTaskDefinitionPtrOutput) Family() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Family
+	}).(pulumi.StringPtrOutput)
+}
+
+// Configuration block(s) with Inference Accelerators settings. Detailed below.
+func (o EC2ServiceTaskDefinitionPtrOutput) InferenceAccelerators() ecs.TaskDefinitionInferenceAcceleratorArrayOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) []ecs.TaskDefinitionInferenceAccelerator {
+		if v == nil {
+			return nil
+		}
+		return v.InferenceAccelerators
+	}).(ecs.TaskDefinitionInferenceAcceleratorArrayOutput)
+}
+
+// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+func (o EC2ServiceTaskDefinitionPtrOutput) IpcMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.IpcMode
+	}).(pulumi.StringPtrOutput)
+}
+
+// A set of volume blocks that containers in your task may use.
+func (o EC2ServiceTaskDefinitionPtrOutput) LogGroup() awsx.DefaultLogGroupPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *awsx.DefaultLogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.LogGroup
+	}).(awsx.DefaultLogGroupPtrOutput)
+}
+
+// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+// based on the cumulative needs specified by [containerDefinitions]
+func (o EC2ServiceTaskDefinitionPtrOutput) Memory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Memory
+	}).(pulumi.StringPtrOutput)
+}
+
+// Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
+func (o EC2ServiceTaskDefinitionPtrOutput) NetworkMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.NetworkMode
+	}).(pulumi.StringPtrOutput)
+}
+
+// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+func (o EC2ServiceTaskDefinitionPtrOutput) PidMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.PidMode
+	}).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+func (o EC2ServiceTaskDefinitionPtrOutput) PlacementConstraints() ecs.TaskDefinitionPlacementConstraintArrayOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) []ecs.TaskDefinitionPlacementConstraint {
+		if v == nil {
+			return nil
+		}
+		return v.PlacementConstraints
+	}).(ecs.TaskDefinitionPlacementConstraintArrayOutput)
+}
+
+// Configuration block for the App Mesh proxy. Detailed below.
+func (o EC2ServiceTaskDefinitionPtrOutput) ProxyConfiguration() ecs.TaskDefinitionProxyConfigurationPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *ecs.TaskDefinitionProxyConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.ProxyConfiguration
+	}).(ecs.TaskDefinitionProxyConfigurationPtrOutput)
+}
+
+// Configuration block for runtime_platform that containers in your task may use.
+func (o EC2ServiceTaskDefinitionPtrOutput) RuntimePlatform() ecs.TaskDefinitionRuntimePlatformPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *ecs.TaskDefinitionRuntimePlatform {
+		if v == nil {
+			return nil
+		}
+		return v.RuntimePlatform
+	}).(ecs.TaskDefinitionRuntimePlatformPtrOutput)
+}
+
+func (o EC2ServiceTaskDefinitionPtrOutput) SkipDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.SkipDestroy
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Key-value map of resource tags.
+func (o EC2ServiceTaskDefinitionPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
+// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+// Will be created automatically if not defined.
+func (o EC2ServiceTaskDefinitionPtrOutput) TaskRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) *awsx.DefaultRoleWithPolicy {
+		if v == nil {
+			return nil
+		}
+		return v.TaskRole
+	}).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// Configuration block for volumes that containers in your task may use. Detailed below.
+func (o EC2ServiceTaskDefinitionPtrOutput) Volumes() ecs.TaskDefinitionVolumeArrayOutput {
+	return o.ApplyT(func(v *EC2ServiceTaskDefinition) []ecs.TaskDefinitionVolume {
+		if v == nil {
+			return nil
+		}
+		return v.Volumes
+	}).(ecs.TaskDefinitionVolumeArrayOutput)
+}
+
 // Create a TaskDefinition resource with the given unique name, arguments, and options.
 // Creates required log-group and task & execution roles.
 // Presents required Service load balancers if target group included in port mappings.
@@ -109,6 +585,463 @@ type FargateServiceTaskDefinition struct {
 	TaskRole *awsx.DefaultRoleWithPolicy `pulumi:"taskRole"`
 	// Configuration block for volumes that containers in your task may use. Detailed below.
 	Volumes []ecs.TaskDefinitionVolume `pulumi:"volumes"`
+}
+
+// FargateServiceTaskDefinitionInput is an input type that accepts FargateServiceTaskDefinitionArgs and FargateServiceTaskDefinitionOutput values.
+// You can construct a concrete instance of `FargateServiceTaskDefinitionInput` via:
+//
+//          FargateServiceTaskDefinitionArgs{...}
+type FargateServiceTaskDefinitionInput interface {
+	pulumi.Input
+
+	ToFargateServiceTaskDefinitionOutput() FargateServiceTaskDefinitionOutput
+	ToFargateServiceTaskDefinitionOutputWithContext(context.Context) FargateServiceTaskDefinitionOutput
+}
+
+// Create a TaskDefinition resource with the given unique name, arguments, and options.
+// Creates required log-group and task & execution roles.
+// Presents required Service load balancers if target group included in port mappings.
+type FargateServiceTaskDefinitionArgs struct {
+	// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+	// multiple containers, especially when creating a TaskDefinition to call [run] on.
+	//
+	// Either [container] or [containers] must be provided.
+	Container *TaskDefinitionContainerDefinitionArgs `pulumi:"container"`
+	// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+	// contain many containers within.
+	//
+	// Either [container] or [containers] must be provided.
+	Containers map[string]TaskDefinitionContainerDefinitionArgs `pulumi:"containers"`
+	// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+	Cpu pulumi.StringPtrInput `pulumi:"cpu"`
+	// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+	EphemeralStorage ecs.TaskDefinitionEphemeralStoragePtrInput `pulumi:"ephemeralStorage"`
+	// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+	// Will be created automatically if not defined.
+	ExecutionRole *awsx.DefaultRoleWithPolicyArgs `pulumi:"executionRole"`
+	// An optional unique name for your task definition. If not specified, then a default will be created.
+	Family pulumi.StringPtrInput `pulumi:"family"`
+	// Configuration block(s) with Inference Accelerators settings. Detailed below.
+	InferenceAccelerators ecs.TaskDefinitionInferenceAcceleratorArrayInput `pulumi:"inferenceAccelerators"`
+	// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+	IpcMode pulumi.StringPtrInput `pulumi:"ipcMode"`
+	// A set of volume blocks that containers in your task may use.
+	LogGroup *awsx.DefaultLogGroupArgs `pulumi:"logGroup"`
+	// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+	// based on the cumulative needs specified by [containerDefinitions]
+	Memory pulumi.StringPtrInput `pulumi:"memory"`
+	// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+	PidMode pulumi.StringPtrInput `pulumi:"pidMode"`
+	// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+	PlacementConstraints ecs.TaskDefinitionPlacementConstraintArrayInput `pulumi:"placementConstraints"`
+	// Configuration block for the App Mesh proxy. Detailed below.
+	ProxyConfiguration ecs.TaskDefinitionProxyConfigurationPtrInput `pulumi:"proxyConfiguration"`
+	// Configuration block for runtime_platform that containers in your task may use.
+	RuntimePlatform ecs.TaskDefinitionRuntimePlatformPtrInput `pulumi:"runtimePlatform"`
+	SkipDestroy     pulumi.BoolPtrInput                       `pulumi:"skipDestroy"`
+	// Key-value map of resource tags.
+	Tags pulumi.StringMapInput `pulumi:"tags"`
+	// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+	// Will be created automatically if not defined.
+	TaskRole *awsx.DefaultRoleWithPolicyArgs `pulumi:"taskRole"`
+	// Configuration block for volumes that containers in your task may use. Detailed below.
+	Volumes ecs.TaskDefinitionVolumeArrayInput `pulumi:"volumes"`
+}
+
+func (FargateServiceTaskDefinitionArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*FargateServiceTaskDefinition)(nil)).Elem()
+}
+
+func (i FargateServiceTaskDefinitionArgs) ToFargateServiceTaskDefinitionOutput() FargateServiceTaskDefinitionOutput {
+	return i.ToFargateServiceTaskDefinitionOutputWithContext(context.Background())
+}
+
+func (i FargateServiceTaskDefinitionArgs) ToFargateServiceTaskDefinitionOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(FargateServiceTaskDefinitionOutput)
+}
+
+func (i FargateServiceTaskDefinitionArgs) ToFargateServiceTaskDefinitionPtrOutput() FargateServiceTaskDefinitionPtrOutput {
+	return i.ToFargateServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i FargateServiceTaskDefinitionArgs) ToFargateServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(FargateServiceTaskDefinitionOutput).ToFargateServiceTaskDefinitionPtrOutputWithContext(ctx)
+}
+
+// FargateServiceTaskDefinitionPtrInput is an input type that accepts FargateServiceTaskDefinitionArgs, FargateServiceTaskDefinitionPtr and FargateServiceTaskDefinitionPtrOutput values.
+// You can construct a concrete instance of `FargateServiceTaskDefinitionPtrInput` via:
+//
+//          FargateServiceTaskDefinitionArgs{...}
+//
+//  or:
+//
+//          nil
+type FargateServiceTaskDefinitionPtrInput interface {
+	pulumi.Input
+
+	ToFargateServiceTaskDefinitionPtrOutput() FargateServiceTaskDefinitionPtrOutput
+	ToFargateServiceTaskDefinitionPtrOutputWithContext(context.Context) FargateServiceTaskDefinitionPtrOutput
+}
+
+type fargateServiceTaskDefinitionPtrType FargateServiceTaskDefinitionArgs
+
+func FargateServiceTaskDefinitionPtr(v *FargateServiceTaskDefinitionArgs) FargateServiceTaskDefinitionPtrInput {
+	return (*fargateServiceTaskDefinitionPtrType)(v)
+}
+
+func (*fargateServiceTaskDefinitionPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**FargateServiceTaskDefinition)(nil)).Elem()
+}
+
+func (i *fargateServiceTaskDefinitionPtrType) ToFargateServiceTaskDefinitionPtrOutput() FargateServiceTaskDefinitionPtrOutput {
+	return i.ToFargateServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i *fargateServiceTaskDefinitionPtrType) ToFargateServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(FargateServiceTaskDefinitionPtrOutput)
+}
+
+// Create a TaskDefinition resource with the given unique name, arguments, and options.
+// Creates required log-group and task & execution roles.
+// Presents required Service load balancers if target group included in port mappings.
+type FargateServiceTaskDefinitionOutput struct{ *pulumi.OutputState }
+
+func (FargateServiceTaskDefinitionOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*FargateServiceTaskDefinition)(nil)).Elem()
+}
+
+func (o FargateServiceTaskDefinitionOutput) ToFargateServiceTaskDefinitionOutput() FargateServiceTaskDefinitionOutput {
+	return o
+}
+
+func (o FargateServiceTaskDefinitionOutput) ToFargateServiceTaskDefinitionOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionOutput {
+	return o
+}
+
+func (o FargateServiceTaskDefinitionOutput) ToFargateServiceTaskDefinitionPtrOutput() FargateServiceTaskDefinitionPtrOutput {
+	return o.ToFargateServiceTaskDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (o FargateServiceTaskDefinitionOutput) ToFargateServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v FargateServiceTaskDefinition) *FargateServiceTaskDefinition {
+		return &v
+	}).(FargateServiceTaskDefinitionPtrOutput)
+}
+
+// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+// multiple containers, especially when creating a TaskDefinition to call [run] on.
+//
+// Either [container] or [containers] must be provided.
+func (o FargateServiceTaskDefinitionOutput) Container() TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *TaskDefinitionContainerDefinition { return v.Container }).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+// contain many containers within.
+//
+// Either [container] or [containers] must be provided.
+func (o FargateServiceTaskDefinitionOutput) Containers() TaskDefinitionContainerDefinitionMapOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) map[string]TaskDefinitionContainerDefinition { return v.Containers }).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+func (o FargateServiceTaskDefinitionOutput) Cpu() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *string { return v.Cpu }).(pulumi.StringPtrOutput)
+}
+
+// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+func (o FargateServiceTaskDefinitionOutput) EphemeralStorage() ecs.TaskDefinitionEphemeralStoragePtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *ecs.TaskDefinitionEphemeralStorage { return v.EphemeralStorage }).(ecs.TaskDefinitionEphemeralStoragePtrOutput)
+}
+
+// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+// Will be created automatically if not defined.
+func (o FargateServiceTaskDefinitionOutput) ExecutionRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *awsx.DefaultRoleWithPolicy { return v.ExecutionRole }).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// An optional unique name for your task definition. If not specified, then a default will be created.
+func (o FargateServiceTaskDefinitionOutput) Family() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *string { return v.Family }).(pulumi.StringPtrOutput)
+}
+
+// Configuration block(s) with Inference Accelerators settings. Detailed below.
+func (o FargateServiceTaskDefinitionOutput) InferenceAccelerators() ecs.TaskDefinitionInferenceAcceleratorArrayOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) []ecs.TaskDefinitionInferenceAccelerator {
+		return v.InferenceAccelerators
+	}).(ecs.TaskDefinitionInferenceAcceleratorArrayOutput)
+}
+
+// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+func (o FargateServiceTaskDefinitionOutput) IpcMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *string { return v.IpcMode }).(pulumi.StringPtrOutput)
+}
+
+// A set of volume blocks that containers in your task may use.
+func (o FargateServiceTaskDefinitionOutput) LogGroup() awsx.DefaultLogGroupPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *awsx.DefaultLogGroup { return v.LogGroup }).(awsx.DefaultLogGroupPtrOutput)
+}
+
+// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+// based on the cumulative needs specified by [containerDefinitions]
+func (o FargateServiceTaskDefinitionOutput) Memory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *string { return v.Memory }).(pulumi.StringPtrOutput)
+}
+
+// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+func (o FargateServiceTaskDefinitionOutput) PidMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *string { return v.PidMode }).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+func (o FargateServiceTaskDefinitionOutput) PlacementConstraints() ecs.TaskDefinitionPlacementConstraintArrayOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) []ecs.TaskDefinitionPlacementConstraint {
+		return v.PlacementConstraints
+	}).(ecs.TaskDefinitionPlacementConstraintArrayOutput)
+}
+
+// Configuration block for the App Mesh proxy. Detailed below.
+func (o FargateServiceTaskDefinitionOutput) ProxyConfiguration() ecs.TaskDefinitionProxyConfigurationPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *ecs.TaskDefinitionProxyConfiguration {
+		return v.ProxyConfiguration
+	}).(ecs.TaskDefinitionProxyConfigurationPtrOutput)
+}
+
+// Configuration block for runtime_platform that containers in your task may use.
+func (o FargateServiceTaskDefinitionOutput) RuntimePlatform() ecs.TaskDefinitionRuntimePlatformPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *ecs.TaskDefinitionRuntimePlatform { return v.RuntimePlatform }).(ecs.TaskDefinitionRuntimePlatformPtrOutput)
+}
+
+func (o FargateServiceTaskDefinitionOutput) SkipDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *bool { return v.SkipDestroy }).(pulumi.BoolPtrOutput)
+}
+
+// Key-value map of resource tags.
+func (o FargateServiceTaskDefinitionOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) map[string]string { return v.Tags }).(pulumi.StringMapOutput)
+}
+
+// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+// Will be created automatically if not defined.
+func (o FargateServiceTaskDefinitionOutput) TaskRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) *awsx.DefaultRoleWithPolicy { return v.TaskRole }).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// Configuration block for volumes that containers in your task may use. Detailed below.
+func (o FargateServiceTaskDefinitionOutput) Volumes() ecs.TaskDefinitionVolumeArrayOutput {
+	return o.ApplyT(func(v FargateServiceTaskDefinition) []ecs.TaskDefinitionVolume { return v.Volumes }).(ecs.TaskDefinitionVolumeArrayOutput)
+}
+
+type FargateServiceTaskDefinitionPtrOutput struct{ *pulumi.OutputState }
+
+func (FargateServiceTaskDefinitionPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**FargateServiceTaskDefinition)(nil)).Elem()
+}
+
+func (o FargateServiceTaskDefinitionPtrOutput) ToFargateServiceTaskDefinitionPtrOutput() FargateServiceTaskDefinitionPtrOutput {
+	return o
+}
+
+func (o FargateServiceTaskDefinitionPtrOutput) ToFargateServiceTaskDefinitionPtrOutputWithContext(ctx context.Context) FargateServiceTaskDefinitionPtrOutput {
+	return o
+}
+
+func (o FargateServiceTaskDefinitionPtrOutput) Elem() FargateServiceTaskDefinitionOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) FargateServiceTaskDefinition {
+		if v != nil {
+			return *v
+		}
+		var ret FargateServiceTaskDefinition
+		return ret
+	}).(FargateServiceTaskDefinitionOutput)
+}
+
+// Single container to make a TaskDefinition from.  Useful for simple cases where there aren't
+// multiple containers, especially when creating a TaskDefinition to call [run] on.
+//
+// Either [container] or [containers] must be provided.
+func (o FargateServiceTaskDefinitionPtrOutput) Container() TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *TaskDefinitionContainerDefinition {
+		if v == nil {
+			return nil
+		}
+		return v.Container
+	}).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+// All the containers to make a TaskDefinition from.  Useful when creating a Service that will
+// contain many containers within.
+//
+// Either [container] or [containers] must be provided.
+func (o FargateServiceTaskDefinitionPtrOutput) Containers() TaskDefinitionContainerDefinitionMapOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) map[string]TaskDefinitionContainerDefinition {
+		if v == nil {
+			return nil
+		}
+		return v.Containers
+	}).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+// The number of cpu units used by the task. If not provided, a default will be computed based on the cumulative needs specified by [containerDefinitions]
+func (o FargateServiceTaskDefinitionPtrOutput) Cpu() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Cpu
+	}).(pulumi.StringPtrOutput)
+}
+
+// The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See Ephemeral Storage.
+func (o FargateServiceTaskDefinitionPtrOutput) EphemeralStorage() ecs.TaskDefinitionEphemeralStoragePtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *ecs.TaskDefinitionEphemeralStorage {
+		if v == nil {
+			return nil
+		}
+		return v.EphemeralStorage
+	}).(ecs.TaskDefinitionEphemeralStoragePtrOutput)
+}
+
+// The execution role that the Amazon ECS container agent and the Docker daemon can assume.
+// Will be created automatically if not defined.
+func (o FargateServiceTaskDefinitionPtrOutput) ExecutionRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *awsx.DefaultRoleWithPolicy {
+		if v == nil {
+			return nil
+		}
+		return v.ExecutionRole
+	}).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// An optional unique name for your task definition. If not specified, then a default will be created.
+func (o FargateServiceTaskDefinitionPtrOutput) Family() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Family
+	}).(pulumi.StringPtrOutput)
+}
+
+// Configuration block(s) with Inference Accelerators settings. Detailed below.
+func (o FargateServiceTaskDefinitionPtrOutput) InferenceAccelerators() ecs.TaskDefinitionInferenceAcceleratorArrayOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) []ecs.TaskDefinitionInferenceAccelerator {
+		if v == nil {
+			return nil
+		}
+		return v.InferenceAccelerators
+	}).(ecs.TaskDefinitionInferenceAcceleratorArrayOutput)
+}
+
+// IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+func (o FargateServiceTaskDefinitionPtrOutput) IpcMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.IpcMode
+	}).(pulumi.StringPtrOutput)
+}
+
+// A set of volume blocks that containers in your task may use.
+func (o FargateServiceTaskDefinitionPtrOutput) LogGroup() awsx.DefaultLogGroupPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *awsx.DefaultLogGroup {
+		if v == nil {
+			return nil
+		}
+		return v.LogGroup
+	}).(awsx.DefaultLogGroupPtrOutput)
+}
+
+// The amount (in MiB) of memory used by the task.  If not provided, a default will be computed
+// based on the cumulative needs specified by [containerDefinitions]
+func (o FargateServiceTaskDefinitionPtrOutput) Memory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Memory
+	}).(pulumi.StringPtrOutput)
+}
+
+// Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+func (o FargateServiceTaskDefinitionPtrOutput) PidMode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.PidMode
+	}).(pulumi.StringPtrOutput)
+}
+
+// Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. Detailed below.
+func (o FargateServiceTaskDefinitionPtrOutput) PlacementConstraints() ecs.TaskDefinitionPlacementConstraintArrayOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) []ecs.TaskDefinitionPlacementConstraint {
+		if v == nil {
+			return nil
+		}
+		return v.PlacementConstraints
+	}).(ecs.TaskDefinitionPlacementConstraintArrayOutput)
+}
+
+// Configuration block for the App Mesh proxy. Detailed below.
+func (o FargateServiceTaskDefinitionPtrOutput) ProxyConfiguration() ecs.TaskDefinitionProxyConfigurationPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *ecs.TaskDefinitionProxyConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.ProxyConfiguration
+	}).(ecs.TaskDefinitionProxyConfigurationPtrOutput)
+}
+
+// Configuration block for runtime_platform that containers in your task may use.
+func (o FargateServiceTaskDefinitionPtrOutput) RuntimePlatform() ecs.TaskDefinitionRuntimePlatformPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *ecs.TaskDefinitionRuntimePlatform {
+		if v == nil {
+			return nil
+		}
+		return v.RuntimePlatform
+	}).(ecs.TaskDefinitionRuntimePlatformPtrOutput)
+}
+
+func (o FargateServiceTaskDefinitionPtrOutput) SkipDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.SkipDestroy
+	}).(pulumi.BoolPtrOutput)
+}
+
+// Key-value map of resource tags.
+func (o FargateServiceTaskDefinitionPtrOutput) Tags() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.Tags
+	}).(pulumi.StringMapOutput)
+}
+
+// IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+// Will be created automatically if not defined.
+func (o FargateServiceTaskDefinitionPtrOutput) TaskRole() awsx.DefaultRoleWithPolicyPtrOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) *awsx.DefaultRoleWithPolicy {
+		if v == nil {
+			return nil
+		}
+		return v.TaskRole
+	}).(awsx.DefaultRoleWithPolicyPtrOutput)
+}
+
+// Configuration block for volumes that containers in your task may use. Detailed below.
+func (o FargateServiceTaskDefinitionPtrOutput) Volumes() ecs.TaskDefinitionVolumeArrayOutput {
+	return o.ApplyT(func(v *FargateServiceTaskDefinition) []ecs.TaskDefinitionVolume {
+		if v == nil {
+			return nil
+		}
+		return v.Volumes
+	}).(ecs.TaskDefinitionVolumeArrayOutput)
 }
 
 // List of container definitions that are passed to the Docker daemon on a container instance
@@ -160,9 +1093,836 @@ type TaskDefinitionContainerDefinition struct {
 	WorkingDirectory       *string                              `pulumi:"workingDirectory"`
 }
 
+// TaskDefinitionContainerDefinitionInput is an input type that accepts TaskDefinitionContainerDefinitionArgs and TaskDefinitionContainerDefinitionOutput values.
+// You can construct a concrete instance of `TaskDefinitionContainerDefinitionInput` via:
+//
+//          TaskDefinitionContainerDefinitionArgs{...}
+type TaskDefinitionContainerDefinitionInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionContainerDefinitionOutput() TaskDefinitionContainerDefinitionOutput
+	ToTaskDefinitionContainerDefinitionOutputWithContext(context.Context) TaskDefinitionContainerDefinitionOutput
+}
+
+// List of container definitions that are passed to the Docker daemon on a container instance
+type TaskDefinitionContainerDefinitionArgs struct {
+	Command               pulumi.StringArrayInput                     `pulumi:"command"`
+	Cpu                   pulumi.IntPtrInput                          `pulumi:"cpu"`
+	DependsOn             TaskDefinitionContainerDependencyArrayInput `pulumi:"dependsOn"`
+	DisableNetworking     pulumi.BoolPtrInput                         `pulumi:"disableNetworking"`
+	DnsSearchDomains      pulumi.StringArrayInput                     `pulumi:"dnsSearchDomains"`
+	DnsServers            pulumi.StringArrayInput                     `pulumi:"dnsServers"`
+	DockerLabels          pulumi.Input                                `pulumi:"dockerLabels"`
+	DockerSecurityOptions pulumi.StringArrayInput                     `pulumi:"dockerSecurityOptions"`
+	EntryPoint            pulumi.StringArrayInput                     `pulumi:"entryPoint"`
+	// The environment variables to pass to a container
+	Environment TaskDefinitionKeyValuePairArrayInput `pulumi:"environment"`
+	// The list of one or more files that contain the environment variables to pass to a container
+	EnvironmentFiles      TaskDefinitionEnvironmentFileArrayInput     `pulumi:"environmentFiles"`
+	Essential             pulumi.BoolPtrInput                         `pulumi:"essential"`
+	ExtraHosts            TaskDefinitionHostEntryArrayInput           `pulumi:"extraHosts"`
+	FirelensConfiguration TaskDefinitionFirelensConfigurationPtrInput `pulumi:"firelensConfiguration"`
+	HealthCheck           TaskDefinitionHealthCheckPtrInput           `pulumi:"healthCheck"`
+	Hostname              pulumi.StringPtrInput                       `pulumi:"hostname"`
+	// The image used to start a container. This string is passed directly to the Docker daemon.
+	Image            pulumi.StringPtrInput                  `pulumi:"image"`
+	Interactive      pulumi.BoolPtrInput                    `pulumi:"interactive"`
+	Links            pulumi.StringArrayInput                `pulumi:"links"`
+	LinuxParameters  TaskDefinitionLinuxParametersPtrInput  `pulumi:"linuxParameters"`
+	LogConfiguration TaskDefinitionLogConfigurationPtrInput `pulumi:"logConfiguration"`
+	// The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.
+	Memory            pulumi.IntPtrInput                 `pulumi:"memory"`
+	MemoryReservation pulumi.IntPtrInput                 `pulumi:"memoryReservation"`
+	MountPoints       TaskDefinitionMountPointArrayInput `pulumi:"mountPoints"`
+	// The name of a container. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed
+	Name pulumi.StringPtrInput `pulumi:"name"`
+	// Port mappings allow containers to access ports on the host container instance to send or receive traffic.
+	PortMappings           TaskDefinitionPortMappingArrayInput         `pulumi:"portMappings"`
+	Privileged             pulumi.BoolPtrInput                         `pulumi:"privileged"`
+	PseudoTerminal         pulumi.BoolPtrInput                         `pulumi:"pseudoTerminal"`
+	ReadonlyRootFilesystem pulumi.BoolPtrInput                         `pulumi:"readonlyRootFilesystem"`
+	RepositoryCredentials  TaskDefinitionRepositoryCredentialsPtrInput `pulumi:"repositoryCredentials"`
+	ResourceRequirements   TaskDefinitionResourceRequirementArrayInput `pulumi:"resourceRequirements"`
+	Secrets                TaskDefinitionSecretArrayInput              `pulumi:"secrets"`
+	StartTimeout           pulumi.IntPtrInput                          `pulumi:"startTimeout"`
+	StopTimeout            pulumi.IntPtrInput                          `pulumi:"stopTimeout"`
+	SystemControls         TaskDefinitionSystemControlArrayInput       `pulumi:"systemControls"`
+	Ulimits                TaskDefinitionUlimitArrayInput              `pulumi:"ulimits"`
+	User                   pulumi.StringPtrInput                       `pulumi:"user"`
+	VolumesFrom            TaskDefinitionVolumeFromArrayInput          `pulumi:"volumesFrom"`
+	WorkingDirectory       pulumi.StringPtrInput                       `pulumi:"workingDirectory"`
+}
+
+func (TaskDefinitionContainerDefinitionArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionOutput() TaskDefinitionContainerDefinitionOutput {
+	return i.ToTaskDefinitionContainerDefinitionOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionOutput)
+}
+
+func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput {
+	return i.ToTaskDefinitionContainerDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionOutput).ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionContainerDefinitionPtrInput is an input type that accepts TaskDefinitionContainerDefinitionArgs, TaskDefinitionContainerDefinitionPtr and TaskDefinitionContainerDefinitionPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionContainerDefinitionPtrInput` via:
+//
+//          TaskDefinitionContainerDefinitionArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionContainerDefinitionPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput
+	ToTaskDefinitionContainerDefinitionPtrOutputWithContext(context.Context) TaskDefinitionContainerDefinitionPtrOutput
+}
+
+type taskDefinitionContainerDefinitionPtrType TaskDefinitionContainerDefinitionArgs
+
+func TaskDefinitionContainerDefinitionPtr(v *TaskDefinitionContainerDefinitionArgs) TaskDefinitionContainerDefinitionPtrInput {
+	return (*taskDefinitionContainerDefinitionPtrType)(v)
+}
+
+func (*taskDefinitionContainerDefinitionPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (i *taskDefinitionContainerDefinitionPtrType) ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput {
+	return i.ToTaskDefinitionContainerDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionContainerDefinitionPtrType) ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+// TaskDefinitionContainerDefinitionMapInput is an input type that accepts TaskDefinitionContainerDefinitionMap and TaskDefinitionContainerDefinitionMapOutput values.
+// You can construct a concrete instance of `TaskDefinitionContainerDefinitionMapInput` via:
+//
+//          TaskDefinitionContainerDefinitionMap{ "key": TaskDefinitionContainerDefinitionArgs{...} }
+type TaskDefinitionContainerDefinitionMapInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionContainerDefinitionMapOutput() TaskDefinitionContainerDefinitionMapOutput
+	ToTaskDefinitionContainerDefinitionMapOutputWithContext(context.Context) TaskDefinitionContainerDefinitionMapOutput
+}
+
+type TaskDefinitionContainerDefinitionMap map[string]TaskDefinitionContainerDefinitionInput
+
+func (TaskDefinitionContainerDefinitionMap) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (i TaskDefinitionContainerDefinitionMap) ToTaskDefinitionContainerDefinitionMapOutput() TaskDefinitionContainerDefinitionMapOutput {
+	return i.ToTaskDefinitionContainerDefinitionMapOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionContainerDefinitionMap) ToTaskDefinitionContainerDefinitionMapOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionMapOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDefinitionMapOutput)
+}
+
+// List of container definitions that are passed to the Docker daemon on a container instance
+type TaskDefinitionContainerDefinitionOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionContainerDefinitionOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ToTaskDefinitionContainerDefinitionOutput() TaskDefinitionContainerDefinitionOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ToTaskDefinitionContainerDefinitionOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ToTaskDefinitionContainerDefinitionPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionContainerDefinition) *TaskDefinitionContainerDefinition {
+		return &v
+	}).(TaskDefinitionContainerDefinitionPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Command() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.Command }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Cpu() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *int { return v.Cpu }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DependsOn() TaskDefinitionContainerDependencyArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionContainerDependency { return v.DependsOn }).(TaskDefinitionContainerDependencyArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DisableNetworking() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.DisableNetworking }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DnsSearchDomains() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.DnsSearchDomains }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DnsServers() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.DnsServers }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DockerLabels() pulumi.AnyOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) interface{} { return v.DockerLabels }).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) DockerSecurityOptions() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.DockerSecurityOptions }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) EntryPoint() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.EntryPoint }).(pulumi.StringArrayOutput)
+}
+
+// The environment variables to pass to a container
+func (o TaskDefinitionContainerDefinitionOutput) Environment() TaskDefinitionKeyValuePairArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionKeyValuePair { return v.Environment }).(TaskDefinitionKeyValuePairArrayOutput)
+}
+
+// The list of one or more files that contain the environment variables to pass to a container
+func (o TaskDefinitionContainerDefinitionOutput) EnvironmentFiles() TaskDefinitionEnvironmentFileArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionEnvironmentFile { return v.EnvironmentFiles }).(TaskDefinitionEnvironmentFileArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Essential() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.Essential }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ExtraHosts() TaskDefinitionHostEntryArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionHostEntry { return v.ExtraHosts }).(TaskDefinitionHostEntryArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) FirelensConfiguration() TaskDefinitionFirelensConfigurationPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *TaskDefinitionFirelensConfiguration {
+		return v.FirelensConfiguration
+	}).(TaskDefinitionFirelensConfigurationPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) HealthCheck() TaskDefinitionHealthCheckPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *TaskDefinitionHealthCheck { return v.HealthCheck }).(TaskDefinitionHealthCheckPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Hostname() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *string { return v.Hostname }).(pulumi.StringPtrOutput)
+}
+
+// The image used to start a container. This string is passed directly to the Docker daemon.
+func (o TaskDefinitionContainerDefinitionOutput) Image() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *string { return v.Image }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Interactive() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.Interactive }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Links() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []string { return v.Links }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) LinuxParameters() TaskDefinitionLinuxParametersPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *TaskDefinitionLinuxParameters { return v.LinuxParameters }).(TaskDefinitionLinuxParametersPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) LogConfiguration() TaskDefinitionLogConfigurationPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *TaskDefinitionLogConfiguration { return v.LogConfiguration }).(TaskDefinitionLogConfigurationPtrOutput)
+}
+
+// The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.
+func (o TaskDefinitionContainerDefinitionOutput) Memory() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *int { return v.Memory }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) MemoryReservation() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *int { return v.MemoryReservation }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) MountPoints() TaskDefinitionMountPointArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionMountPoint { return v.MountPoints }).(TaskDefinitionMountPointArrayOutput)
+}
+
+// The name of a container. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed
+func (o TaskDefinitionContainerDefinitionOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+// Port mappings allow containers to access ports on the host container instance to send or receive traffic.
+func (o TaskDefinitionContainerDefinitionOutput) PortMappings() TaskDefinitionPortMappingArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionPortMapping { return v.PortMappings }).(TaskDefinitionPortMappingArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Privileged() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.Privileged }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) PseudoTerminal() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.PseudoTerminal }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ReadonlyRootFilesystem() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *bool { return v.ReadonlyRootFilesystem }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) RepositoryCredentials() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *TaskDefinitionRepositoryCredentials {
+		return v.RepositoryCredentials
+	}).(TaskDefinitionRepositoryCredentialsPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) ResourceRequirements() TaskDefinitionResourceRequirementArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionResourceRequirement {
+		return v.ResourceRequirements
+	}).(TaskDefinitionResourceRequirementArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Secrets() TaskDefinitionSecretArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionSecret { return v.Secrets }).(TaskDefinitionSecretArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) StartTimeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *int { return v.StartTimeout }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) StopTimeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *int { return v.StopTimeout }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) SystemControls() TaskDefinitionSystemControlArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionSystemControl { return v.SystemControls }).(TaskDefinitionSystemControlArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) Ulimits() TaskDefinitionUlimitArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionUlimit { return v.Ulimits }).(TaskDefinitionUlimitArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) User() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *string { return v.User }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) VolumesFrom() TaskDefinitionVolumeFromArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) []TaskDefinitionVolumeFrom { return v.VolumesFrom }).(TaskDefinitionVolumeFromArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionOutput) WorkingDirectory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDefinition) *string { return v.WorkingDirectory }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionContainerDefinitionPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionContainerDefinitionPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ToTaskDefinitionContainerDefinitionPtrOutput() TaskDefinitionContainerDefinitionPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ToTaskDefinitionContainerDefinitionPtrOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Elem() TaskDefinitionContainerDefinitionOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) TaskDefinitionContainerDefinition {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionContainerDefinition
+		return ret
+	}).(TaskDefinitionContainerDefinitionOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Command() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Command
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Cpu() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Cpu
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DependsOn() TaskDefinitionContainerDependencyArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionContainerDependency {
+		if v == nil {
+			return nil
+		}
+		return v.DependsOn
+	}).(TaskDefinitionContainerDependencyArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DisableNetworking() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.DisableNetworking
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DnsSearchDomains() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.DnsSearchDomains
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DnsServers() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.DnsServers
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DockerLabels() pulumi.AnyOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) interface{} {
+		if v == nil {
+			return nil
+		}
+		return v.DockerLabels
+	}).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) DockerSecurityOptions() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.DockerSecurityOptions
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) EntryPoint() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.EntryPoint
+	}).(pulumi.StringArrayOutput)
+}
+
+// The environment variables to pass to a container
+func (o TaskDefinitionContainerDefinitionPtrOutput) Environment() TaskDefinitionKeyValuePairArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionKeyValuePair {
+		if v == nil {
+			return nil
+		}
+		return v.Environment
+	}).(TaskDefinitionKeyValuePairArrayOutput)
+}
+
+// The list of one or more files that contain the environment variables to pass to a container
+func (o TaskDefinitionContainerDefinitionPtrOutput) EnvironmentFiles() TaskDefinitionEnvironmentFileArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionEnvironmentFile {
+		if v == nil {
+			return nil
+		}
+		return v.EnvironmentFiles
+	}).(TaskDefinitionEnvironmentFileArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Essential() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Essential
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ExtraHosts() TaskDefinitionHostEntryArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionHostEntry {
+		if v == nil {
+			return nil
+		}
+		return v.ExtraHosts
+	}).(TaskDefinitionHostEntryArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) FirelensConfiguration() TaskDefinitionFirelensConfigurationPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *TaskDefinitionFirelensConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.FirelensConfiguration
+	}).(TaskDefinitionFirelensConfigurationPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) HealthCheck() TaskDefinitionHealthCheckPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *TaskDefinitionHealthCheck {
+		if v == nil {
+			return nil
+		}
+		return v.HealthCheck
+	}).(TaskDefinitionHealthCheckPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Hostname() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Hostname
+	}).(pulumi.StringPtrOutput)
+}
+
+// The image used to start a container. This string is passed directly to the Docker daemon.
+func (o TaskDefinitionContainerDefinitionPtrOutput) Image() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Image
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Interactive() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Interactive
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Links() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Links
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) LinuxParameters() TaskDefinitionLinuxParametersPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *TaskDefinitionLinuxParameters {
+		if v == nil {
+			return nil
+		}
+		return v.LinuxParameters
+	}).(TaskDefinitionLinuxParametersPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) LogConfiguration() TaskDefinitionLogConfigurationPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *TaskDefinitionLogConfiguration {
+		if v == nil {
+			return nil
+		}
+		return v.LogConfiguration
+	}).(TaskDefinitionLogConfigurationPtrOutput)
+}
+
+// The amount (in MiB) of memory to present to the container. If your container attempts to exceed the memory specified here, the container is killed.
+func (o TaskDefinitionContainerDefinitionPtrOutput) Memory() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Memory
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) MemoryReservation() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *int {
+		if v == nil {
+			return nil
+		}
+		return v.MemoryReservation
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) MountPoints() TaskDefinitionMountPointArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionMountPoint {
+		if v == nil {
+			return nil
+		}
+		return v.MountPoints
+	}).(TaskDefinitionMountPointArrayOutput)
+}
+
+// The name of a container. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed
+func (o TaskDefinitionContainerDefinitionPtrOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Name
+	}).(pulumi.StringPtrOutput)
+}
+
+// Port mappings allow containers to access ports on the host container instance to send or receive traffic.
+func (o TaskDefinitionContainerDefinitionPtrOutput) PortMappings() TaskDefinitionPortMappingArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionPortMapping {
+		if v == nil {
+			return nil
+		}
+		return v.PortMappings
+	}).(TaskDefinitionPortMappingArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Privileged() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.Privileged
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) PseudoTerminal() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.PseudoTerminal
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ReadonlyRootFilesystem() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.ReadonlyRootFilesystem
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) RepositoryCredentials() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *TaskDefinitionRepositoryCredentials {
+		if v == nil {
+			return nil
+		}
+		return v.RepositoryCredentials
+	}).(TaskDefinitionRepositoryCredentialsPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) ResourceRequirements() TaskDefinitionResourceRequirementArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionResourceRequirement {
+		if v == nil {
+			return nil
+		}
+		return v.ResourceRequirements
+	}).(TaskDefinitionResourceRequirementArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Secrets() TaskDefinitionSecretArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionSecret {
+		if v == nil {
+			return nil
+		}
+		return v.Secrets
+	}).(TaskDefinitionSecretArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) StartTimeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *int {
+		if v == nil {
+			return nil
+		}
+		return v.StartTimeout
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) StopTimeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *int {
+		if v == nil {
+			return nil
+		}
+		return v.StopTimeout
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) SystemControls() TaskDefinitionSystemControlArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionSystemControl {
+		if v == nil {
+			return nil
+		}
+		return v.SystemControls
+	}).(TaskDefinitionSystemControlArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) Ulimits() TaskDefinitionUlimitArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionUlimit {
+		if v == nil {
+			return nil
+		}
+		return v.Ulimits
+	}).(TaskDefinitionUlimitArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) User() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.User
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) VolumesFrom() TaskDefinitionVolumeFromArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) []TaskDefinitionVolumeFrom {
+		if v == nil {
+			return nil
+		}
+		return v.VolumesFrom
+	}).(TaskDefinitionVolumeFromArrayOutput)
+}
+
+func (o TaskDefinitionContainerDefinitionPtrOutput) WorkingDirectory() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionContainerDefinition) *string {
+		if v == nil {
+			return nil
+		}
+		return v.WorkingDirectory
+	}).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionContainerDefinitionMapOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionContainerDefinitionMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]TaskDefinitionContainerDefinition)(nil)).Elem()
+}
+
+func (o TaskDefinitionContainerDefinitionMapOutput) ToTaskDefinitionContainerDefinitionMapOutput() TaskDefinitionContainerDefinitionMapOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionMapOutput) ToTaskDefinitionContainerDefinitionMapOutputWithContext(ctx context.Context) TaskDefinitionContainerDefinitionMapOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDefinitionMapOutput) MapIndex(k pulumi.StringInput) TaskDefinitionContainerDefinitionOutput {
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) TaskDefinitionContainerDefinition {
+		return vs[0].(map[string]TaskDefinitionContainerDefinition)[vs[1].(string)]
+	}).(TaskDefinitionContainerDefinitionOutput)
+}
+
 type TaskDefinitionContainerDependency struct {
 	Condition     *string `pulumi:"condition"`
 	ContainerName *string `pulumi:"containerName"`
+}
+
+// TaskDefinitionContainerDependencyInput is an input type that accepts TaskDefinitionContainerDependencyArgs and TaskDefinitionContainerDependencyOutput values.
+// You can construct a concrete instance of `TaskDefinitionContainerDependencyInput` via:
+//
+//          TaskDefinitionContainerDependencyArgs{...}
+type TaskDefinitionContainerDependencyInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionContainerDependencyOutput() TaskDefinitionContainerDependencyOutput
+	ToTaskDefinitionContainerDependencyOutputWithContext(context.Context) TaskDefinitionContainerDependencyOutput
+}
+
+type TaskDefinitionContainerDependencyArgs struct {
+	Condition     pulumi.StringPtrInput `pulumi:"condition"`
+	ContainerName pulumi.StringPtrInput `pulumi:"containerName"`
+}
+
+func (TaskDefinitionContainerDependencyArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionContainerDependency)(nil)).Elem()
+}
+
+func (i TaskDefinitionContainerDependencyArgs) ToTaskDefinitionContainerDependencyOutput() TaskDefinitionContainerDependencyOutput {
+	return i.ToTaskDefinitionContainerDependencyOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionContainerDependencyArgs) ToTaskDefinitionContainerDependencyOutputWithContext(ctx context.Context) TaskDefinitionContainerDependencyOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDependencyOutput)
+}
+
+// TaskDefinitionContainerDependencyArrayInput is an input type that accepts TaskDefinitionContainerDependencyArray and TaskDefinitionContainerDependencyArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionContainerDependencyArrayInput` via:
+//
+//          TaskDefinitionContainerDependencyArray{ TaskDefinitionContainerDependencyArgs{...} }
+type TaskDefinitionContainerDependencyArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionContainerDependencyArrayOutput() TaskDefinitionContainerDependencyArrayOutput
+	ToTaskDefinitionContainerDependencyArrayOutputWithContext(context.Context) TaskDefinitionContainerDependencyArrayOutput
+}
+
+type TaskDefinitionContainerDependencyArray []TaskDefinitionContainerDependencyInput
+
+func (TaskDefinitionContainerDependencyArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionContainerDependency)(nil)).Elem()
+}
+
+func (i TaskDefinitionContainerDependencyArray) ToTaskDefinitionContainerDependencyArrayOutput() TaskDefinitionContainerDependencyArrayOutput {
+	return i.ToTaskDefinitionContainerDependencyArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionContainerDependencyArray) ToTaskDefinitionContainerDependencyArrayOutputWithContext(ctx context.Context) TaskDefinitionContainerDependencyArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionContainerDependencyArrayOutput)
+}
+
+type TaskDefinitionContainerDependencyOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionContainerDependencyOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionContainerDependency)(nil)).Elem()
+}
+
+func (o TaskDefinitionContainerDependencyOutput) ToTaskDefinitionContainerDependencyOutput() TaskDefinitionContainerDependencyOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDependencyOutput) ToTaskDefinitionContainerDependencyOutputWithContext(ctx context.Context) TaskDefinitionContainerDependencyOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDependencyOutput) Condition() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDependency) *string { return v.Condition }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionContainerDependencyOutput) ContainerName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionContainerDependency) *string { return v.ContainerName }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionContainerDependencyArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionContainerDependencyArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionContainerDependency)(nil)).Elem()
+}
+
+func (o TaskDefinitionContainerDependencyArrayOutput) ToTaskDefinitionContainerDependencyArrayOutput() TaskDefinitionContainerDependencyArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDependencyArrayOutput) ToTaskDefinitionContainerDependencyArrayOutputWithContext(ctx context.Context) TaskDefinitionContainerDependencyArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionContainerDependencyArrayOutput) Index(i pulumi.IntInput) TaskDefinitionContainerDependencyOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionContainerDependency {
+		return vs[0].([]TaskDefinitionContainerDependency)[vs[1].(int)]
+	}).(TaskDefinitionContainerDependencyOutput)
 }
 
 type TaskDefinitionDevice struct {
@@ -171,14 +1931,352 @@ type TaskDefinitionDevice struct {
 	Permissions   []string `pulumi:"permissions"`
 }
 
+// TaskDefinitionDeviceInput is an input type that accepts TaskDefinitionDeviceArgs and TaskDefinitionDeviceOutput values.
+// You can construct a concrete instance of `TaskDefinitionDeviceInput` via:
+//
+//          TaskDefinitionDeviceArgs{...}
+type TaskDefinitionDeviceInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionDeviceOutput() TaskDefinitionDeviceOutput
+	ToTaskDefinitionDeviceOutputWithContext(context.Context) TaskDefinitionDeviceOutput
+}
+
+type TaskDefinitionDeviceArgs struct {
+	ContainerPath pulumi.StringPtrInput   `pulumi:"containerPath"`
+	HostPath      pulumi.StringPtrInput   `pulumi:"hostPath"`
+	Permissions   pulumi.StringArrayInput `pulumi:"permissions"`
+}
+
+func (TaskDefinitionDeviceArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionDevice)(nil)).Elem()
+}
+
+func (i TaskDefinitionDeviceArgs) ToTaskDefinitionDeviceOutput() TaskDefinitionDeviceOutput {
+	return i.ToTaskDefinitionDeviceOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionDeviceArgs) ToTaskDefinitionDeviceOutputWithContext(ctx context.Context) TaskDefinitionDeviceOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionDeviceOutput)
+}
+
+// TaskDefinitionDeviceArrayInput is an input type that accepts TaskDefinitionDeviceArray and TaskDefinitionDeviceArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionDeviceArrayInput` via:
+//
+//          TaskDefinitionDeviceArray{ TaskDefinitionDeviceArgs{...} }
+type TaskDefinitionDeviceArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionDeviceArrayOutput() TaskDefinitionDeviceArrayOutput
+	ToTaskDefinitionDeviceArrayOutputWithContext(context.Context) TaskDefinitionDeviceArrayOutput
+}
+
+type TaskDefinitionDeviceArray []TaskDefinitionDeviceInput
+
+func (TaskDefinitionDeviceArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionDevice)(nil)).Elem()
+}
+
+func (i TaskDefinitionDeviceArray) ToTaskDefinitionDeviceArrayOutput() TaskDefinitionDeviceArrayOutput {
+	return i.ToTaskDefinitionDeviceArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionDeviceArray) ToTaskDefinitionDeviceArrayOutputWithContext(ctx context.Context) TaskDefinitionDeviceArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionDeviceArrayOutput)
+}
+
+type TaskDefinitionDeviceOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionDeviceOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionDevice)(nil)).Elem()
+}
+
+func (o TaskDefinitionDeviceOutput) ToTaskDefinitionDeviceOutput() TaskDefinitionDeviceOutput {
+	return o
+}
+
+func (o TaskDefinitionDeviceOutput) ToTaskDefinitionDeviceOutputWithContext(ctx context.Context) TaskDefinitionDeviceOutput {
+	return o
+}
+
+func (o TaskDefinitionDeviceOutput) ContainerPath() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionDevice) *string { return v.ContainerPath }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionDeviceOutput) HostPath() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionDevice) *string { return v.HostPath }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionDeviceOutput) Permissions() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionDevice) []string { return v.Permissions }).(pulumi.StringArrayOutput)
+}
+
+type TaskDefinitionDeviceArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionDeviceArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionDevice)(nil)).Elem()
+}
+
+func (o TaskDefinitionDeviceArrayOutput) ToTaskDefinitionDeviceArrayOutput() TaskDefinitionDeviceArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionDeviceArrayOutput) ToTaskDefinitionDeviceArrayOutputWithContext(ctx context.Context) TaskDefinitionDeviceArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionDeviceArrayOutput) Index(i pulumi.IntInput) TaskDefinitionDeviceOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionDevice {
+		return vs[0].([]TaskDefinitionDevice)[vs[1].(int)]
+	}).(TaskDefinitionDeviceOutput)
+}
+
 type TaskDefinitionEnvironmentFile struct {
 	Type  *string `pulumi:"type"`
 	Value *string `pulumi:"value"`
 }
 
+// TaskDefinitionEnvironmentFileInput is an input type that accepts TaskDefinitionEnvironmentFileArgs and TaskDefinitionEnvironmentFileOutput values.
+// You can construct a concrete instance of `TaskDefinitionEnvironmentFileInput` via:
+//
+//          TaskDefinitionEnvironmentFileArgs{...}
+type TaskDefinitionEnvironmentFileInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionEnvironmentFileOutput() TaskDefinitionEnvironmentFileOutput
+	ToTaskDefinitionEnvironmentFileOutputWithContext(context.Context) TaskDefinitionEnvironmentFileOutput
+}
+
+type TaskDefinitionEnvironmentFileArgs struct {
+	Type  pulumi.StringPtrInput `pulumi:"type"`
+	Value pulumi.StringPtrInput `pulumi:"value"`
+}
+
+func (TaskDefinitionEnvironmentFileArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionEnvironmentFile)(nil)).Elem()
+}
+
+func (i TaskDefinitionEnvironmentFileArgs) ToTaskDefinitionEnvironmentFileOutput() TaskDefinitionEnvironmentFileOutput {
+	return i.ToTaskDefinitionEnvironmentFileOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionEnvironmentFileArgs) ToTaskDefinitionEnvironmentFileOutputWithContext(ctx context.Context) TaskDefinitionEnvironmentFileOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionEnvironmentFileOutput)
+}
+
+// TaskDefinitionEnvironmentFileArrayInput is an input type that accepts TaskDefinitionEnvironmentFileArray and TaskDefinitionEnvironmentFileArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionEnvironmentFileArrayInput` via:
+//
+//          TaskDefinitionEnvironmentFileArray{ TaskDefinitionEnvironmentFileArgs{...} }
+type TaskDefinitionEnvironmentFileArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionEnvironmentFileArrayOutput() TaskDefinitionEnvironmentFileArrayOutput
+	ToTaskDefinitionEnvironmentFileArrayOutputWithContext(context.Context) TaskDefinitionEnvironmentFileArrayOutput
+}
+
+type TaskDefinitionEnvironmentFileArray []TaskDefinitionEnvironmentFileInput
+
+func (TaskDefinitionEnvironmentFileArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionEnvironmentFile)(nil)).Elem()
+}
+
+func (i TaskDefinitionEnvironmentFileArray) ToTaskDefinitionEnvironmentFileArrayOutput() TaskDefinitionEnvironmentFileArrayOutput {
+	return i.ToTaskDefinitionEnvironmentFileArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionEnvironmentFileArray) ToTaskDefinitionEnvironmentFileArrayOutputWithContext(ctx context.Context) TaskDefinitionEnvironmentFileArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionEnvironmentFileArrayOutput)
+}
+
+type TaskDefinitionEnvironmentFileOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionEnvironmentFileOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionEnvironmentFile)(nil)).Elem()
+}
+
+func (o TaskDefinitionEnvironmentFileOutput) ToTaskDefinitionEnvironmentFileOutput() TaskDefinitionEnvironmentFileOutput {
+	return o
+}
+
+func (o TaskDefinitionEnvironmentFileOutput) ToTaskDefinitionEnvironmentFileOutputWithContext(ctx context.Context) TaskDefinitionEnvironmentFileOutput {
+	return o
+}
+
+func (o TaskDefinitionEnvironmentFileOutput) Type() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionEnvironmentFile) *string { return v.Type }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionEnvironmentFileOutput) Value() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionEnvironmentFile) *string { return v.Value }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionEnvironmentFileArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionEnvironmentFileArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionEnvironmentFile)(nil)).Elem()
+}
+
+func (o TaskDefinitionEnvironmentFileArrayOutput) ToTaskDefinitionEnvironmentFileArrayOutput() TaskDefinitionEnvironmentFileArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionEnvironmentFileArrayOutput) ToTaskDefinitionEnvironmentFileArrayOutputWithContext(ctx context.Context) TaskDefinitionEnvironmentFileArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionEnvironmentFileArrayOutput) Index(i pulumi.IntInput) TaskDefinitionEnvironmentFileOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionEnvironmentFile {
+		return vs[0].([]TaskDefinitionEnvironmentFile)[vs[1].(int)]
+	}).(TaskDefinitionEnvironmentFileOutput)
+}
+
 type TaskDefinitionFirelensConfiguration struct {
 	Options interface{} `pulumi:"options"`
 	Type    *string     `pulumi:"type"`
+}
+
+// TaskDefinitionFirelensConfigurationInput is an input type that accepts TaskDefinitionFirelensConfigurationArgs and TaskDefinitionFirelensConfigurationOutput values.
+// You can construct a concrete instance of `TaskDefinitionFirelensConfigurationInput` via:
+//
+//          TaskDefinitionFirelensConfigurationArgs{...}
+type TaskDefinitionFirelensConfigurationInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionFirelensConfigurationOutput() TaskDefinitionFirelensConfigurationOutput
+	ToTaskDefinitionFirelensConfigurationOutputWithContext(context.Context) TaskDefinitionFirelensConfigurationOutput
+}
+
+type TaskDefinitionFirelensConfigurationArgs struct {
+	Options pulumi.Input          `pulumi:"options"`
+	Type    pulumi.StringPtrInput `pulumi:"type"`
+}
+
+func (TaskDefinitionFirelensConfigurationArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionFirelensConfiguration)(nil)).Elem()
+}
+
+func (i TaskDefinitionFirelensConfigurationArgs) ToTaskDefinitionFirelensConfigurationOutput() TaskDefinitionFirelensConfigurationOutput {
+	return i.ToTaskDefinitionFirelensConfigurationOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionFirelensConfigurationArgs) ToTaskDefinitionFirelensConfigurationOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionFirelensConfigurationOutput)
+}
+
+func (i TaskDefinitionFirelensConfigurationArgs) ToTaskDefinitionFirelensConfigurationPtrOutput() TaskDefinitionFirelensConfigurationPtrOutput {
+	return i.ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionFirelensConfigurationArgs) ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionFirelensConfigurationOutput).ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionFirelensConfigurationPtrInput is an input type that accepts TaskDefinitionFirelensConfigurationArgs, TaskDefinitionFirelensConfigurationPtr and TaskDefinitionFirelensConfigurationPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionFirelensConfigurationPtrInput` via:
+//
+//          TaskDefinitionFirelensConfigurationArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionFirelensConfigurationPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionFirelensConfigurationPtrOutput() TaskDefinitionFirelensConfigurationPtrOutput
+	ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(context.Context) TaskDefinitionFirelensConfigurationPtrOutput
+}
+
+type taskDefinitionFirelensConfigurationPtrType TaskDefinitionFirelensConfigurationArgs
+
+func TaskDefinitionFirelensConfigurationPtr(v *TaskDefinitionFirelensConfigurationArgs) TaskDefinitionFirelensConfigurationPtrInput {
+	return (*taskDefinitionFirelensConfigurationPtrType)(v)
+}
+
+func (*taskDefinitionFirelensConfigurationPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionFirelensConfiguration)(nil)).Elem()
+}
+
+func (i *taskDefinitionFirelensConfigurationPtrType) ToTaskDefinitionFirelensConfigurationPtrOutput() TaskDefinitionFirelensConfigurationPtrOutput {
+	return i.ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionFirelensConfigurationPtrType) ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionFirelensConfigurationPtrOutput)
+}
+
+type TaskDefinitionFirelensConfigurationOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionFirelensConfigurationOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionFirelensConfiguration)(nil)).Elem()
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) ToTaskDefinitionFirelensConfigurationOutput() TaskDefinitionFirelensConfigurationOutput {
+	return o
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) ToTaskDefinitionFirelensConfigurationOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationOutput {
+	return o
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) ToTaskDefinitionFirelensConfigurationPtrOutput() TaskDefinitionFirelensConfigurationPtrOutput {
+	return o.ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionFirelensConfiguration) *TaskDefinitionFirelensConfiguration {
+		return &v
+	}).(TaskDefinitionFirelensConfigurationPtrOutput)
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) Options() pulumi.AnyOutput {
+	return o.ApplyT(func(v TaskDefinitionFirelensConfiguration) interface{} { return v.Options }).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionFirelensConfigurationOutput) Type() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionFirelensConfiguration) *string { return v.Type }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionFirelensConfigurationPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionFirelensConfigurationPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionFirelensConfiguration)(nil)).Elem()
+}
+
+func (o TaskDefinitionFirelensConfigurationPtrOutput) ToTaskDefinitionFirelensConfigurationPtrOutput() TaskDefinitionFirelensConfigurationPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionFirelensConfigurationPtrOutput) ToTaskDefinitionFirelensConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionFirelensConfigurationPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionFirelensConfigurationPtrOutput) Elem() TaskDefinitionFirelensConfigurationOutput {
+	return o.ApplyT(func(v *TaskDefinitionFirelensConfiguration) TaskDefinitionFirelensConfiguration {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionFirelensConfiguration
+		return ret
+	}).(TaskDefinitionFirelensConfigurationOutput)
+}
+
+func (o TaskDefinitionFirelensConfigurationPtrOutput) Options() pulumi.AnyOutput {
+	return o.ApplyT(func(v *TaskDefinitionFirelensConfiguration) interface{} {
+		if v == nil {
+			return nil
+		}
+		return v.Options
+	}).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionFirelensConfigurationPtrOutput) Type() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionFirelensConfiguration) *string {
+		if v == nil {
+			return nil
+		}
+		return v.Type
+	}).(pulumi.StringPtrOutput)
 }
 
 // The health check command and associated configuration parameters for the container.
@@ -195,9 +2293,306 @@ type TaskDefinitionHealthCheck struct {
 	Timeout *int `pulumi:"timeout"`
 }
 
+// TaskDefinitionHealthCheckInput is an input type that accepts TaskDefinitionHealthCheckArgs and TaskDefinitionHealthCheckOutput values.
+// You can construct a concrete instance of `TaskDefinitionHealthCheckInput` via:
+//
+//          TaskDefinitionHealthCheckArgs{...}
+type TaskDefinitionHealthCheckInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionHealthCheckOutput() TaskDefinitionHealthCheckOutput
+	ToTaskDefinitionHealthCheckOutputWithContext(context.Context) TaskDefinitionHealthCheckOutput
+}
+
+// The health check command and associated configuration parameters for the container.
+type TaskDefinitionHealthCheckArgs struct {
+	// A string array representing the command that the container runs to determine if it is healthy.
+	Command pulumi.StringArrayInput `pulumi:"command"`
+	// The time period in seconds between each health check execution. You may specify between 5 and 300 seconds. The default value is 30 seconds.
+	Interval pulumi.IntPtrInput `pulumi:"interval"`
+	// The number of times to retry a failed health check before the container is considered unhealthy. You may specify between 1 and 10 retries. The default value is three retries.
+	Retries pulumi.IntPtrInput `pulumi:"retries"`
+	// The optional grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. You may specify between 0 and 300 seconds. The startPeriod is disabled by default.
+	StartPeriod pulumi.IntPtrInput `pulumi:"startPeriod"`
+	// The time period in seconds to wait for a health check to succeed before it is considered a failure. You may specify between 2 and 60 seconds. The default value is 5 seconds.
+	Timeout pulumi.IntPtrInput `pulumi:"timeout"`
+}
+
+func (TaskDefinitionHealthCheckArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionHealthCheck)(nil)).Elem()
+}
+
+func (i TaskDefinitionHealthCheckArgs) ToTaskDefinitionHealthCheckOutput() TaskDefinitionHealthCheckOutput {
+	return i.ToTaskDefinitionHealthCheckOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionHealthCheckArgs) ToTaskDefinitionHealthCheckOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionHealthCheckOutput)
+}
+
+func (i TaskDefinitionHealthCheckArgs) ToTaskDefinitionHealthCheckPtrOutput() TaskDefinitionHealthCheckPtrOutput {
+	return i.ToTaskDefinitionHealthCheckPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionHealthCheckArgs) ToTaskDefinitionHealthCheckPtrOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionHealthCheckOutput).ToTaskDefinitionHealthCheckPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionHealthCheckPtrInput is an input type that accepts TaskDefinitionHealthCheckArgs, TaskDefinitionHealthCheckPtr and TaskDefinitionHealthCheckPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionHealthCheckPtrInput` via:
+//
+//          TaskDefinitionHealthCheckArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionHealthCheckPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionHealthCheckPtrOutput() TaskDefinitionHealthCheckPtrOutput
+	ToTaskDefinitionHealthCheckPtrOutputWithContext(context.Context) TaskDefinitionHealthCheckPtrOutput
+}
+
+type taskDefinitionHealthCheckPtrType TaskDefinitionHealthCheckArgs
+
+func TaskDefinitionHealthCheckPtr(v *TaskDefinitionHealthCheckArgs) TaskDefinitionHealthCheckPtrInput {
+	return (*taskDefinitionHealthCheckPtrType)(v)
+}
+
+func (*taskDefinitionHealthCheckPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionHealthCheck)(nil)).Elem()
+}
+
+func (i *taskDefinitionHealthCheckPtrType) ToTaskDefinitionHealthCheckPtrOutput() TaskDefinitionHealthCheckPtrOutput {
+	return i.ToTaskDefinitionHealthCheckPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionHealthCheckPtrType) ToTaskDefinitionHealthCheckPtrOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionHealthCheckPtrOutput)
+}
+
+// The health check command and associated configuration parameters for the container.
+type TaskDefinitionHealthCheckOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionHealthCheckOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionHealthCheck)(nil)).Elem()
+}
+
+func (o TaskDefinitionHealthCheckOutput) ToTaskDefinitionHealthCheckOutput() TaskDefinitionHealthCheckOutput {
+	return o
+}
+
+func (o TaskDefinitionHealthCheckOutput) ToTaskDefinitionHealthCheckOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckOutput {
+	return o
+}
+
+func (o TaskDefinitionHealthCheckOutput) ToTaskDefinitionHealthCheckPtrOutput() TaskDefinitionHealthCheckPtrOutput {
+	return o.ToTaskDefinitionHealthCheckPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionHealthCheckOutput) ToTaskDefinitionHealthCheckPtrOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionHealthCheck) *TaskDefinitionHealthCheck {
+		return &v
+	}).(TaskDefinitionHealthCheckPtrOutput)
+}
+
+// A string array representing the command that the container runs to determine if it is healthy.
+func (o TaskDefinitionHealthCheckOutput) Command() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionHealthCheck) []string { return v.Command }).(pulumi.StringArrayOutput)
+}
+
+// The time period in seconds between each health check execution. You may specify between 5 and 300 seconds. The default value is 30 seconds.
+func (o TaskDefinitionHealthCheckOutput) Interval() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHealthCheck) *int { return v.Interval }).(pulumi.IntPtrOutput)
+}
+
+// The number of times to retry a failed health check before the container is considered unhealthy. You may specify between 1 and 10 retries. The default value is three retries.
+func (o TaskDefinitionHealthCheckOutput) Retries() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHealthCheck) *int { return v.Retries }).(pulumi.IntPtrOutput)
+}
+
+// The optional grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. You may specify between 0 and 300 seconds. The startPeriod is disabled by default.
+func (o TaskDefinitionHealthCheckOutput) StartPeriod() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHealthCheck) *int { return v.StartPeriod }).(pulumi.IntPtrOutput)
+}
+
+// The time period in seconds to wait for a health check to succeed before it is considered a failure. You may specify between 2 and 60 seconds. The default value is 5 seconds.
+func (o TaskDefinitionHealthCheckOutput) Timeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHealthCheck) *int { return v.Timeout }).(pulumi.IntPtrOutput)
+}
+
+type TaskDefinitionHealthCheckPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionHealthCheckPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionHealthCheck)(nil)).Elem()
+}
+
+func (o TaskDefinitionHealthCheckPtrOutput) ToTaskDefinitionHealthCheckPtrOutput() TaskDefinitionHealthCheckPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionHealthCheckPtrOutput) ToTaskDefinitionHealthCheckPtrOutputWithContext(ctx context.Context) TaskDefinitionHealthCheckPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionHealthCheckPtrOutput) Elem() TaskDefinitionHealthCheckOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) TaskDefinitionHealthCheck {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionHealthCheck
+		return ret
+	}).(TaskDefinitionHealthCheckOutput)
+}
+
+// A string array representing the command that the container runs to determine if it is healthy.
+func (o TaskDefinitionHealthCheckPtrOutput) Command() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Command
+	}).(pulumi.StringArrayOutput)
+}
+
+// The time period in seconds between each health check execution. You may specify between 5 and 300 seconds. The default value is 30 seconds.
+func (o TaskDefinitionHealthCheckPtrOutput) Interval() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Interval
+	}).(pulumi.IntPtrOutput)
+}
+
+// The number of times to retry a failed health check before the container is considered unhealthy. You may specify between 1 and 10 retries. The default value is three retries.
+func (o TaskDefinitionHealthCheckPtrOutput) Retries() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Retries
+	}).(pulumi.IntPtrOutput)
+}
+
+// The optional grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. You may specify between 0 and 300 seconds. The startPeriod is disabled by default.
+func (o TaskDefinitionHealthCheckPtrOutput) StartPeriod() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) *int {
+		if v == nil {
+			return nil
+		}
+		return v.StartPeriod
+	}).(pulumi.IntPtrOutput)
+}
+
+// The time period in seconds to wait for a health check to succeed before it is considered a failure. You may specify between 2 and 60 seconds. The default value is 5 seconds.
+func (o TaskDefinitionHealthCheckPtrOutput) Timeout() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionHealthCheck) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Timeout
+	}).(pulumi.IntPtrOutput)
+}
+
 type TaskDefinitionHostEntry struct {
 	Hostname  *string `pulumi:"hostname"`
 	IpAddress *string `pulumi:"ipAddress"`
+}
+
+// TaskDefinitionHostEntryInput is an input type that accepts TaskDefinitionHostEntryArgs and TaskDefinitionHostEntryOutput values.
+// You can construct a concrete instance of `TaskDefinitionHostEntryInput` via:
+//
+//          TaskDefinitionHostEntryArgs{...}
+type TaskDefinitionHostEntryInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionHostEntryOutput() TaskDefinitionHostEntryOutput
+	ToTaskDefinitionHostEntryOutputWithContext(context.Context) TaskDefinitionHostEntryOutput
+}
+
+type TaskDefinitionHostEntryArgs struct {
+	Hostname  pulumi.StringPtrInput `pulumi:"hostname"`
+	IpAddress pulumi.StringPtrInput `pulumi:"ipAddress"`
+}
+
+func (TaskDefinitionHostEntryArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionHostEntry)(nil)).Elem()
+}
+
+func (i TaskDefinitionHostEntryArgs) ToTaskDefinitionHostEntryOutput() TaskDefinitionHostEntryOutput {
+	return i.ToTaskDefinitionHostEntryOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionHostEntryArgs) ToTaskDefinitionHostEntryOutputWithContext(ctx context.Context) TaskDefinitionHostEntryOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionHostEntryOutput)
+}
+
+// TaskDefinitionHostEntryArrayInput is an input type that accepts TaskDefinitionHostEntryArray and TaskDefinitionHostEntryArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionHostEntryArrayInput` via:
+//
+//          TaskDefinitionHostEntryArray{ TaskDefinitionHostEntryArgs{...} }
+type TaskDefinitionHostEntryArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionHostEntryArrayOutput() TaskDefinitionHostEntryArrayOutput
+	ToTaskDefinitionHostEntryArrayOutputWithContext(context.Context) TaskDefinitionHostEntryArrayOutput
+}
+
+type TaskDefinitionHostEntryArray []TaskDefinitionHostEntryInput
+
+func (TaskDefinitionHostEntryArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionHostEntry)(nil)).Elem()
+}
+
+func (i TaskDefinitionHostEntryArray) ToTaskDefinitionHostEntryArrayOutput() TaskDefinitionHostEntryArrayOutput {
+	return i.ToTaskDefinitionHostEntryArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionHostEntryArray) ToTaskDefinitionHostEntryArrayOutputWithContext(ctx context.Context) TaskDefinitionHostEntryArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionHostEntryArrayOutput)
+}
+
+type TaskDefinitionHostEntryOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionHostEntryOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionHostEntry)(nil)).Elem()
+}
+
+func (o TaskDefinitionHostEntryOutput) ToTaskDefinitionHostEntryOutput() TaskDefinitionHostEntryOutput {
+	return o
+}
+
+func (o TaskDefinitionHostEntryOutput) ToTaskDefinitionHostEntryOutputWithContext(ctx context.Context) TaskDefinitionHostEntryOutput {
+	return o
+}
+
+func (o TaskDefinitionHostEntryOutput) Hostname() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHostEntry) *string { return v.Hostname }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionHostEntryOutput) IpAddress() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionHostEntry) *string { return v.IpAddress }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionHostEntryArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionHostEntryArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionHostEntry)(nil)).Elem()
+}
+
+func (o TaskDefinitionHostEntryArrayOutput) ToTaskDefinitionHostEntryArrayOutput() TaskDefinitionHostEntryArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionHostEntryArrayOutput) ToTaskDefinitionHostEntryArrayOutputWithContext(ctx context.Context) TaskDefinitionHostEntryArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionHostEntryArrayOutput) Index(i pulumi.IntInput) TaskDefinitionHostEntryOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionHostEntry {
+		return vs[0].([]TaskDefinitionHostEntry)[vs[1].(int)]
+	}).(TaskDefinitionHostEntryOutput)
 }
 
 type TaskDefinitionKernelCapabilities struct {
@@ -205,9 +2600,247 @@ type TaskDefinitionKernelCapabilities struct {
 	Drop []string `pulumi:"drop"`
 }
 
+// TaskDefinitionKernelCapabilitiesInput is an input type that accepts TaskDefinitionKernelCapabilitiesArgs and TaskDefinitionKernelCapabilitiesOutput values.
+// You can construct a concrete instance of `TaskDefinitionKernelCapabilitiesInput` via:
+//
+//          TaskDefinitionKernelCapabilitiesArgs{...}
+type TaskDefinitionKernelCapabilitiesInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionKernelCapabilitiesOutput() TaskDefinitionKernelCapabilitiesOutput
+	ToTaskDefinitionKernelCapabilitiesOutputWithContext(context.Context) TaskDefinitionKernelCapabilitiesOutput
+}
+
+type TaskDefinitionKernelCapabilitiesArgs struct {
+	Add  pulumi.StringArrayInput `pulumi:"add"`
+	Drop pulumi.StringArrayInput `pulumi:"drop"`
+}
+
+func (TaskDefinitionKernelCapabilitiesArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionKernelCapabilities)(nil)).Elem()
+}
+
+func (i TaskDefinitionKernelCapabilitiesArgs) ToTaskDefinitionKernelCapabilitiesOutput() TaskDefinitionKernelCapabilitiesOutput {
+	return i.ToTaskDefinitionKernelCapabilitiesOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionKernelCapabilitiesArgs) ToTaskDefinitionKernelCapabilitiesOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionKernelCapabilitiesOutput)
+}
+
+func (i TaskDefinitionKernelCapabilitiesArgs) ToTaskDefinitionKernelCapabilitiesPtrOutput() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return i.ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionKernelCapabilitiesArgs) ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionKernelCapabilitiesOutput).ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionKernelCapabilitiesPtrInput is an input type that accepts TaskDefinitionKernelCapabilitiesArgs, TaskDefinitionKernelCapabilitiesPtr and TaskDefinitionKernelCapabilitiesPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionKernelCapabilitiesPtrInput` via:
+//
+//          TaskDefinitionKernelCapabilitiesArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionKernelCapabilitiesPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionKernelCapabilitiesPtrOutput() TaskDefinitionKernelCapabilitiesPtrOutput
+	ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(context.Context) TaskDefinitionKernelCapabilitiesPtrOutput
+}
+
+type taskDefinitionKernelCapabilitiesPtrType TaskDefinitionKernelCapabilitiesArgs
+
+func TaskDefinitionKernelCapabilitiesPtr(v *TaskDefinitionKernelCapabilitiesArgs) TaskDefinitionKernelCapabilitiesPtrInput {
+	return (*taskDefinitionKernelCapabilitiesPtrType)(v)
+}
+
+func (*taskDefinitionKernelCapabilitiesPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionKernelCapabilities)(nil)).Elem()
+}
+
+func (i *taskDefinitionKernelCapabilitiesPtrType) ToTaskDefinitionKernelCapabilitiesPtrOutput() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return i.ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionKernelCapabilitiesPtrType) ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionKernelCapabilitiesPtrOutput)
+}
+
+type TaskDefinitionKernelCapabilitiesOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionKernelCapabilitiesOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionKernelCapabilities)(nil)).Elem()
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) ToTaskDefinitionKernelCapabilitiesOutput() TaskDefinitionKernelCapabilitiesOutput {
+	return o
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) ToTaskDefinitionKernelCapabilitiesOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesOutput {
+	return o
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) ToTaskDefinitionKernelCapabilitiesPtrOutput() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o.ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionKernelCapabilities) *TaskDefinitionKernelCapabilities {
+		return &v
+	}).(TaskDefinitionKernelCapabilitiesPtrOutput)
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) Add() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionKernelCapabilities) []string { return v.Add }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionKernelCapabilitiesOutput) Drop() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionKernelCapabilities) []string { return v.Drop }).(pulumi.StringArrayOutput)
+}
+
+type TaskDefinitionKernelCapabilitiesPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionKernelCapabilitiesPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionKernelCapabilities)(nil)).Elem()
+}
+
+func (o TaskDefinitionKernelCapabilitiesPtrOutput) ToTaskDefinitionKernelCapabilitiesPtrOutput() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionKernelCapabilitiesPtrOutput) ToTaskDefinitionKernelCapabilitiesPtrOutputWithContext(ctx context.Context) TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionKernelCapabilitiesPtrOutput) Elem() TaskDefinitionKernelCapabilitiesOutput {
+	return o.ApplyT(func(v *TaskDefinitionKernelCapabilities) TaskDefinitionKernelCapabilities {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionKernelCapabilities
+		return ret
+	}).(TaskDefinitionKernelCapabilitiesOutput)
+}
+
+func (o TaskDefinitionKernelCapabilitiesPtrOutput) Add() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionKernelCapabilities) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Add
+	}).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionKernelCapabilitiesPtrOutput) Drop() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionKernelCapabilities) []string {
+		if v == nil {
+			return nil
+		}
+		return v.Drop
+	}).(pulumi.StringArrayOutput)
+}
+
 type TaskDefinitionKeyValuePair struct {
 	Name  *string `pulumi:"name"`
 	Value *string `pulumi:"value"`
+}
+
+// TaskDefinitionKeyValuePairInput is an input type that accepts TaskDefinitionKeyValuePairArgs and TaskDefinitionKeyValuePairOutput values.
+// You can construct a concrete instance of `TaskDefinitionKeyValuePairInput` via:
+//
+//          TaskDefinitionKeyValuePairArgs{...}
+type TaskDefinitionKeyValuePairInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionKeyValuePairOutput() TaskDefinitionKeyValuePairOutput
+	ToTaskDefinitionKeyValuePairOutputWithContext(context.Context) TaskDefinitionKeyValuePairOutput
+}
+
+type TaskDefinitionKeyValuePairArgs struct {
+	Name  pulumi.StringPtrInput `pulumi:"name"`
+	Value pulumi.StringPtrInput `pulumi:"value"`
+}
+
+func (TaskDefinitionKeyValuePairArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionKeyValuePair)(nil)).Elem()
+}
+
+func (i TaskDefinitionKeyValuePairArgs) ToTaskDefinitionKeyValuePairOutput() TaskDefinitionKeyValuePairOutput {
+	return i.ToTaskDefinitionKeyValuePairOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionKeyValuePairArgs) ToTaskDefinitionKeyValuePairOutputWithContext(ctx context.Context) TaskDefinitionKeyValuePairOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionKeyValuePairOutput)
+}
+
+// TaskDefinitionKeyValuePairArrayInput is an input type that accepts TaskDefinitionKeyValuePairArray and TaskDefinitionKeyValuePairArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionKeyValuePairArrayInput` via:
+//
+//          TaskDefinitionKeyValuePairArray{ TaskDefinitionKeyValuePairArgs{...} }
+type TaskDefinitionKeyValuePairArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionKeyValuePairArrayOutput() TaskDefinitionKeyValuePairArrayOutput
+	ToTaskDefinitionKeyValuePairArrayOutputWithContext(context.Context) TaskDefinitionKeyValuePairArrayOutput
+}
+
+type TaskDefinitionKeyValuePairArray []TaskDefinitionKeyValuePairInput
+
+func (TaskDefinitionKeyValuePairArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionKeyValuePair)(nil)).Elem()
+}
+
+func (i TaskDefinitionKeyValuePairArray) ToTaskDefinitionKeyValuePairArrayOutput() TaskDefinitionKeyValuePairArrayOutput {
+	return i.ToTaskDefinitionKeyValuePairArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionKeyValuePairArray) ToTaskDefinitionKeyValuePairArrayOutputWithContext(ctx context.Context) TaskDefinitionKeyValuePairArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionKeyValuePairArrayOutput)
+}
+
+type TaskDefinitionKeyValuePairOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionKeyValuePairOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionKeyValuePair)(nil)).Elem()
+}
+
+func (o TaskDefinitionKeyValuePairOutput) ToTaskDefinitionKeyValuePairOutput() TaskDefinitionKeyValuePairOutput {
+	return o
+}
+
+func (o TaskDefinitionKeyValuePairOutput) ToTaskDefinitionKeyValuePairOutputWithContext(ctx context.Context) TaskDefinitionKeyValuePairOutput {
+	return o
+}
+
+func (o TaskDefinitionKeyValuePairOutput) Name() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionKeyValuePair) *string { return v.Name }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionKeyValuePairOutput) Value() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionKeyValuePair) *string { return v.Value }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionKeyValuePairArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionKeyValuePairArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionKeyValuePair)(nil)).Elem()
+}
+
+func (o TaskDefinitionKeyValuePairArrayOutput) ToTaskDefinitionKeyValuePairArrayOutput() TaskDefinitionKeyValuePairArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionKeyValuePairArrayOutput) ToTaskDefinitionKeyValuePairArrayOutputWithContext(ctx context.Context) TaskDefinitionKeyValuePairArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionKeyValuePairArrayOutput) Index(i pulumi.IntInput) TaskDefinitionKeyValuePairOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionKeyValuePair {
+		return vs[0].([]TaskDefinitionKeyValuePair)[vs[1].(int)]
+	}).(TaskDefinitionKeyValuePairOutput)
 }
 
 type TaskDefinitionLinuxParameters struct {
@@ -220,16 +2853,486 @@ type TaskDefinitionLinuxParameters struct {
 	Tmpfs              []TaskDefinitionTmpfs             `pulumi:"tmpfs"`
 }
 
+// TaskDefinitionLinuxParametersInput is an input type that accepts TaskDefinitionLinuxParametersArgs and TaskDefinitionLinuxParametersOutput values.
+// You can construct a concrete instance of `TaskDefinitionLinuxParametersInput` via:
+//
+//          TaskDefinitionLinuxParametersArgs{...}
+type TaskDefinitionLinuxParametersInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionLinuxParametersOutput() TaskDefinitionLinuxParametersOutput
+	ToTaskDefinitionLinuxParametersOutputWithContext(context.Context) TaskDefinitionLinuxParametersOutput
+}
+
+type TaskDefinitionLinuxParametersArgs struct {
+	Capabilities       TaskDefinitionKernelCapabilitiesPtrInput `pulumi:"capabilities"`
+	Devices            TaskDefinitionDeviceArrayInput           `pulumi:"devices"`
+	InitProcessEnabled pulumi.BoolPtrInput                      `pulumi:"initProcessEnabled"`
+	MaxSwap            pulumi.IntPtrInput                       `pulumi:"maxSwap"`
+	SharedMemorySize   pulumi.IntPtrInput                       `pulumi:"sharedMemorySize"`
+	Swappiness         pulumi.IntPtrInput                       `pulumi:"swappiness"`
+	Tmpfs              TaskDefinitionTmpfsArrayInput            `pulumi:"tmpfs"`
+}
+
+func (TaskDefinitionLinuxParametersArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionLinuxParameters)(nil)).Elem()
+}
+
+func (i TaskDefinitionLinuxParametersArgs) ToTaskDefinitionLinuxParametersOutput() TaskDefinitionLinuxParametersOutput {
+	return i.ToTaskDefinitionLinuxParametersOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionLinuxParametersArgs) ToTaskDefinitionLinuxParametersOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLinuxParametersOutput)
+}
+
+func (i TaskDefinitionLinuxParametersArgs) ToTaskDefinitionLinuxParametersPtrOutput() TaskDefinitionLinuxParametersPtrOutput {
+	return i.ToTaskDefinitionLinuxParametersPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionLinuxParametersArgs) ToTaskDefinitionLinuxParametersPtrOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLinuxParametersOutput).ToTaskDefinitionLinuxParametersPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionLinuxParametersPtrInput is an input type that accepts TaskDefinitionLinuxParametersArgs, TaskDefinitionLinuxParametersPtr and TaskDefinitionLinuxParametersPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionLinuxParametersPtrInput` via:
+//
+//          TaskDefinitionLinuxParametersArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionLinuxParametersPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionLinuxParametersPtrOutput() TaskDefinitionLinuxParametersPtrOutput
+	ToTaskDefinitionLinuxParametersPtrOutputWithContext(context.Context) TaskDefinitionLinuxParametersPtrOutput
+}
+
+type taskDefinitionLinuxParametersPtrType TaskDefinitionLinuxParametersArgs
+
+func TaskDefinitionLinuxParametersPtr(v *TaskDefinitionLinuxParametersArgs) TaskDefinitionLinuxParametersPtrInput {
+	return (*taskDefinitionLinuxParametersPtrType)(v)
+}
+
+func (*taskDefinitionLinuxParametersPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionLinuxParameters)(nil)).Elem()
+}
+
+func (i *taskDefinitionLinuxParametersPtrType) ToTaskDefinitionLinuxParametersPtrOutput() TaskDefinitionLinuxParametersPtrOutput {
+	return i.ToTaskDefinitionLinuxParametersPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionLinuxParametersPtrType) ToTaskDefinitionLinuxParametersPtrOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLinuxParametersPtrOutput)
+}
+
+type TaskDefinitionLinuxParametersOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionLinuxParametersOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionLinuxParameters)(nil)).Elem()
+}
+
+func (o TaskDefinitionLinuxParametersOutput) ToTaskDefinitionLinuxParametersOutput() TaskDefinitionLinuxParametersOutput {
+	return o
+}
+
+func (o TaskDefinitionLinuxParametersOutput) ToTaskDefinitionLinuxParametersOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersOutput {
+	return o
+}
+
+func (o TaskDefinitionLinuxParametersOutput) ToTaskDefinitionLinuxParametersPtrOutput() TaskDefinitionLinuxParametersPtrOutput {
+	return o.ToTaskDefinitionLinuxParametersPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionLinuxParametersOutput) ToTaskDefinitionLinuxParametersPtrOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionLinuxParameters) *TaskDefinitionLinuxParameters {
+		return &v
+	}).(TaskDefinitionLinuxParametersPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) Capabilities() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) *TaskDefinitionKernelCapabilities { return v.Capabilities }).(TaskDefinitionKernelCapabilitiesPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) Devices() TaskDefinitionDeviceArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) []TaskDefinitionDevice { return v.Devices }).(TaskDefinitionDeviceArrayOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) InitProcessEnabled() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) *bool { return v.InitProcessEnabled }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) MaxSwap() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) *int { return v.MaxSwap }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) SharedMemorySize() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) *int { return v.SharedMemorySize }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) Swappiness() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) *int { return v.Swappiness }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersOutput) Tmpfs() TaskDefinitionTmpfsArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionLinuxParameters) []TaskDefinitionTmpfs { return v.Tmpfs }).(TaskDefinitionTmpfsArrayOutput)
+}
+
+type TaskDefinitionLinuxParametersPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionLinuxParametersPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionLinuxParameters)(nil)).Elem()
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) ToTaskDefinitionLinuxParametersPtrOutput() TaskDefinitionLinuxParametersPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) ToTaskDefinitionLinuxParametersPtrOutputWithContext(ctx context.Context) TaskDefinitionLinuxParametersPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) Elem() TaskDefinitionLinuxParametersOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) TaskDefinitionLinuxParameters {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionLinuxParameters
+		return ret
+	}).(TaskDefinitionLinuxParametersOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) Capabilities() TaskDefinitionKernelCapabilitiesPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) *TaskDefinitionKernelCapabilities {
+		if v == nil {
+			return nil
+		}
+		return v.Capabilities
+	}).(TaskDefinitionKernelCapabilitiesPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) Devices() TaskDefinitionDeviceArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) []TaskDefinitionDevice {
+		if v == nil {
+			return nil
+		}
+		return v.Devices
+	}).(TaskDefinitionDeviceArrayOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) InitProcessEnabled() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.InitProcessEnabled
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) MaxSwap() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) *int {
+		if v == nil {
+			return nil
+		}
+		return v.MaxSwap
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) SharedMemorySize() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) *int {
+		if v == nil {
+			return nil
+		}
+		return v.SharedMemorySize
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) Swappiness() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) *int {
+		if v == nil {
+			return nil
+		}
+		return v.Swappiness
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionLinuxParametersPtrOutput) Tmpfs() TaskDefinitionTmpfsArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionLinuxParameters) []TaskDefinitionTmpfs {
+		if v == nil {
+			return nil
+		}
+		return v.Tmpfs
+	}).(TaskDefinitionTmpfsArrayOutput)
+}
+
 type TaskDefinitionLogConfiguration struct {
 	LogDriver     string                 `pulumi:"logDriver"`
 	Options       interface{}            `pulumi:"options"`
 	SecretOptions []TaskDefinitionSecret `pulumi:"secretOptions"`
 }
 
+// TaskDefinitionLogConfigurationInput is an input type that accepts TaskDefinitionLogConfigurationArgs and TaskDefinitionLogConfigurationOutput values.
+// You can construct a concrete instance of `TaskDefinitionLogConfigurationInput` via:
+//
+//          TaskDefinitionLogConfigurationArgs{...}
+type TaskDefinitionLogConfigurationInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionLogConfigurationOutput() TaskDefinitionLogConfigurationOutput
+	ToTaskDefinitionLogConfigurationOutputWithContext(context.Context) TaskDefinitionLogConfigurationOutput
+}
+
+type TaskDefinitionLogConfigurationArgs struct {
+	LogDriver     pulumi.StringInput             `pulumi:"logDriver"`
+	Options       pulumi.Input                   `pulumi:"options"`
+	SecretOptions TaskDefinitionSecretArrayInput `pulumi:"secretOptions"`
+}
+
+func (TaskDefinitionLogConfigurationArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionLogConfiguration)(nil)).Elem()
+}
+
+func (i TaskDefinitionLogConfigurationArgs) ToTaskDefinitionLogConfigurationOutput() TaskDefinitionLogConfigurationOutput {
+	return i.ToTaskDefinitionLogConfigurationOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionLogConfigurationArgs) ToTaskDefinitionLogConfigurationOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLogConfigurationOutput)
+}
+
+func (i TaskDefinitionLogConfigurationArgs) ToTaskDefinitionLogConfigurationPtrOutput() TaskDefinitionLogConfigurationPtrOutput {
+	return i.ToTaskDefinitionLogConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionLogConfigurationArgs) ToTaskDefinitionLogConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLogConfigurationOutput).ToTaskDefinitionLogConfigurationPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionLogConfigurationPtrInput is an input type that accepts TaskDefinitionLogConfigurationArgs, TaskDefinitionLogConfigurationPtr and TaskDefinitionLogConfigurationPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionLogConfigurationPtrInput` via:
+//
+//          TaskDefinitionLogConfigurationArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionLogConfigurationPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionLogConfigurationPtrOutput() TaskDefinitionLogConfigurationPtrOutput
+	ToTaskDefinitionLogConfigurationPtrOutputWithContext(context.Context) TaskDefinitionLogConfigurationPtrOutput
+}
+
+type taskDefinitionLogConfigurationPtrType TaskDefinitionLogConfigurationArgs
+
+func TaskDefinitionLogConfigurationPtr(v *TaskDefinitionLogConfigurationArgs) TaskDefinitionLogConfigurationPtrInput {
+	return (*taskDefinitionLogConfigurationPtrType)(v)
+}
+
+func (*taskDefinitionLogConfigurationPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionLogConfiguration)(nil)).Elem()
+}
+
+func (i *taskDefinitionLogConfigurationPtrType) ToTaskDefinitionLogConfigurationPtrOutput() TaskDefinitionLogConfigurationPtrOutput {
+	return i.ToTaskDefinitionLogConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionLogConfigurationPtrType) ToTaskDefinitionLogConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionLogConfigurationPtrOutput)
+}
+
+type TaskDefinitionLogConfigurationOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionLogConfigurationOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionLogConfiguration)(nil)).Elem()
+}
+
+func (o TaskDefinitionLogConfigurationOutput) ToTaskDefinitionLogConfigurationOutput() TaskDefinitionLogConfigurationOutput {
+	return o
+}
+
+func (o TaskDefinitionLogConfigurationOutput) ToTaskDefinitionLogConfigurationOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationOutput {
+	return o
+}
+
+func (o TaskDefinitionLogConfigurationOutput) ToTaskDefinitionLogConfigurationPtrOutput() TaskDefinitionLogConfigurationPtrOutput {
+	return o.ToTaskDefinitionLogConfigurationPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionLogConfigurationOutput) ToTaskDefinitionLogConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionLogConfiguration) *TaskDefinitionLogConfiguration {
+		return &v
+	}).(TaskDefinitionLogConfigurationPtrOutput)
+}
+
+func (o TaskDefinitionLogConfigurationOutput) LogDriver() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionLogConfiguration) string { return v.LogDriver }).(pulumi.StringOutput)
+}
+
+func (o TaskDefinitionLogConfigurationOutput) Options() pulumi.AnyOutput {
+	return o.ApplyT(func(v TaskDefinitionLogConfiguration) interface{} { return v.Options }).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionLogConfigurationOutput) SecretOptions() TaskDefinitionSecretArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionLogConfiguration) []TaskDefinitionSecret { return v.SecretOptions }).(TaskDefinitionSecretArrayOutput)
+}
+
+type TaskDefinitionLogConfigurationPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionLogConfigurationPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionLogConfiguration)(nil)).Elem()
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) ToTaskDefinitionLogConfigurationPtrOutput() TaskDefinitionLogConfigurationPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) ToTaskDefinitionLogConfigurationPtrOutputWithContext(ctx context.Context) TaskDefinitionLogConfigurationPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) Elem() TaskDefinitionLogConfigurationOutput {
+	return o.ApplyT(func(v *TaskDefinitionLogConfiguration) TaskDefinitionLogConfiguration {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionLogConfiguration
+		return ret
+	}).(TaskDefinitionLogConfigurationOutput)
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) LogDriver() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionLogConfiguration) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.LogDriver
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) Options() pulumi.AnyOutput {
+	return o.ApplyT(func(v *TaskDefinitionLogConfiguration) interface{} {
+		if v == nil {
+			return nil
+		}
+		return v.Options
+	}).(pulumi.AnyOutput)
+}
+
+func (o TaskDefinitionLogConfigurationPtrOutput) SecretOptions() TaskDefinitionSecretArrayOutput {
+	return o.ApplyT(func(v *TaskDefinitionLogConfiguration) []TaskDefinitionSecret {
+		if v == nil {
+			return nil
+		}
+		return v.SecretOptions
+	}).(TaskDefinitionSecretArrayOutput)
+}
+
 type TaskDefinitionMountPoint struct {
 	ContainerPath *string `pulumi:"containerPath"`
 	ReadOnly      *bool   `pulumi:"readOnly"`
 	SourceVolume  *string `pulumi:"sourceVolume"`
+}
+
+// TaskDefinitionMountPointInput is an input type that accepts TaskDefinitionMountPointArgs and TaskDefinitionMountPointOutput values.
+// You can construct a concrete instance of `TaskDefinitionMountPointInput` via:
+//
+//          TaskDefinitionMountPointArgs{...}
+type TaskDefinitionMountPointInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionMountPointOutput() TaskDefinitionMountPointOutput
+	ToTaskDefinitionMountPointOutputWithContext(context.Context) TaskDefinitionMountPointOutput
+}
+
+type TaskDefinitionMountPointArgs struct {
+	ContainerPath pulumi.StringPtrInput `pulumi:"containerPath"`
+	ReadOnly      pulumi.BoolPtrInput   `pulumi:"readOnly"`
+	SourceVolume  pulumi.StringPtrInput `pulumi:"sourceVolume"`
+}
+
+func (TaskDefinitionMountPointArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionMountPoint)(nil)).Elem()
+}
+
+func (i TaskDefinitionMountPointArgs) ToTaskDefinitionMountPointOutput() TaskDefinitionMountPointOutput {
+	return i.ToTaskDefinitionMountPointOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionMountPointArgs) ToTaskDefinitionMountPointOutputWithContext(ctx context.Context) TaskDefinitionMountPointOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionMountPointOutput)
+}
+
+// TaskDefinitionMountPointArrayInput is an input type that accepts TaskDefinitionMountPointArray and TaskDefinitionMountPointArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionMountPointArrayInput` via:
+//
+//          TaskDefinitionMountPointArray{ TaskDefinitionMountPointArgs{...} }
+type TaskDefinitionMountPointArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionMountPointArrayOutput() TaskDefinitionMountPointArrayOutput
+	ToTaskDefinitionMountPointArrayOutputWithContext(context.Context) TaskDefinitionMountPointArrayOutput
+}
+
+type TaskDefinitionMountPointArray []TaskDefinitionMountPointInput
+
+func (TaskDefinitionMountPointArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionMountPoint)(nil)).Elem()
+}
+
+func (i TaskDefinitionMountPointArray) ToTaskDefinitionMountPointArrayOutput() TaskDefinitionMountPointArrayOutput {
+	return i.ToTaskDefinitionMountPointArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionMountPointArray) ToTaskDefinitionMountPointArrayOutputWithContext(ctx context.Context) TaskDefinitionMountPointArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionMountPointArrayOutput)
+}
+
+type TaskDefinitionMountPointOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionMountPointOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionMountPoint)(nil)).Elem()
+}
+
+func (o TaskDefinitionMountPointOutput) ToTaskDefinitionMountPointOutput() TaskDefinitionMountPointOutput {
+	return o
+}
+
+func (o TaskDefinitionMountPointOutput) ToTaskDefinitionMountPointOutputWithContext(ctx context.Context) TaskDefinitionMountPointOutput {
+	return o
+}
+
+func (o TaskDefinitionMountPointOutput) ContainerPath() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionMountPoint) *string { return v.ContainerPath }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionMountPointOutput) ReadOnly() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionMountPoint) *bool { return v.ReadOnly }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionMountPointOutput) SourceVolume() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionMountPoint) *string { return v.SourceVolume }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionMountPointArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionMountPointArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionMountPoint)(nil)).Elem()
+}
+
+func (o TaskDefinitionMountPointArrayOutput) ToTaskDefinitionMountPointArrayOutput() TaskDefinitionMountPointArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionMountPointArrayOutput) ToTaskDefinitionMountPointArrayOutputWithContext(ctx context.Context) TaskDefinitionMountPointArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionMountPointArrayOutput) Index(i pulumi.IntInput) TaskDefinitionMountPointOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionMountPoint {
+		return vs[0].([]TaskDefinitionMountPoint)[vs[1].(int)]
+	}).(TaskDefinitionMountPointOutput)
 }
 
 type TaskDefinitionPortMapping struct {
@@ -239,8 +3342,242 @@ type TaskDefinitionPortMapping struct {
 	TargetGroup   *lb.TargetGroup `pulumi:"targetGroup"`
 }
 
+// TaskDefinitionPortMappingInput is an input type that accepts TaskDefinitionPortMappingArgs and TaskDefinitionPortMappingOutput values.
+// You can construct a concrete instance of `TaskDefinitionPortMappingInput` via:
+//
+//          TaskDefinitionPortMappingArgs{...}
+type TaskDefinitionPortMappingInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionPortMappingOutput() TaskDefinitionPortMappingOutput
+	ToTaskDefinitionPortMappingOutputWithContext(context.Context) TaskDefinitionPortMappingOutput
+}
+
+type TaskDefinitionPortMappingArgs struct {
+	ContainerPort pulumi.IntPtrInput    `pulumi:"containerPort"`
+	HostPort      pulumi.IntPtrInput    `pulumi:"hostPort"`
+	Protocol      pulumi.StringPtrInput `pulumi:"protocol"`
+	TargetGroup   lb.TargetGroupInput   `pulumi:"targetGroup"`
+}
+
+func (TaskDefinitionPortMappingArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionPortMapping)(nil)).Elem()
+}
+
+func (i TaskDefinitionPortMappingArgs) ToTaskDefinitionPortMappingOutput() TaskDefinitionPortMappingOutput {
+	return i.ToTaskDefinitionPortMappingOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionPortMappingArgs) ToTaskDefinitionPortMappingOutputWithContext(ctx context.Context) TaskDefinitionPortMappingOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionPortMappingOutput)
+}
+
+// TaskDefinitionPortMappingArrayInput is an input type that accepts TaskDefinitionPortMappingArray and TaskDefinitionPortMappingArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionPortMappingArrayInput` via:
+//
+//          TaskDefinitionPortMappingArray{ TaskDefinitionPortMappingArgs{...} }
+type TaskDefinitionPortMappingArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionPortMappingArrayOutput() TaskDefinitionPortMappingArrayOutput
+	ToTaskDefinitionPortMappingArrayOutputWithContext(context.Context) TaskDefinitionPortMappingArrayOutput
+}
+
+type TaskDefinitionPortMappingArray []TaskDefinitionPortMappingInput
+
+func (TaskDefinitionPortMappingArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionPortMapping)(nil)).Elem()
+}
+
+func (i TaskDefinitionPortMappingArray) ToTaskDefinitionPortMappingArrayOutput() TaskDefinitionPortMappingArrayOutput {
+	return i.ToTaskDefinitionPortMappingArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionPortMappingArray) ToTaskDefinitionPortMappingArrayOutputWithContext(ctx context.Context) TaskDefinitionPortMappingArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionPortMappingArrayOutput)
+}
+
+type TaskDefinitionPortMappingOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionPortMappingOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionPortMapping)(nil)).Elem()
+}
+
+func (o TaskDefinitionPortMappingOutput) ToTaskDefinitionPortMappingOutput() TaskDefinitionPortMappingOutput {
+	return o
+}
+
+func (o TaskDefinitionPortMappingOutput) ToTaskDefinitionPortMappingOutputWithContext(ctx context.Context) TaskDefinitionPortMappingOutput {
+	return o
+}
+
+func (o TaskDefinitionPortMappingOutput) ContainerPort() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionPortMapping) *int { return v.ContainerPort }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionPortMappingOutput) HostPort() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionPortMapping) *int { return v.HostPort }).(pulumi.IntPtrOutput)
+}
+
+func (o TaskDefinitionPortMappingOutput) Protocol() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionPortMapping) *string { return v.Protocol }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionPortMappingOutput) TargetGroup() lb.TargetGroupOutput {
+	return o.ApplyT(func(v TaskDefinitionPortMapping) *lb.TargetGroup { return v.TargetGroup }).(lb.TargetGroupOutput)
+}
+
+type TaskDefinitionPortMappingArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionPortMappingArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionPortMapping)(nil)).Elem()
+}
+
+func (o TaskDefinitionPortMappingArrayOutput) ToTaskDefinitionPortMappingArrayOutput() TaskDefinitionPortMappingArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionPortMappingArrayOutput) ToTaskDefinitionPortMappingArrayOutputWithContext(ctx context.Context) TaskDefinitionPortMappingArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionPortMappingArrayOutput) Index(i pulumi.IntInput) TaskDefinitionPortMappingOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionPortMapping {
+		return vs[0].([]TaskDefinitionPortMapping)[vs[1].(int)]
+	}).(TaskDefinitionPortMappingOutput)
+}
+
 type TaskDefinitionRepositoryCredentials struct {
 	CredentialsParameter *string `pulumi:"credentialsParameter"`
+}
+
+// TaskDefinitionRepositoryCredentialsInput is an input type that accepts TaskDefinitionRepositoryCredentialsArgs and TaskDefinitionRepositoryCredentialsOutput values.
+// You can construct a concrete instance of `TaskDefinitionRepositoryCredentialsInput` via:
+//
+//          TaskDefinitionRepositoryCredentialsArgs{...}
+type TaskDefinitionRepositoryCredentialsInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionRepositoryCredentialsOutput() TaskDefinitionRepositoryCredentialsOutput
+	ToTaskDefinitionRepositoryCredentialsOutputWithContext(context.Context) TaskDefinitionRepositoryCredentialsOutput
+}
+
+type TaskDefinitionRepositoryCredentialsArgs struct {
+	CredentialsParameter pulumi.StringPtrInput `pulumi:"credentialsParameter"`
+}
+
+func (TaskDefinitionRepositoryCredentialsArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionRepositoryCredentials)(nil)).Elem()
+}
+
+func (i TaskDefinitionRepositoryCredentialsArgs) ToTaskDefinitionRepositoryCredentialsOutput() TaskDefinitionRepositoryCredentialsOutput {
+	return i.ToTaskDefinitionRepositoryCredentialsOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionRepositoryCredentialsArgs) ToTaskDefinitionRepositoryCredentialsOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionRepositoryCredentialsOutput)
+}
+
+func (i TaskDefinitionRepositoryCredentialsArgs) ToTaskDefinitionRepositoryCredentialsPtrOutput() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return i.ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionRepositoryCredentialsArgs) ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionRepositoryCredentialsOutput).ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(ctx)
+}
+
+// TaskDefinitionRepositoryCredentialsPtrInput is an input type that accepts TaskDefinitionRepositoryCredentialsArgs, TaskDefinitionRepositoryCredentialsPtr and TaskDefinitionRepositoryCredentialsPtrOutput values.
+// You can construct a concrete instance of `TaskDefinitionRepositoryCredentialsPtrInput` via:
+//
+//          TaskDefinitionRepositoryCredentialsArgs{...}
+//
+//  or:
+//
+//          nil
+type TaskDefinitionRepositoryCredentialsPtrInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionRepositoryCredentialsPtrOutput() TaskDefinitionRepositoryCredentialsPtrOutput
+	ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(context.Context) TaskDefinitionRepositoryCredentialsPtrOutput
+}
+
+type taskDefinitionRepositoryCredentialsPtrType TaskDefinitionRepositoryCredentialsArgs
+
+func TaskDefinitionRepositoryCredentialsPtr(v *TaskDefinitionRepositoryCredentialsArgs) TaskDefinitionRepositoryCredentialsPtrInput {
+	return (*taskDefinitionRepositoryCredentialsPtrType)(v)
+}
+
+func (*taskDefinitionRepositoryCredentialsPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionRepositoryCredentials)(nil)).Elem()
+}
+
+func (i *taskDefinitionRepositoryCredentialsPtrType) ToTaskDefinitionRepositoryCredentialsPtrOutput() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return i.ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(context.Background())
+}
+
+func (i *taskDefinitionRepositoryCredentialsPtrType) ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionRepositoryCredentialsPtrOutput)
+}
+
+type TaskDefinitionRepositoryCredentialsOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionRepositoryCredentialsOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionRepositoryCredentials)(nil)).Elem()
+}
+
+func (o TaskDefinitionRepositoryCredentialsOutput) ToTaskDefinitionRepositoryCredentialsOutput() TaskDefinitionRepositoryCredentialsOutput {
+	return o
+}
+
+func (o TaskDefinitionRepositoryCredentialsOutput) ToTaskDefinitionRepositoryCredentialsOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsOutput {
+	return o
+}
+
+func (o TaskDefinitionRepositoryCredentialsOutput) ToTaskDefinitionRepositoryCredentialsPtrOutput() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o.ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(context.Background())
+}
+
+func (o TaskDefinitionRepositoryCredentialsOutput) ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v TaskDefinitionRepositoryCredentials) *TaskDefinitionRepositoryCredentials {
+		return &v
+	}).(TaskDefinitionRepositoryCredentialsPtrOutput)
+}
+
+func (o TaskDefinitionRepositoryCredentialsOutput) CredentialsParameter() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionRepositoryCredentials) *string { return v.CredentialsParameter }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionRepositoryCredentialsPtrOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionRepositoryCredentialsPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**TaskDefinitionRepositoryCredentials)(nil)).Elem()
+}
+
+func (o TaskDefinitionRepositoryCredentialsPtrOutput) ToTaskDefinitionRepositoryCredentialsPtrOutput() TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionRepositoryCredentialsPtrOutput) ToTaskDefinitionRepositoryCredentialsPtrOutputWithContext(ctx context.Context) TaskDefinitionRepositoryCredentialsPtrOutput {
+	return o
+}
+
+func (o TaskDefinitionRepositoryCredentialsPtrOutput) Elem() TaskDefinitionRepositoryCredentialsOutput {
+	return o.ApplyT(func(v *TaskDefinitionRepositoryCredentials) TaskDefinitionRepositoryCredentials {
+		if v != nil {
+			return *v
+		}
+		var ret TaskDefinitionRepositoryCredentials
+		return ret
+	}).(TaskDefinitionRepositoryCredentialsOutput)
+}
+
+func (o TaskDefinitionRepositoryCredentialsPtrOutput) CredentialsParameter() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TaskDefinitionRepositoryCredentials) *string {
+		if v == nil {
+			return nil
+		}
+		return v.CredentialsParameter
+	}).(pulumi.StringPtrOutput)
 }
 
 type TaskDefinitionResourceRequirement struct {
@@ -248,14 +3585,299 @@ type TaskDefinitionResourceRequirement struct {
 	Value string `pulumi:"value"`
 }
 
+// TaskDefinitionResourceRequirementInput is an input type that accepts TaskDefinitionResourceRequirementArgs and TaskDefinitionResourceRequirementOutput values.
+// You can construct a concrete instance of `TaskDefinitionResourceRequirementInput` via:
+//
+//          TaskDefinitionResourceRequirementArgs{...}
+type TaskDefinitionResourceRequirementInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionResourceRequirementOutput() TaskDefinitionResourceRequirementOutput
+	ToTaskDefinitionResourceRequirementOutputWithContext(context.Context) TaskDefinitionResourceRequirementOutput
+}
+
+type TaskDefinitionResourceRequirementArgs struct {
+	Type  pulumi.StringInput `pulumi:"type"`
+	Value pulumi.StringInput `pulumi:"value"`
+}
+
+func (TaskDefinitionResourceRequirementArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionResourceRequirement)(nil)).Elem()
+}
+
+func (i TaskDefinitionResourceRequirementArgs) ToTaskDefinitionResourceRequirementOutput() TaskDefinitionResourceRequirementOutput {
+	return i.ToTaskDefinitionResourceRequirementOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionResourceRequirementArgs) ToTaskDefinitionResourceRequirementOutputWithContext(ctx context.Context) TaskDefinitionResourceRequirementOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionResourceRequirementOutput)
+}
+
+// TaskDefinitionResourceRequirementArrayInput is an input type that accepts TaskDefinitionResourceRequirementArray and TaskDefinitionResourceRequirementArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionResourceRequirementArrayInput` via:
+//
+//          TaskDefinitionResourceRequirementArray{ TaskDefinitionResourceRequirementArgs{...} }
+type TaskDefinitionResourceRequirementArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionResourceRequirementArrayOutput() TaskDefinitionResourceRequirementArrayOutput
+	ToTaskDefinitionResourceRequirementArrayOutputWithContext(context.Context) TaskDefinitionResourceRequirementArrayOutput
+}
+
+type TaskDefinitionResourceRequirementArray []TaskDefinitionResourceRequirementInput
+
+func (TaskDefinitionResourceRequirementArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionResourceRequirement)(nil)).Elem()
+}
+
+func (i TaskDefinitionResourceRequirementArray) ToTaskDefinitionResourceRequirementArrayOutput() TaskDefinitionResourceRequirementArrayOutput {
+	return i.ToTaskDefinitionResourceRequirementArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionResourceRequirementArray) ToTaskDefinitionResourceRequirementArrayOutputWithContext(ctx context.Context) TaskDefinitionResourceRequirementArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionResourceRequirementArrayOutput)
+}
+
+type TaskDefinitionResourceRequirementOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionResourceRequirementOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionResourceRequirement)(nil)).Elem()
+}
+
+func (o TaskDefinitionResourceRequirementOutput) ToTaskDefinitionResourceRequirementOutput() TaskDefinitionResourceRequirementOutput {
+	return o
+}
+
+func (o TaskDefinitionResourceRequirementOutput) ToTaskDefinitionResourceRequirementOutputWithContext(ctx context.Context) TaskDefinitionResourceRequirementOutput {
+	return o
+}
+
+func (o TaskDefinitionResourceRequirementOutput) Type() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionResourceRequirement) string { return v.Type }).(pulumi.StringOutput)
+}
+
+func (o TaskDefinitionResourceRequirementOutput) Value() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionResourceRequirement) string { return v.Value }).(pulumi.StringOutput)
+}
+
+type TaskDefinitionResourceRequirementArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionResourceRequirementArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionResourceRequirement)(nil)).Elem()
+}
+
+func (o TaskDefinitionResourceRequirementArrayOutput) ToTaskDefinitionResourceRequirementArrayOutput() TaskDefinitionResourceRequirementArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionResourceRequirementArrayOutput) ToTaskDefinitionResourceRequirementArrayOutputWithContext(ctx context.Context) TaskDefinitionResourceRequirementArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionResourceRequirementArrayOutput) Index(i pulumi.IntInput) TaskDefinitionResourceRequirementOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionResourceRequirement {
+		return vs[0].([]TaskDefinitionResourceRequirement)[vs[1].(int)]
+	}).(TaskDefinitionResourceRequirementOutput)
+}
+
 type TaskDefinitionSecret struct {
 	Name      string `pulumi:"name"`
 	ValueFrom string `pulumi:"valueFrom"`
 }
 
+// TaskDefinitionSecretInput is an input type that accepts TaskDefinitionSecretArgs and TaskDefinitionSecretOutput values.
+// You can construct a concrete instance of `TaskDefinitionSecretInput` via:
+//
+//          TaskDefinitionSecretArgs{...}
+type TaskDefinitionSecretInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionSecretOutput() TaskDefinitionSecretOutput
+	ToTaskDefinitionSecretOutputWithContext(context.Context) TaskDefinitionSecretOutput
+}
+
+type TaskDefinitionSecretArgs struct {
+	Name      pulumi.StringInput `pulumi:"name"`
+	ValueFrom pulumi.StringInput `pulumi:"valueFrom"`
+}
+
+func (TaskDefinitionSecretArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionSecret)(nil)).Elem()
+}
+
+func (i TaskDefinitionSecretArgs) ToTaskDefinitionSecretOutput() TaskDefinitionSecretOutput {
+	return i.ToTaskDefinitionSecretOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionSecretArgs) ToTaskDefinitionSecretOutputWithContext(ctx context.Context) TaskDefinitionSecretOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionSecretOutput)
+}
+
+// TaskDefinitionSecretArrayInput is an input type that accepts TaskDefinitionSecretArray and TaskDefinitionSecretArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionSecretArrayInput` via:
+//
+//          TaskDefinitionSecretArray{ TaskDefinitionSecretArgs{...} }
+type TaskDefinitionSecretArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionSecretArrayOutput() TaskDefinitionSecretArrayOutput
+	ToTaskDefinitionSecretArrayOutputWithContext(context.Context) TaskDefinitionSecretArrayOutput
+}
+
+type TaskDefinitionSecretArray []TaskDefinitionSecretInput
+
+func (TaskDefinitionSecretArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionSecret)(nil)).Elem()
+}
+
+func (i TaskDefinitionSecretArray) ToTaskDefinitionSecretArrayOutput() TaskDefinitionSecretArrayOutput {
+	return i.ToTaskDefinitionSecretArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionSecretArray) ToTaskDefinitionSecretArrayOutputWithContext(ctx context.Context) TaskDefinitionSecretArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionSecretArrayOutput)
+}
+
+type TaskDefinitionSecretOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionSecretOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionSecret)(nil)).Elem()
+}
+
+func (o TaskDefinitionSecretOutput) ToTaskDefinitionSecretOutput() TaskDefinitionSecretOutput {
+	return o
+}
+
+func (o TaskDefinitionSecretOutput) ToTaskDefinitionSecretOutputWithContext(ctx context.Context) TaskDefinitionSecretOutput {
+	return o
+}
+
+func (o TaskDefinitionSecretOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionSecret) string { return v.Name }).(pulumi.StringOutput)
+}
+
+func (o TaskDefinitionSecretOutput) ValueFrom() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionSecret) string { return v.ValueFrom }).(pulumi.StringOutput)
+}
+
+type TaskDefinitionSecretArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionSecretArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionSecret)(nil)).Elem()
+}
+
+func (o TaskDefinitionSecretArrayOutput) ToTaskDefinitionSecretArrayOutput() TaskDefinitionSecretArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionSecretArrayOutput) ToTaskDefinitionSecretArrayOutputWithContext(ctx context.Context) TaskDefinitionSecretArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionSecretArrayOutput) Index(i pulumi.IntInput) TaskDefinitionSecretOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionSecret {
+		return vs[0].([]TaskDefinitionSecret)[vs[1].(int)]
+	}).(TaskDefinitionSecretOutput)
+}
+
 type TaskDefinitionSystemControl struct {
 	Namespace *string `pulumi:"namespace"`
 	Value     *string `pulumi:"value"`
+}
+
+// TaskDefinitionSystemControlInput is an input type that accepts TaskDefinitionSystemControlArgs and TaskDefinitionSystemControlOutput values.
+// You can construct a concrete instance of `TaskDefinitionSystemControlInput` via:
+//
+//          TaskDefinitionSystemControlArgs{...}
+type TaskDefinitionSystemControlInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionSystemControlOutput() TaskDefinitionSystemControlOutput
+	ToTaskDefinitionSystemControlOutputWithContext(context.Context) TaskDefinitionSystemControlOutput
+}
+
+type TaskDefinitionSystemControlArgs struct {
+	Namespace pulumi.StringPtrInput `pulumi:"namespace"`
+	Value     pulumi.StringPtrInput `pulumi:"value"`
+}
+
+func (TaskDefinitionSystemControlArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionSystemControl)(nil)).Elem()
+}
+
+func (i TaskDefinitionSystemControlArgs) ToTaskDefinitionSystemControlOutput() TaskDefinitionSystemControlOutput {
+	return i.ToTaskDefinitionSystemControlOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionSystemControlArgs) ToTaskDefinitionSystemControlOutputWithContext(ctx context.Context) TaskDefinitionSystemControlOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionSystemControlOutput)
+}
+
+// TaskDefinitionSystemControlArrayInput is an input type that accepts TaskDefinitionSystemControlArray and TaskDefinitionSystemControlArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionSystemControlArrayInput` via:
+//
+//          TaskDefinitionSystemControlArray{ TaskDefinitionSystemControlArgs{...} }
+type TaskDefinitionSystemControlArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionSystemControlArrayOutput() TaskDefinitionSystemControlArrayOutput
+	ToTaskDefinitionSystemControlArrayOutputWithContext(context.Context) TaskDefinitionSystemControlArrayOutput
+}
+
+type TaskDefinitionSystemControlArray []TaskDefinitionSystemControlInput
+
+func (TaskDefinitionSystemControlArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionSystemControl)(nil)).Elem()
+}
+
+func (i TaskDefinitionSystemControlArray) ToTaskDefinitionSystemControlArrayOutput() TaskDefinitionSystemControlArrayOutput {
+	return i.ToTaskDefinitionSystemControlArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionSystemControlArray) ToTaskDefinitionSystemControlArrayOutputWithContext(ctx context.Context) TaskDefinitionSystemControlArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionSystemControlArrayOutput)
+}
+
+type TaskDefinitionSystemControlOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionSystemControlOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionSystemControl)(nil)).Elem()
+}
+
+func (o TaskDefinitionSystemControlOutput) ToTaskDefinitionSystemControlOutput() TaskDefinitionSystemControlOutput {
+	return o
+}
+
+func (o TaskDefinitionSystemControlOutput) ToTaskDefinitionSystemControlOutputWithContext(ctx context.Context) TaskDefinitionSystemControlOutput {
+	return o
+}
+
+func (o TaskDefinitionSystemControlOutput) Namespace() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionSystemControl) *string { return v.Namespace }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionSystemControlOutput) Value() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionSystemControl) *string { return v.Value }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionSystemControlArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionSystemControlArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionSystemControl)(nil)).Elem()
+}
+
+func (o TaskDefinitionSystemControlArrayOutput) ToTaskDefinitionSystemControlArrayOutput() TaskDefinitionSystemControlArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionSystemControlArrayOutput) ToTaskDefinitionSystemControlArrayOutputWithContext(ctx context.Context) TaskDefinitionSystemControlArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionSystemControlArrayOutput) Index(i pulumi.IntInput) TaskDefinitionSystemControlOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionSystemControl {
+		return vs[0].([]TaskDefinitionSystemControl)[vs[1].(int)]
+	}).(TaskDefinitionSystemControlOutput)
 }
 
 type TaskDefinitionTmpfs struct {
@@ -264,10 +3886,210 @@ type TaskDefinitionTmpfs struct {
 	Size          int      `pulumi:"size"`
 }
 
+// TaskDefinitionTmpfsInput is an input type that accepts TaskDefinitionTmpfsArgs and TaskDefinitionTmpfsOutput values.
+// You can construct a concrete instance of `TaskDefinitionTmpfsInput` via:
+//
+//          TaskDefinitionTmpfsArgs{...}
+type TaskDefinitionTmpfsInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionTmpfsOutput() TaskDefinitionTmpfsOutput
+	ToTaskDefinitionTmpfsOutputWithContext(context.Context) TaskDefinitionTmpfsOutput
+}
+
+type TaskDefinitionTmpfsArgs struct {
+	ContainerPath pulumi.StringPtrInput   `pulumi:"containerPath"`
+	MountOptions  pulumi.StringArrayInput `pulumi:"mountOptions"`
+	Size          pulumi.IntInput         `pulumi:"size"`
+}
+
+func (TaskDefinitionTmpfsArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionTmpfs)(nil)).Elem()
+}
+
+func (i TaskDefinitionTmpfsArgs) ToTaskDefinitionTmpfsOutput() TaskDefinitionTmpfsOutput {
+	return i.ToTaskDefinitionTmpfsOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionTmpfsArgs) ToTaskDefinitionTmpfsOutputWithContext(ctx context.Context) TaskDefinitionTmpfsOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionTmpfsOutput)
+}
+
+// TaskDefinitionTmpfsArrayInput is an input type that accepts TaskDefinitionTmpfsArray and TaskDefinitionTmpfsArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionTmpfsArrayInput` via:
+//
+//          TaskDefinitionTmpfsArray{ TaskDefinitionTmpfsArgs{...} }
+type TaskDefinitionTmpfsArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionTmpfsArrayOutput() TaskDefinitionTmpfsArrayOutput
+	ToTaskDefinitionTmpfsArrayOutputWithContext(context.Context) TaskDefinitionTmpfsArrayOutput
+}
+
+type TaskDefinitionTmpfsArray []TaskDefinitionTmpfsInput
+
+func (TaskDefinitionTmpfsArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionTmpfs)(nil)).Elem()
+}
+
+func (i TaskDefinitionTmpfsArray) ToTaskDefinitionTmpfsArrayOutput() TaskDefinitionTmpfsArrayOutput {
+	return i.ToTaskDefinitionTmpfsArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionTmpfsArray) ToTaskDefinitionTmpfsArrayOutputWithContext(ctx context.Context) TaskDefinitionTmpfsArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionTmpfsArrayOutput)
+}
+
+type TaskDefinitionTmpfsOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionTmpfsOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionTmpfs)(nil)).Elem()
+}
+
+func (o TaskDefinitionTmpfsOutput) ToTaskDefinitionTmpfsOutput() TaskDefinitionTmpfsOutput {
+	return o
+}
+
+func (o TaskDefinitionTmpfsOutput) ToTaskDefinitionTmpfsOutputWithContext(ctx context.Context) TaskDefinitionTmpfsOutput {
+	return o
+}
+
+func (o TaskDefinitionTmpfsOutput) ContainerPath() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionTmpfs) *string { return v.ContainerPath }).(pulumi.StringPtrOutput)
+}
+
+func (o TaskDefinitionTmpfsOutput) MountOptions() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v TaskDefinitionTmpfs) []string { return v.MountOptions }).(pulumi.StringArrayOutput)
+}
+
+func (o TaskDefinitionTmpfsOutput) Size() pulumi.IntOutput {
+	return o.ApplyT(func(v TaskDefinitionTmpfs) int { return v.Size }).(pulumi.IntOutput)
+}
+
+type TaskDefinitionTmpfsArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionTmpfsArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionTmpfs)(nil)).Elem()
+}
+
+func (o TaskDefinitionTmpfsArrayOutput) ToTaskDefinitionTmpfsArrayOutput() TaskDefinitionTmpfsArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionTmpfsArrayOutput) ToTaskDefinitionTmpfsArrayOutputWithContext(ctx context.Context) TaskDefinitionTmpfsArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionTmpfsArrayOutput) Index(i pulumi.IntInput) TaskDefinitionTmpfsOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionTmpfs {
+		return vs[0].([]TaskDefinitionTmpfs)[vs[1].(int)]
+	}).(TaskDefinitionTmpfsOutput)
+}
+
 type TaskDefinitionUlimit struct {
 	HardLimit int    `pulumi:"hardLimit"`
 	Name      string `pulumi:"name"`
 	SoftLimit int    `pulumi:"softLimit"`
+}
+
+// TaskDefinitionUlimitInput is an input type that accepts TaskDefinitionUlimitArgs and TaskDefinitionUlimitOutput values.
+// You can construct a concrete instance of `TaskDefinitionUlimitInput` via:
+//
+//          TaskDefinitionUlimitArgs{...}
+type TaskDefinitionUlimitInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionUlimitOutput() TaskDefinitionUlimitOutput
+	ToTaskDefinitionUlimitOutputWithContext(context.Context) TaskDefinitionUlimitOutput
+}
+
+type TaskDefinitionUlimitArgs struct {
+	HardLimit pulumi.IntInput    `pulumi:"hardLimit"`
+	Name      pulumi.StringInput `pulumi:"name"`
+	SoftLimit pulumi.IntInput    `pulumi:"softLimit"`
+}
+
+func (TaskDefinitionUlimitArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionUlimit)(nil)).Elem()
+}
+
+func (i TaskDefinitionUlimitArgs) ToTaskDefinitionUlimitOutput() TaskDefinitionUlimitOutput {
+	return i.ToTaskDefinitionUlimitOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionUlimitArgs) ToTaskDefinitionUlimitOutputWithContext(ctx context.Context) TaskDefinitionUlimitOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionUlimitOutput)
+}
+
+// TaskDefinitionUlimitArrayInput is an input type that accepts TaskDefinitionUlimitArray and TaskDefinitionUlimitArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionUlimitArrayInput` via:
+//
+//          TaskDefinitionUlimitArray{ TaskDefinitionUlimitArgs{...} }
+type TaskDefinitionUlimitArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionUlimitArrayOutput() TaskDefinitionUlimitArrayOutput
+	ToTaskDefinitionUlimitArrayOutputWithContext(context.Context) TaskDefinitionUlimitArrayOutput
+}
+
+type TaskDefinitionUlimitArray []TaskDefinitionUlimitInput
+
+func (TaskDefinitionUlimitArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionUlimit)(nil)).Elem()
+}
+
+func (i TaskDefinitionUlimitArray) ToTaskDefinitionUlimitArrayOutput() TaskDefinitionUlimitArrayOutput {
+	return i.ToTaskDefinitionUlimitArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionUlimitArray) ToTaskDefinitionUlimitArrayOutputWithContext(ctx context.Context) TaskDefinitionUlimitArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionUlimitArrayOutput)
+}
+
+type TaskDefinitionUlimitOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionUlimitOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionUlimit)(nil)).Elem()
+}
+
+func (o TaskDefinitionUlimitOutput) ToTaskDefinitionUlimitOutput() TaskDefinitionUlimitOutput {
+	return o
+}
+
+func (o TaskDefinitionUlimitOutput) ToTaskDefinitionUlimitOutputWithContext(ctx context.Context) TaskDefinitionUlimitOutput {
+	return o
+}
+
+func (o TaskDefinitionUlimitOutput) HardLimit() pulumi.IntOutput {
+	return o.ApplyT(func(v TaskDefinitionUlimit) int { return v.HardLimit }).(pulumi.IntOutput)
+}
+
+func (o TaskDefinitionUlimitOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v TaskDefinitionUlimit) string { return v.Name }).(pulumi.StringOutput)
+}
+
+func (o TaskDefinitionUlimitOutput) SoftLimit() pulumi.IntOutput {
+	return o.ApplyT(func(v TaskDefinitionUlimit) int { return v.SoftLimit }).(pulumi.IntOutput)
+}
+
+type TaskDefinitionUlimitArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionUlimitArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionUlimit)(nil)).Elem()
+}
+
+func (o TaskDefinitionUlimitArrayOutput) ToTaskDefinitionUlimitArrayOutput() TaskDefinitionUlimitArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionUlimitArrayOutput) ToTaskDefinitionUlimitArrayOutputWithContext(ctx context.Context) TaskDefinitionUlimitArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionUlimitArrayOutput) Index(i pulumi.IntInput) TaskDefinitionUlimitOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionUlimit {
+		return vs[0].([]TaskDefinitionUlimit)[vs[1].(int)]
+	}).(TaskDefinitionUlimitOutput)
 }
 
 type TaskDefinitionVolumeFrom struct {
@@ -275,5 +4097,190 @@ type TaskDefinitionVolumeFrom struct {
 	SourceContainer *string `pulumi:"sourceContainer"`
 }
 
+// TaskDefinitionVolumeFromInput is an input type that accepts TaskDefinitionVolumeFromArgs and TaskDefinitionVolumeFromOutput values.
+// You can construct a concrete instance of `TaskDefinitionVolumeFromInput` via:
+//
+//          TaskDefinitionVolumeFromArgs{...}
+type TaskDefinitionVolumeFromInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionVolumeFromOutput() TaskDefinitionVolumeFromOutput
+	ToTaskDefinitionVolumeFromOutputWithContext(context.Context) TaskDefinitionVolumeFromOutput
+}
+
+type TaskDefinitionVolumeFromArgs struct {
+	ReadOnly        pulumi.BoolPtrInput   `pulumi:"readOnly"`
+	SourceContainer pulumi.StringPtrInput `pulumi:"sourceContainer"`
+}
+
+func (TaskDefinitionVolumeFromArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionVolumeFrom)(nil)).Elem()
+}
+
+func (i TaskDefinitionVolumeFromArgs) ToTaskDefinitionVolumeFromOutput() TaskDefinitionVolumeFromOutput {
+	return i.ToTaskDefinitionVolumeFromOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionVolumeFromArgs) ToTaskDefinitionVolumeFromOutputWithContext(ctx context.Context) TaskDefinitionVolumeFromOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionVolumeFromOutput)
+}
+
+// TaskDefinitionVolumeFromArrayInput is an input type that accepts TaskDefinitionVolumeFromArray and TaskDefinitionVolumeFromArrayOutput values.
+// You can construct a concrete instance of `TaskDefinitionVolumeFromArrayInput` via:
+//
+//          TaskDefinitionVolumeFromArray{ TaskDefinitionVolumeFromArgs{...} }
+type TaskDefinitionVolumeFromArrayInput interface {
+	pulumi.Input
+
+	ToTaskDefinitionVolumeFromArrayOutput() TaskDefinitionVolumeFromArrayOutput
+	ToTaskDefinitionVolumeFromArrayOutputWithContext(context.Context) TaskDefinitionVolumeFromArrayOutput
+}
+
+type TaskDefinitionVolumeFromArray []TaskDefinitionVolumeFromInput
+
+func (TaskDefinitionVolumeFromArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionVolumeFrom)(nil)).Elem()
+}
+
+func (i TaskDefinitionVolumeFromArray) ToTaskDefinitionVolumeFromArrayOutput() TaskDefinitionVolumeFromArrayOutput {
+	return i.ToTaskDefinitionVolumeFromArrayOutputWithContext(context.Background())
+}
+
+func (i TaskDefinitionVolumeFromArray) ToTaskDefinitionVolumeFromArrayOutputWithContext(ctx context.Context) TaskDefinitionVolumeFromArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(TaskDefinitionVolumeFromArrayOutput)
+}
+
+type TaskDefinitionVolumeFromOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionVolumeFromOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*TaskDefinitionVolumeFrom)(nil)).Elem()
+}
+
+func (o TaskDefinitionVolumeFromOutput) ToTaskDefinitionVolumeFromOutput() TaskDefinitionVolumeFromOutput {
+	return o
+}
+
+func (o TaskDefinitionVolumeFromOutput) ToTaskDefinitionVolumeFromOutputWithContext(ctx context.Context) TaskDefinitionVolumeFromOutput {
+	return o
+}
+
+func (o TaskDefinitionVolumeFromOutput) ReadOnly() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionVolumeFrom) *bool { return v.ReadOnly }).(pulumi.BoolPtrOutput)
+}
+
+func (o TaskDefinitionVolumeFromOutput) SourceContainer() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v TaskDefinitionVolumeFrom) *string { return v.SourceContainer }).(pulumi.StringPtrOutput)
+}
+
+type TaskDefinitionVolumeFromArrayOutput struct{ *pulumi.OutputState }
+
+func (TaskDefinitionVolumeFromArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]TaskDefinitionVolumeFrom)(nil)).Elem()
+}
+
+func (o TaskDefinitionVolumeFromArrayOutput) ToTaskDefinitionVolumeFromArrayOutput() TaskDefinitionVolumeFromArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionVolumeFromArrayOutput) ToTaskDefinitionVolumeFromArrayOutputWithContext(ctx context.Context) TaskDefinitionVolumeFromArrayOutput {
+	return o
+}
+
+func (o TaskDefinitionVolumeFromArrayOutput) Index(i pulumi.IntInput) TaskDefinitionVolumeFromOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) TaskDefinitionVolumeFrom {
+		return vs[0].([]TaskDefinitionVolumeFrom)[vs[1].(int)]
+	}).(TaskDefinitionVolumeFromOutput)
+}
+
 func init() {
+	pulumi.RegisterInputType(reflect.TypeOf((*EC2ServiceTaskDefinitionInput)(nil)).Elem(), EC2ServiceTaskDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*EC2ServiceTaskDefinitionPtrInput)(nil)).Elem(), EC2ServiceTaskDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FargateServiceTaskDefinitionInput)(nil)).Elem(), FargateServiceTaskDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*FargateServiceTaskDefinitionPtrInput)(nil)).Elem(), FargateServiceTaskDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionContainerDefinitionInput)(nil)).Elem(), TaskDefinitionContainerDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionContainerDefinitionPtrInput)(nil)).Elem(), TaskDefinitionContainerDefinitionArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionContainerDefinitionMapInput)(nil)).Elem(), TaskDefinitionContainerDefinitionMap{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionContainerDependencyInput)(nil)).Elem(), TaskDefinitionContainerDependencyArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionContainerDependencyArrayInput)(nil)).Elem(), TaskDefinitionContainerDependencyArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionDeviceInput)(nil)).Elem(), TaskDefinitionDeviceArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionDeviceArrayInput)(nil)).Elem(), TaskDefinitionDeviceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionEnvironmentFileInput)(nil)).Elem(), TaskDefinitionEnvironmentFileArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionEnvironmentFileArrayInput)(nil)).Elem(), TaskDefinitionEnvironmentFileArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionFirelensConfigurationInput)(nil)).Elem(), TaskDefinitionFirelensConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionFirelensConfigurationPtrInput)(nil)).Elem(), TaskDefinitionFirelensConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionHealthCheckInput)(nil)).Elem(), TaskDefinitionHealthCheckArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionHealthCheckPtrInput)(nil)).Elem(), TaskDefinitionHealthCheckArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionHostEntryInput)(nil)).Elem(), TaskDefinitionHostEntryArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionHostEntryArrayInput)(nil)).Elem(), TaskDefinitionHostEntryArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionKernelCapabilitiesInput)(nil)).Elem(), TaskDefinitionKernelCapabilitiesArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionKernelCapabilitiesPtrInput)(nil)).Elem(), TaskDefinitionKernelCapabilitiesArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionKeyValuePairInput)(nil)).Elem(), TaskDefinitionKeyValuePairArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionKeyValuePairArrayInput)(nil)).Elem(), TaskDefinitionKeyValuePairArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionLinuxParametersInput)(nil)).Elem(), TaskDefinitionLinuxParametersArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionLinuxParametersPtrInput)(nil)).Elem(), TaskDefinitionLinuxParametersArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionLogConfigurationInput)(nil)).Elem(), TaskDefinitionLogConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionLogConfigurationPtrInput)(nil)).Elem(), TaskDefinitionLogConfigurationArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionMountPointInput)(nil)).Elem(), TaskDefinitionMountPointArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionMountPointArrayInput)(nil)).Elem(), TaskDefinitionMountPointArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionPortMappingInput)(nil)).Elem(), TaskDefinitionPortMappingArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionPortMappingArrayInput)(nil)).Elem(), TaskDefinitionPortMappingArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionRepositoryCredentialsInput)(nil)).Elem(), TaskDefinitionRepositoryCredentialsArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionRepositoryCredentialsPtrInput)(nil)).Elem(), TaskDefinitionRepositoryCredentialsArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionResourceRequirementInput)(nil)).Elem(), TaskDefinitionResourceRequirementArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionResourceRequirementArrayInput)(nil)).Elem(), TaskDefinitionResourceRequirementArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionSecretInput)(nil)).Elem(), TaskDefinitionSecretArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionSecretArrayInput)(nil)).Elem(), TaskDefinitionSecretArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionSystemControlInput)(nil)).Elem(), TaskDefinitionSystemControlArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionSystemControlArrayInput)(nil)).Elem(), TaskDefinitionSystemControlArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionTmpfsInput)(nil)).Elem(), TaskDefinitionTmpfsArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionTmpfsArrayInput)(nil)).Elem(), TaskDefinitionTmpfsArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionUlimitInput)(nil)).Elem(), TaskDefinitionUlimitArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionUlimitArrayInput)(nil)).Elem(), TaskDefinitionUlimitArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionVolumeFromInput)(nil)).Elem(), TaskDefinitionVolumeFromArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TaskDefinitionVolumeFromArrayInput)(nil)).Elem(), TaskDefinitionVolumeFromArray{})
+	pulumi.RegisterOutputType(EC2ServiceTaskDefinitionOutput{})
+	pulumi.RegisterOutputType(EC2ServiceTaskDefinitionPtrOutput{})
+	pulumi.RegisterOutputType(FargateServiceTaskDefinitionOutput{})
+	pulumi.RegisterOutputType(FargateServiceTaskDefinitionPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionContainerDefinitionOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionContainerDefinitionPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionContainerDefinitionMapOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionContainerDependencyOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionContainerDependencyArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionDeviceOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionDeviceArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionEnvironmentFileOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionEnvironmentFileArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionFirelensConfigurationOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionFirelensConfigurationPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionHealthCheckOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionHealthCheckPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionHostEntryOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionHostEntryArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionKernelCapabilitiesOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionKernelCapabilitiesPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionKeyValuePairOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionKeyValuePairArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionLinuxParametersOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionLinuxParametersPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionLogConfigurationOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionLogConfigurationPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionMountPointOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionMountPointArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionPortMappingOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionPortMappingArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionRepositoryCredentialsOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionRepositoryCredentialsPtrOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionResourceRequirementOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionResourceRequirementArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionSecretOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionSecretArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionSystemControlOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionSystemControlArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionTmpfsOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionTmpfsArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionUlimitOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionUlimitArrayOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionVolumeFromOutput{})
+	pulumi.RegisterOutputType(TaskDefinitionVolumeFromArrayOutput{})
 }

--- a/sdk/go/awsx/lb/applicationLoadBalancer.go
+++ b/sdk/go/awsx/lb/applicationLoadBalancer.go
@@ -104,9 +104,9 @@ type ApplicationLoadBalancerArgs struct {
 	// The ID of the customer owned ipv4 pool to use for this load balancer.
 	CustomerOwnedIpv4Pool pulumi.StringPtrInput
 	// Options for creating a default security group if [securityGroups] not specified.
-	DefaultSecurityGroup *awsx.DefaultSecurityGroup
+	DefaultSecurityGroup *awsx.DefaultSecurityGroupArgs
 	// Options creating a default target group.
-	DefaultTargetGroup *TargetGroup
+	DefaultTargetGroup *TargetGroupArgs
 	// Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
 	DesyncMitigationMode pulumi.StringPtrInput
 	// Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
@@ -125,9 +125,9 @@ type ApplicationLoadBalancerArgs struct {
 	// The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`
 	IpAddressType pulumi.StringPtrInput
 	// A listener to create. Only one of [listener] and [listeners] can be specified.
-	Listener *Listener
+	Listener *ListenerArgs
 	// List of listeners to create. Only one of [listener] and [listeners] can be specified.
-	Listeners []Listener
+	Listeners []ListenerArgs
 	// The name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters,
 	// must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified,
 	// this provider will autogenerate a name beginning with `tf-lb`.
@@ -233,6 +233,31 @@ func (o ApplicationLoadBalancerOutput) ToApplicationLoadBalancerOutput() Applica
 
 func (o ApplicationLoadBalancerOutput) ToApplicationLoadBalancerOutputWithContext(ctx context.Context) ApplicationLoadBalancerOutput {
 	return o
+}
+
+// Default security group, if auto-created
+func (o ApplicationLoadBalancerOutput) DefaultSecurityGroup() ec2.SecurityGroupOutput {
+	return o.ApplyT(func(v *ApplicationLoadBalancer) ec2.SecurityGroupOutput { return v.DefaultSecurityGroup }).(ec2.SecurityGroupOutput)
+}
+
+// Default target group, if auto-created
+func (o ApplicationLoadBalancerOutput) DefaultTargetGroup() lb.TargetGroupOutput {
+	return o.ApplyT(func(v *ApplicationLoadBalancer) lb.TargetGroupOutput { return v.DefaultTargetGroup }).(lb.TargetGroupOutput)
+}
+
+// Listeners created as part of this load balancer
+func (o ApplicationLoadBalancerOutput) Listeners() lb.ListenerArrayOutput {
+	return o.ApplyT(func(v *ApplicationLoadBalancer) lb.ListenerArrayOutput { return v.Listeners }).(lb.ListenerArrayOutput)
+}
+
+// Underlying Load Balancer resource
+func (o ApplicationLoadBalancerOutput) LoadBalancer() lb.LoadBalancerOutput {
+	return o.ApplyT(func(v *ApplicationLoadBalancer) lb.LoadBalancerOutput { return v.LoadBalancer }).(lb.LoadBalancerOutput)
+}
+
+// Id of the VPC in which this load balancer is operating
+func (o ApplicationLoadBalancerOutput) VpcId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *ApplicationLoadBalancer) pulumi.StringPtrOutput { return v.VpcId }).(pulumi.StringPtrOutput)
 }
 
 type ApplicationLoadBalancerArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/lb/networkLoadBalancer.go
+++ b/sdk/go/awsx/lb/networkLoadBalancer.go
@@ -95,7 +95,7 @@ type NetworkLoadBalancerArgs struct {
 	// The ID of the customer owned ipv4 pool to use for this load balancer.
 	CustomerOwnedIpv4Pool pulumi.StringPtrInput
 	// Options creating a default target group.
-	DefaultTargetGroup *TargetGroup
+	DefaultTargetGroup *TargetGroupArgs
 	// Determines how the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
 	DesyncMitigationMode pulumi.StringPtrInput
 	// Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type `application`.
@@ -115,9 +115,9 @@ type NetworkLoadBalancerArgs struct {
 	// The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`
 	IpAddressType pulumi.StringPtrInput
 	// A listener to create. Only one of [listener] and [listeners] can be specified.
-	Listener *Listener
+	Listener *ListenerArgs
 	// List of listeners to create. Only one of [listener] and [listeners] can be specified.
-	Listeners []Listener
+	Listeners []ListenerArgs
 	// The name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters,
 	// must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified,
 	// this provider will autogenerate a name beginning with `tf-lb`.
@@ -221,6 +221,26 @@ func (o NetworkLoadBalancerOutput) ToNetworkLoadBalancerOutput() NetworkLoadBala
 
 func (o NetworkLoadBalancerOutput) ToNetworkLoadBalancerOutputWithContext(ctx context.Context) NetworkLoadBalancerOutput {
 	return o
+}
+
+// Default target group, if auto-created
+func (o NetworkLoadBalancerOutput) DefaultTargetGroup() lb.TargetGroupOutput {
+	return o.ApplyT(func(v *NetworkLoadBalancer) lb.TargetGroupOutput { return v.DefaultTargetGroup }).(lb.TargetGroupOutput)
+}
+
+// Listeners created as part of this load balancer
+func (o NetworkLoadBalancerOutput) Listeners() lb.ListenerArrayOutput {
+	return o.ApplyT(func(v *NetworkLoadBalancer) lb.ListenerArrayOutput { return v.Listeners }).(lb.ListenerArrayOutput)
+}
+
+// Underlying Load Balancer resource
+func (o NetworkLoadBalancerOutput) LoadBalancer() lb.LoadBalancerOutput {
+	return o.ApplyT(func(v *NetworkLoadBalancer) lb.LoadBalancerOutput { return v.LoadBalancer }).(lb.LoadBalancerOutput)
+}
+
+// Id of the VPC in which this load balancer is operating
+func (o NetworkLoadBalancerOutput) VpcId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *NetworkLoadBalancer) pulumi.StringPtrOutput { return v.VpcId }).(pulumi.StringPtrOutput)
 }
 
 type NetworkLoadBalancerArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/awsx/lb/targetGroupAttachment.go
+++ b/sdk/go/awsx/lb/targetGroupAttachment.go
@@ -156,6 +156,16 @@ func (o TargetGroupAttachmentOutput) ToTargetGroupAttachmentOutputWithContext(ct
 	return o
 }
 
+// Auto-created Lambda permission, if targeting a Lambda function
+func (o TargetGroupAttachmentOutput) LambdaPermission() lambda.PermissionOutput {
+	return o.ApplyT(func(v *TargetGroupAttachment) lambda.PermissionOutput { return v.LambdaPermission }).(lambda.PermissionOutput)
+}
+
+// Underlying Target Group Attachment resource
+func (o TargetGroupAttachmentOutput) TargetGroupAttachment() lb.TargetGroupAttachmentOutput {
+	return o.ApplyT(func(v *TargetGroupAttachment) lb.TargetGroupAttachmentOutput { return v.TargetGroupAttachment }).(lb.TargetGroupAttachmentOutput)
+}
+
 type TargetGroupAttachmentArrayOutput struct{ *pulumi.OutputState }
 
 func (TargetGroupAttachmentArrayOutput) ElementType() reflect.Type {


### PR DESCRIPTION
Updates the Go SDK codegen and dependencies to support:
- https://github.com/pulumi/pulumi/issues/9506
- https://github.com/pulumi/pulumi/issues/9507

This improves the Go SDK so that the following example can run without ApplyT:

```go
package main

import (
	aws_ecs "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/lb"
	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		cluster, err := aws_ecs.NewCluster(ctx, "cluster", nil)
		if err != nil {
			return err
		}
		lb, err := lb.NewApplicationLoadBalancer(ctx, "lb", nil)
		if err != nil {
			return err
		}
		_, err = ecs.NewFargateService(ctx, "nginx", &ecs.FargateServiceArgs{
			Cluster: cluster.Arn,
			TaskDefinitionArgs: &ecs.FargateServiceTaskDefinitionArgs{
				Container: &ecs.TaskDefinitionContainerDefinitionArgs{
					Image:  pulumi.StringPtr("nginx:latest"),
					Cpu:    pulumi.IntPtr(512),
					Memory: pulumi.IntPtr(128),
					PortMappings: ecs.TaskDefinitionPortMappingArray{
						ecs.TaskDefinitionPortMappingArgs{
							ContainerPort: pulumi.IntPtr(80),
							TargetGroup:   lb.DefaultTargetGroup,
						},
					},
				},
			},
		})
		if err != nil {
			return err
		}
		ctx.Export("dnsName", lb.LoadBalancer.DnsName())
		return nil
	})
}
```

Without these changes, the `ecs.NewFargateService` would have to be run in an ApplyT (9507), and the export of `dnsName` would require an ApplyT as well, with a very unintuitive signature.