### PR TITLE
Fix local provider install

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -99,7 +99,7 @@ jobs:
         goversion:
           - 1.17.x
         nodeversion:
-          - 14.x
+          - 16.x
   build_sdk:
     name: build_sdk
     runs-on: ubuntu-latest
@@ -171,7 +171,7 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   publish:
@@ -286,7 +286,7 @@ jobs:
         dotnetversion:
           - 3.1
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   acceptance-test:
@@ -381,7 +381,7 @@ jobs:
         pythonversion:
           - 3.8
         nodeversion:
-          - 14.x
+          - 16.x
         language:
           - nodejs
           - python

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -99,7 +99,7 @@ jobs:
         goversion:
           - 1.17.x
         nodeversion:
-          - 14.x
+          - 16.x
   build_sdk:
     name: build_sdk
     runs-on: ubuntu-latest
@@ -171,7 +171,7 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   publish:
@@ -294,7 +294,7 @@ jobs:
         dotnetversion:
           - 3.1
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   acceptance-test:
@@ -389,7 +389,7 @@ jobs:
         pythonversion:
           - 3.8
         nodeversion:
-          - 14.x
+          - 16.x
         language:
           - nodejs
           - python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         goversion:
           - 1.17.x
         nodeversion:
-          - 14.x
+          - 16.x
   build_sdk:
     name: build_sdk
     runs-on: ubuntu-latest
@@ -170,7 +170,7 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   publish:
@@ -292,7 +292,7 @@ jobs:
         dotnetversion:
           - 3.1
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   tag_sdk:
@@ -414,7 +414,7 @@ jobs:
         pythonversion:
           - 3.8
         nodeversion:
-          - 14.x
+          - 16.x
         language:
           - nodejs
           - python

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -114,7 +114,7 @@ jobs:
         goversion:
           - 1.17.x
         nodeversion:
-          - 14.x
+          - 16.x
   build_sdk:
     name: build_sdk
     runs-on: ubuntu-latest
@@ -187,7 +187,7 @@ jobs:
           - dotnet
           - go
         nodeversion:
-          - 14.x
+          - 16.x
         pythonversion:
           - "3.7"
   acceptance-test:
@@ -280,7 +280,7 @@ jobs:
         pythonversion:
           - 3.8
         nodeversion:
-          - 14.x
+          - 16.x
         language:
           - nodejs
           - python

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ provider:: schema ensure_provider
 dist:: provider
 	mkdir -p dist
 	cd bin && \
-		npx --yes -- pkg . --compress GZip --target node17 --output ../dist/${PROVIDER}
+		npx --yes -- pkg . --compress GZip --target node16 --output ../dist/${PROVIDER}
 
 install_provider:: dist
 	rm -f ${GOBIN}/${PROVIDER}
@@ -49,7 +49,7 @@ install_provider:: dist
 dist_all:: provider
 	mkdir -p dist
 	cd bin && \
-		npx --yes -- pkg . --compress GZip --target node17-macos-x64,node17-macos-arm64,node17-linux-x64,node17-win-x64 --output ../dist/out
+		npx --yes -- pkg . --compress GZip --target node16-macos-x64,node16-macos-arm64,node16-linux-x64,node16-win-x64 --output ../dist/out
 	cd dist && \
 		mv -f out-linux-x64 pulumi-resource-${PACK}-v${VERSION}-linux-amd64 && \
 		mv -f out-macos-x64 pulumi-resource-${PACK}-v${VERSION}-darwin-amd64 && \

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ CODEGEN         := pulumi-gen-${PACK}
 
 WORKING_DIR     := $(shell pwd)
 
-GOPATH 		 ?= "$(HOME)/go"
-GOBIN  		 ?= "$(GOPATH)/bin"
+GOPATH 		 ?= ${HOME}/go
+GOBIN  		 ?= ${GOPATH}/bin
 LanguageTags ?= "all"
 
 build:: provider build_nodejs build_python build_go build_dotnet
@@ -40,10 +40,11 @@ provider:: schema ensure_provider
 dist:: provider
 	mkdir -p dist
 	cd bin && \
-		npx --yes -- pkg . --compress GZip --target node17 --output ../dist/pulumi-resource-${PACK}
+		npx --yes -- pkg . --compress GZip --target node17 --output ../dist/${PROVIDER}
 
 install_provider:: dist
-	cp dist/pulumi-resource-${PACK} $(GOBIN)/pulumi-resource-${PACK}
+	rm -f ${GOBIN}/${PROVIDER}
+	cp dist/${PROVIDER} ${GOBIN}/${PROVIDER}
 
 dist_all:: provider
 	mkdir -p dist

--- a/awsx/scripts/generate-provider-types.ts
+++ b/awsx/scripts/generate-provider-types.ts
@@ -527,8 +527,8 @@ function resourceConstructorType() {
   );
 }
 
-export function generateProviderTypes(args: { schama: string; out: string }) {
-  const schemaPath = path.resolve(args.schama);
+export function generateProviderTypes(args: { schema: string; out: string }) {
+  const schemaPath = path.resolve(args.schema);
   const schemaText = fs.readFileSync(schemaPath, { encoding: "utf-8" });
   const schema: pulumiSchema.PulumiPackageMetaschema = JSON.parse(schemaText);
 
@@ -575,6 +575,6 @@ export function generateProviderTypes(args: { schama: string; out: string }) {
 }
 
 generateProviderTypes({
-  schama: "schema.json",
+  schema: "schema.json",
   out: "schema-types.ts",
 });

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -107,8 +107,9 @@ func TestDefaultVpc(t *testing.T) {
 	t.Skip("https://github.com/pulumi/pulumi-awsx/issues/788")
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false,
-			Dir:           filepath.Join(getCwd(t), "ts-vpc-getDefaultVpc"),
+			RunUpdateTest:    false,
+			Dir:              filepath.Join(getCwd(t), "ts-vpc-getDefaultVpc"),
+			RetryFailedSteps: true, // Internet Gateway occasionally fails to delete on first attempt.
 		})
 
 	integration.ProgramTest(t, &test)
@@ -117,8 +118,9 @@ func TestDefaultVpc(t *testing.T) {
 func TestVpcDefaultArgs(t *testing.T) {
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false,
-			Dir:           filepath.Join(getCwd(t), "vpc", "nodejs", "default-args"),
+			RunUpdateTest:    false,
+			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "default-args"),
+			RetryFailedSteps: true, // Internet Gateway occasionally fails to delete on first attempt.
 		})
 
 	integration.ProgramTest(t, &test)
@@ -127,8 +129,9 @@ func TestVpcDefaultArgs(t *testing.T) {
 func TestVpcWithServiceEndpoint(t *testing.T) {
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false,
-			Dir:           filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-with-service-endpoint"),
+			RunUpdateTest:    false,
+			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-with-service-endpoint"),
+			RetryFailedSteps: true, // Internet Gateway occasionally fails to delete on first attempt.
 		})
 
 	integration.ProgramTest(t, &test)
@@ -137,8 +140,9 @@ func TestVpcWithServiceEndpoint(t *testing.T) {
 func TestVpcSpecificSubnetSpecArgs(t *testing.T) {
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false,
-			Dir:           filepath.Join(getCwd(t), "vpc", "nodejs", "specific-vpc-layout"),
+			RunUpdateTest:    false,
+			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "specific-vpc-layout"),
+			RetryFailedSteps: true, // Internet Gateway occasionally fails to delete on first attempt.
 		})
 
 	integration.ProgramTest(t, &test)
@@ -147,8 +151,9 @@ func TestVpcSpecificSubnetSpecArgs(t *testing.T) {
 func TestVpcMultipleSimilarSubnetSpecArgs(t *testing.T) {
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			RunUpdateTest: false,
-			Dir:           filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-multiple-similar-subnet-types"),
+			RunUpdateTest:    false,
+			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-multiple-similar-subnet-types"),
+			RetryFailedSteps: true, // Internet Gateway occasionally fails to delete on first attempt.
 		})
 
 	integration.ProgramTest(t, &test)


### PR DESCRIPTION
For some reason, if the binary already exists in the gobin then after copying the new executable it fails with a message such as

```
[1]    9392 killed     ./pulumi-resource-awsx
```

To work around this, we'll just delete before copying, though not entirely sure why this works.