### PR TITLE
fix: add necessary dependencies for type checking to succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Add multi-lang component support scaffolding.
+* Fix type errors in TypeScript checking awsx-classic properties.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx-classic/apigateway/api.ts
+++ b/awsx-classic/apigateway/api.ts
@@ -21,7 +21,7 @@ import * as fspath from "path";
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as awslambda from "aws-lambda";
+import type * as awslambda from "aws-lambda";
 
 import { getRegion, ifUndefined, sha1hash } from "../utils";
 

--- a/awsx-classic/apigateway/lambdaAuthorizer.ts
+++ b/awsx-classic/apigateway/lambdaAuthorizer.ts
@@ -17,7 +17,7 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as awslambda from "aws-lambda";
+import type * as awslambda from "aws-lambda";
 import { CognitoAuthorizer } from "./cognitoAuthorizer";
 
 import * as utils from "../utils";

--- a/awsx-classic/ec2/vpcTopology.ts
+++ b/awsx-classic/ec2/vpcTopology.ts
@@ -445,14 +445,12 @@ class ExplicitLocationTopology extends VpcTopology {
     }
 }
 
-/** @internal */
 export interface VpcTopologyDescription {
     subnets: SubnetDescription[];
     natGateways: NatGatewayDescription[];
     natRoutes: NatRouteDescription[];
 }
 
-/** @internal */
 export interface SubnetDescription {
     type: VpcSubnetType;
     subnetName: string;
@@ -461,7 +459,6 @@ export interface SubnetDescription {
 }
 
 
-/** @internal */
 export interface NatGatewayDescription {
     name: string;
 
@@ -469,7 +466,6 @@ export interface NatGatewayDescription {
     publicSubnet: string;
 }
 
-/** @internal */
 export interface NatRouteDescription {
     name: string;
 

--- a/awsx-classic/ecs/taskDefinition.ts
+++ b/awsx-classic/ecs/taskDefinition.ts
@@ -14,7 +14,7 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import * as awssdk from "aws-sdk";
+import type * as awssdk from "aws-sdk";
 import * as ec2 from "../ec2";
 import * as lb from "../lb";
 import * as role from "../role";

--- a/awsx-classic/package.json
+++ b/awsx-classic/package.json
@@ -1,36 +1,31 @@
 {
     "name": "@pulumi/awsx",
     "version": "${VERSION}",
-    "description": "Pulumi Amazon Web Services (AWS) infrastructure components.",
-    "license": "Apache-2.0",
     "keywords": [
         "pulumi",
         "aws",
         "awsx"
     ],
-    "homepage": "https://pulumi.io",
+    "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-awsx",
+    "license": "Apache-2.0",
     "scripts": {
-        "install-peers": "install-peers",
-        "postinstall": "install-peers",
         "lint": "tslint -c tslint.json -p tsconfig.json"
     },
     "dependencies": {
+        "@pulumi/aws": "^5.3.0",
         "@pulumi/docker": "^3.0.0",
-        "@types/aws-lambda": "^8.10.23",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-lambda": "^1.0.7",
         "mime": "^2.0.0"
-    },
-    "peerDependencies": {
-        "@pulumi/aws": "~4.23.0",
-        "@pulumi/pulumi": "^3.0.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",
+        "@types/aws-lambda": "^8.10.23",
         "@types/mime": "^2.0.0",
-        "@types/node": "^10.0.0",
-        "install-peers-cli": "^2.2.0",
+        "@types/node": "^17.0.21",
         "tslint": "^5.11.0",
         "typedoc": "^0.13.0",
-        "typescript": "~3.7.3"
+        "typescript": "^4.6.2"
     }
 }

--- a/awsx-classic/tsconfig.json
+++ b/awsx-classic/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "ES2017",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -2859,10 +2859,10 @@
                 "@pulumi/aws": "^5.3.0",
                 "@pulumi/docker": "^3.0.0",
                 "@pulumi/pulumi": "^3.0.0",
+                "@types/aws-lambda": "^8.10.23",
                 "mime": "^2.0.0"
             },
             "devDependencies": {
-                "@types/aws-lambda": "^8.10.23",
                 "@types/mime": "^2.0.0",
                 "@types/node": "^17.0.21",
                 "typescript": "^4.6.2"

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -2859,10 +2859,11 @@
                 "@pulumi/aws": "^5.3.0",
                 "@pulumi/docker": "^3.0.0",
                 "@pulumi/pulumi": "^3.0.0",
+                "@types/aws-lambda": "^8.10.23",
+                "aws-lambda": "^1.0.7",
                 "mime": "^2.0.0"
             },
             "devDependencies": {
-                "@types/aws-lambda": "^8.10.23",
                 "@types/mime": "^2.0.0",
                 "@types/node": "^17.0.21",
                 "typescript": "^4.6.2"

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -2859,11 +2859,10 @@
                 "@pulumi/aws": "^5.3.0",
                 "@pulumi/docker": "^3.0.0",
                 "@pulumi/pulumi": "^3.0.0",
-                "@types/aws-lambda": "^8.10.23",
-                "aws-lambda": "^1.0.7",
                 "mime": "^2.0.0"
             },
             "devDependencies": {
+                "@types/aws-lambda": "^8.10.23",
                 "@types/mime": "^2.0.0",
                 "@types/node": "^17.0.21",
                 "typescript": "^4.6.2"

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -66,17 +66,16 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"nodejs": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
-					"@pulumi/pulumi":    "^3.0.0",
-					"@pulumi/aws":       "^5.3.0",
-					"@pulumi/docker":    "^3.0.0",
-					"@types/aws-lambda": "^8.10.23",
-					"aws-lambda":        "^1.0.7",
-					"mime":              "^2.0.0",
+					"@pulumi/pulumi": "^3.0.0",
+					"@pulumi/aws":    "^5.3.0",
+					"@pulumi/docker": "^3.0.0",
+					"mime":           "^2.0.0",
 				},
 				"devDependencies": map[string]string{
-					"@types/node": "^17.0.21",
-					"@types/mime": "^2.0.0",
-					"typescript":  "^4.6.2",
+					"@types/aws-lambda": "^8.10.23",
+					"@types/node":       "^17.0.21",
+					"@types/mime":       "^2.0.0",
+					"typescript":        "^4.6.2",
 				},
 			}),
 			"python": rawMessage(map[string]interface{}{

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -66,16 +66,17 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"nodejs": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
-					"@pulumi/pulumi": "^3.0.0",
-					"@pulumi/aws":    "^5.3.0",
-					"@pulumi/docker": "^3.0.0",
-					"mime":           "^2.0.0",
+					"@pulumi/pulumi":    "^3.0.0",
+					"@pulumi/aws":       "^5.3.0",
+					"@pulumi/docker":    "^3.0.0",
+					"@types/aws-lambda": "^8.10.23",
+					"aws-lambda":        "^1.0.7",
+					"mime":              "^2.0.0",
 				},
 				"devDependencies": map[string]string{
-					"@types/aws-lambda": "^8.10.23",
-					"@types/node":       "^17.0.21",
-					"@types/mime":       "^2.0.0",
-					"typescript":        "^4.6.2",
+					"@types/node": "^17.0.21",
+					"@types/mime": "^2.0.0",
+					"typescript":  "^4.6.2",
 				},
 			}),
 			"python": rawMessage(map[string]interface{}{

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -66,16 +66,16 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"nodejs": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
-					"@pulumi/pulumi": "^3.0.0",
-					"@pulumi/aws":    "^5.3.0",
-					"@pulumi/docker": "^3.0.0",
-					"mime":           "^2.0.0",
+					"@pulumi/pulumi":    "^3.0.0",
+					"@pulumi/aws":       "^5.3.0",
+					"@pulumi/docker":    "^3.0.0",
+					"@types/aws-lambda": "^8.10.23",
+					"mime":              "^2.0.0",
 				},
 				"devDependencies": map[string]string{
-					"@types/aws-lambda": "^8.10.23",
-					"@types/node":       "^17.0.21",
-					"@types/mime":       "^2.0.0",
-					"typescript":        "^4.6.2",
+					"@types/node": "^17.0.21",
+					"@types/mime": "^2.0.0",
+					"typescript":  "^4.6.2",
 				},
 			}),
 			"python": rawMessage(map[string]interface{}{

--- a/sdk/nodejs/classic/apigateway/api.ts
+++ b/sdk/nodejs/classic/apigateway/api.ts
@@ -21,7 +21,7 @@ import * as fspath from "path";
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as awslambda from "aws-lambda";
+import type * as awslambda from "aws-lambda";
 
 import { getRegion, ifUndefined, sha1hash } from "../utils";
 

--- a/sdk/nodejs/classic/apigateway/lambdaAuthorizer.ts
+++ b/sdk/nodejs/classic/apigateway/lambdaAuthorizer.ts
@@ -17,7 +17,7 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as awslambda from "aws-lambda";
+import type * as awslambda from "aws-lambda";
 import { CognitoAuthorizer } from "./cognitoAuthorizer";
 
 import * as utils from "../utils";

--- a/sdk/nodejs/classic/ec2/vpcTopology.ts
+++ b/sdk/nodejs/classic/ec2/vpcTopology.ts
@@ -445,14 +445,12 @@ class ExplicitLocationTopology extends VpcTopology {
     }
 }
 
-/** @internal */
 export interface VpcTopologyDescription {
     subnets: SubnetDescription[];
     natGateways: NatGatewayDescription[];
     natRoutes: NatRouteDescription[];
 }
 
-/** @internal */
 export interface SubnetDescription {
     type: VpcSubnetType;
     subnetName: string;
@@ -461,7 +459,6 @@ export interface SubnetDescription {
 }
 
 
-/** @internal */
 export interface NatGatewayDescription {
     name: string;
 
@@ -469,7 +466,6 @@ export interface NatGatewayDescription {
     publicSubnet: string;
 }
 
-/** @internal */
 export interface NatRouteDescription {
     name: string;
 

--- a/sdk/nodejs/classic/ecs/taskDefinition.ts
+++ b/sdk/nodejs/classic/ecs/taskDefinition.ts
@@ -14,7 +14,7 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import * as awssdk from "aws-sdk";
+import type * as awssdk from "aws-sdk";
 import * as ec2 from "../ec2";
 import * as lb from "../lb";
 import * as role from "../role";

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -17,10 +17,11 @@
         "@pulumi/aws": "^5.3.0",
         "@pulumi/docker": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",
+        "@types/aws-lambda": "^8.10.23",
+        "aws-lambda": "^1.0.7",
         "mime": "^2.0.0"
     },
     "devDependencies": {
-        "@types/aws-lambda": "^8.10.23",
         "@types/mime": "^2.0.0",
         "@types/node": "^17.0.21",
         "typescript": "^4.6.2"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -17,11 +17,10 @@
         "@pulumi/aws": "^5.3.0",
         "@pulumi/docker": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",
-        "@types/aws-lambda": "^8.10.23",
-        "aws-lambda": "^1.0.7",
         "mime": "^2.0.0"
     },
     "devDependencies": {
+        "@types/aws-lambda": "^8.10.23",
         "@types/mime": "^2.0.0",
         "@types/node": "^17.0.21",
         "typescript": "^4.6.2"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -17,10 +17,10 @@
         "@pulumi/aws": "^5.3.0",
         "@pulumi/docker": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",
+        "@types/aws-lambda": "^8.10.23",
         "mime": "^2.0.0"
     },
     "devDependencies": {
-        "@types/aws-lambda": "^8.10.23",
         "@types/mime": "^2.0.0",
         "@types/node": "^17.0.21",
         "typescript": "^4.6.2"


### PR DESCRIPTION
Moves two dependencies out of devDeps into primary deps, and removes internal annotations that caused type errors.

Fixes #853 