### PR TITLE
use bash in PATH

### DIFF
--- a/awsx/pulumi-resource-awsx
+++ b/awsx/pulumi-resource-awsx
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-node $SCRIPT_DIR $@
+node $SCRIPT_DIR/bin $@


### PR DESCRIPTION
Systems like nixos, does not have bash in `/bin/bash`.  
So previous script did not execute.
With `/usr/bin/env bash` it will use the systems default bash interpreter.
So this is a more flexible approach.

Weirdly, on `v1.0.0-beta. 5, 6 and 7` `~/.pulumi/plugins/resource-awsx-v1.0.0-beta.*/pulumi-resource-awsx` is no longer a bash script, but a dynamic executable.  
Is that intended?  
That does not work very well on nixos.