### PR TITLE
Change reason for skipping TestDefaultVpc to point to relevant issue

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -104,7 +104,7 @@ func TestEcrSimple(t *testing.T) {
 }
 
 func TestDefaultVpc(t *testing.T) {
-	t.Skip("https://github.com/pulumi/pulumi-awsx/issues/784")
+	t.Skip("https://github.com/pulumi/pulumi-awsx/issues/788")
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			RunUpdateTest: false,


### PR DESCRIPTION
Change reason for skipping TestDefaultVpc to point to relevant issue.
The relevant issue is https://github.com/pulumi/pulumi-awsx/issues/788 and not https://github.com/pulumi/pulumi-awsx/issues/784

Note: I didn't add a changelog entry as I didn't think it was necessary as this change doesn't impact crosswalk.