### PR TITLE
Fix build warnings

### DIFF
--- a/awsx-classic/apigateway/api.ts
+++ b/awsx-classic/apigateway/api.ts
@@ -825,7 +825,7 @@ function addSwaggerOperation(swagger: SwaggerSpec, path: string, method: string,
 
 function checkRoute<TRoute>(parent: pulumi.Resource, route: TRoute, propName: keyof TRoute) {
     if (route[propName] === undefined) {
-        throw new pulumi.ResourceError(`Route missing required [${propName}] property`, parent);
+        throw new pulumi.ResourceError(`Route missing required [${String(propName)}] property`, parent);
     }
 }
 
@@ -926,7 +926,7 @@ function addAuthorizersToSwagger(
     authorizers = Array.isArray(authorizers) ? authorizers : [authorizers];
 
     for (const auth of authorizers) {
-        const suffix = Object.keys(swagger.securityDefinitions).length;
+        const suffix: number = Object.keys(swagger.securityDefinitions).length;
         const authName = auth.authorizerName || `${swagger.info.title}-authorizer-${suffix}`;
         auth.authorizerName = authName;
 

--- a/awsx-classic/package.json
+++ b/awsx-classic/package.json
@@ -20,8 +20,8 @@
         "mime": "^2.0.0"
     },
     "devDependencies": {
-        "@types/aws-sdk": "^2.7.0",
         "@types/aws-lambda": "^8.10.23",
+        "@types/aws-sdk": "^2.7.0",
         "@types/mime": "^2.0.0",
         "@types/node": "^17.0.21",
         "tslint": "^5.11.0",

--- a/awsx/package.json
+++ b/awsx/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@pulumi/aws": "5.4.0",
     "@pulumi/docker": "3.2.0",
-    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/pulumi": "3.34.0-alpha.1653429916",
     "@types/aws-lambda": "^8.10.23",
     "ip-address": "^8.1.0",
     "mime": "^2.0.0",
@@ -46,6 +46,10 @@
     "tslint": "^6.1.3",
     "typedoc": "^0.13.0",
     "typescript": "^4.6.2"
+  },
+  "//": "Need to also bump p/p inside aws and docker dependencies because they're constrained to only stable releases.",
+  "resolutions": {
+    "@pulumi/pulumi": "3.34.0-alpha.1653429916"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -2865,7 +2865,7 @@
             "devDependencies": {
                 "@types/mime": "^2.0.0",
                 "@types/node": "^17.0.21",
-                "typescript": "~4.6.2"
+                "typescript": "^4.6.2"
             }
         },
         "python": {

--- a/awsx/yarn.lock
+++ b/awsx/yarn.lock
@@ -1280,17 +1280,18 @@
     "@pulumi/pulumi" "^3.0.0"
     semver "^5.4.0"
 
-"@pulumi/pulumi@^3.0.0":
-  version "3.23.2"
-  resolved "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.23.2.tgz"
-  integrity sha512-rSbNJlR2ddGaNDdT1kPL71oY1xxJfnCQy/bP29p7gQtuwgL74godE3VqqYH4tzgKIK9vQygDQ2PY3JWkPLYLEQ==
+"@pulumi/pulumi@3.34.0-alpha.1653429916", "@pulumi/pulumi@^3.0.0":
+  version "3.34.0-alpha.1653429916"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.34.0-alpha.1653429916.tgz#0f52cfe03f52dfebdbdd4c6eb03e9ec1e1a8f423"
+  integrity sha512-TAhr/kxOqKHW6rdrGoIBYx5FiO8ShcxDYKoFrWL4xLGJJv/PB0SoEUumXQe7qOiw4fsJ1RGlh7PJbmny67hDQQ==
   dependencies:
     "@grpc/grpc-js" "~1.3.8"
     "@logdna/tail-file" "^2.0.6"
     "@pulumi/query" "^0.3.0"
     google-protobuf "^3.5.0"
+    ini "^2.0.0"
     js-yaml "^3.14.0"
-    minimist "^1.2.0"
+    minimist "^1.2.6"
     normalize-package-data "^2.4.0"
     protobufjs "^6.8.6"
     read-package-tree "^5.3.1"
@@ -2790,6 +2791,11 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
 ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
@@ -3717,7 +3723,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -75,7 +75,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 				"devDependencies": map[string]string{
 					"@types/node": "^17.0.21",
 					"@types/mime": "^2.0.0",
-					"typescript":  "~4.6.2",
+					"typescript":  "^4.6.2",
 				},
 			}),
 			"python": rawMessage(map[string]interface{}{

--- a/sdk/nodejs/classic/apigateway/api.ts
+++ b/sdk/nodejs/classic/apigateway/api.ts
@@ -825,7 +825,7 @@ function addSwaggerOperation(swagger: SwaggerSpec, path: string, method: string,
 
 function checkRoute<TRoute>(parent: pulumi.Resource, route: TRoute, propName: keyof TRoute) {
     if (route[propName] === undefined) {
-        throw new pulumi.ResourceError(`Route missing required [${propName}] property`, parent);
+        throw new pulumi.ResourceError(`Route missing required [${String(propName)}] property`, parent);
     }
 }
 
@@ -926,7 +926,7 @@ function addAuthorizersToSwagger(
     authorizers = Array.isArray(authorizers) ? authorizers : [authorizers];
 
     for (const auth of authorizers) {
-        const suffix = Object.keys(swagger.securityDefinitions).length;
+        const suffix: number = Object.keys(swagger.securityDefinitions).length;
         const authName = auth.authorizerName || `${swagger.info.title}-authorizer-${suffix}`;
         auth.authorizerName = authName;
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -23,7 +23,7 @@
     "devDependencies": {
         "@types/mime": "^2.0.0",
         "@types/node": "^17.0.21",
-        "typescript": "~4.6.2"
+        "typescript": "^4.6.2"
     },
     "pulumi": {
         "resource": true


### PR DESCRIPTION
- Use pulumi dev release until 3.34 is available - this resolves the ERR_INSPECTOR_NOT_AVAILABLE warnings
- Fix errors from typescript 4.7 release - revert pinning of typescript to 4.6.