### PR TITLE
expose route table ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Add multi-lang component support scaffolding.
 * Fix type errors in TypeScript checking awsx-classic properties.
+* Expose all route table ids as outputs
+  [#885](https://github.com/pulumi/pulumi-awsx/pull/885)
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -24,6 +24,9 @@ interface VpcData {
   routeTables: aws.ec2.RouteTable[];
   routes: aws.ec2.Route[];
   routeTableAssociations: aws.ec2.RouteTableAssociation[];
+  privateRouteTableIds: pulumi.Output<string>[];
+  publicRouteTableIds: pulumi.Output<string>[];
+  isolatedRouteTableIds: pulumi.Output<string>[];
   igw: aws.ec2.InternetGateway;
   natGateways: aws.ec2.NatGateway[];
   eips: aws.ec2.Eip[];
@@ -44,6 +47,9 @@ export class Vpc extends schema.Vpc<VpcData> {
     this.routeTables = data.routeTables;
     this.routes = data.routes;
     this.routeTableAssociations = data.routeTableAssociations;
+    this.privateRouteTableIds = data.privateRouteTableIds;
+    this.publicRouteTableIds = data.publicRouteTableIds;
+    this.isolatedSubnetIds = data.isolatedSubnetIds;
     this.internetGateway = data.igw;
     this.natGateways = data.natGateways;
     this.eips = data.eips;
@@ -118,6 +124,9 @@ export class Vpc extends schema.Vpc<VpcData> {
     const subnets: aws.ec2.Subnet[] = [];
     const routeTables: aws.ec2.RouteTable[] = [];
     const routeTableAssociations: aws.ec2.RouteTableAssociation[] = [];
+    const privateRouteTableIds: pulumi.Output<string>[] = [];
+    const publicRouteTableIds: pulumi.Output<string>[] = [];
+    const isolatedRouteTableIds: pulumi.Output<string>[] = [];
     const routes: aws.ec2.Route[] = [];
     const natGateways: aws.ec2.NatGateway[] = [];
     const eips: aws.ec2.Eip[] = [];
@@ -185,6 +194,25 @@ export class Vpc extends schema.Vpc<VpcData> {
             { parent: subnet, dependsOn: [subnet] },
           );
           routeTables.push(routeTable);
+
+          // populate routeTableIds
+          switch (spec.type.toLowerCase()) {
+            case "public": {
+              publicRouteTableIds.push(routeTable.id)
+              break;
+            }
+            case "private": {
+              privateRouteTableIds.push(routeTable.id)
+              break;
+            }
+            case "isolated": {
+              isolatedRouteTableIds.push(routeTable.id)
+              break;
+            }
+            default: {
+              break
+            }
+          }
 
           const routeTableAssoc = new aws.ec2.RouteTableAssociation(
             spec.subnetName,
@@ -268,6 +296,9 @@ export class Vpc extends schema.Vpc<VpcData> {
       igw,
       routeTables,
       routeTableAssociations,
+      privateRouteTableIds,
+      publicRouteTableIds,
+      isolatedRouteTableIds,
       routes,
       natGateways,
       eips,

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -198,19 +198,19 @@ export class Vpc extends schema.Vpc<VpcData> {
           // populate routeTableIds
           switch (spec.type.toLowerCase()) {
             case "public": {
-              publicRouteTableIds.push(routeTable.id)
+              publicRouteTableIds.push(routeTable.id);
               break;
             }
             case "private": {
-              privateRouteTableIds.push(routeTable.id)
+              privateRouteTableIds.push(routeTable.id);
               break;
             }
             case "isolated": {
-              isolatedRouteTableIds.push(routeTable.id)
+              isolatedRouteTableIds.push(routeTable.id);
               break;
             }
             default: {
-              break
+              break;
             }
           }
 

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -67,6 +67,9 @@ export abstract class Vpc<TData = any> extends pulumi.ComponentResource<TData> {
     public privateSubnetIds!: string[] | pulumi.Output<string[]>;
     public publicSubnetIds!: string[] | pulumi.Output<string[]>;
     public routeTableAssociations!: aws.ec2.RouteTableAssociation[] | pulumi.Output<aws.ec2.RouteTableAssociation[]>;
+    public publicRouteTableIds!: string[] | pulumi.Output<string[]>;
+    public privateRouteTableIds!: string[] | pulumi.Output<string[]>;
+    public isolatedRouteTableIds!: string[] | pulumi.Output<string[]>;
     public routeTables!: aws.ec2.RouteTable[] | pulumi.Output<aws.ec2.RouteTable[]>;
     public routes!: aws.ec2.Route[] | pulumi.Output<aws.ec2.Route[]>;
     public subnets!: aws.ec2.Subnet[] | pulumi.Output<aws.ec2.Subnet[]>;
@@ -74,7 +77,7 @@ export abstract class Vpc<TData = any> extends pulumi.ComponentResource<TData> {
     public vpcEndpoints!: aws.ec2.VpcEndpoint[] | pulumi.Output<aws.ec2.VpcEndpoint[]>;
     public vpcId!: string | pulumi.Output<string>;
     constructor(name: string, args: pulumi.Inputs, opts: pulumi.ComponentResourceOptions = {}) {
-        super("awsx:ec2:Vpc", name, opts.urn ? { eips: undefined, internetGateway: undefined, isolatedSubnetIds: undefined, natGateways: undefined, privateSubnetIds: undefined, publicSubnetIds: undefined, routeTableAssociations: undefined, routeTables: undefined, routes: undefined, subnets: undefined, vpc: undefined, vpcEndpoints: undefined, vpcId: undefined } : { name, args, opts }, opts);
+        super("awsx:ec2:Vpc", name, opts.urn ? { eips: undefined, internetGateway: undefined, isolatedSubnetIds: undefined, natGateways: undefined, privateSubnetIds: undefined, publicSubnetIds: undefined, routeTableAssociations: undefined, publicRouteTableIds: undefined, privateRouteTableIds: undefined, isolatedRouteTableIds: undefined, routeTables: undefined, routes: undefined, subnets: undefined, vpc: undefined, vpcEndpoints: undefined, vpcId: undefined } : { name, args, opts }, opts);
     }
 }
 export interface VpcArgs {

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -1689,6 +1689,24 @@
                     },
                     "description": "The Route Table Associations for the VPC."
                 },
+                "publicRouteTableIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "privateRouteTableIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "isolatedRouteTableIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "routeTables": {
                     "type": "array",
                     "items": {
@@ -1736,6 +1754,9 @@
                 "routeTables",
                 "routeTableAssociations",
                 "routes",
+                "privateRouteTableIds",
+                "publicRouteTableIds",
+                "isolatedRouteTableIds",
                 "internetGateway",
                 "natGateways",
                 "eips",

--- a/sdk/dotnet/Ec2/Vpc.cs
+++ b/sdk/dotnet/Ec2/Vpc.cs
@@ -24,6 +24,9 @@ namespace Pulumi.Awsx.Ec2
         [Output("internetGateway")]
         public Output<Pulumi.Aws.Ec2.InternetGateway> InternetGateway { get; private set; } = null!;
 
+        [Output("isolatedRouteTableIds")]
+        public Output<ImmutableArray<string>> IsolatedRouteTableIds { get; private set; } = null!;
+
         [Output("isolatedSubnetIds")]
         public Output<ImmutableArray<string>> IsolatedSubnetIds { get; private set; } = null!;
 
@@ -33,8 +36,14 @@ namespace Pulumi.Awsx.Ec2
         [Output("natGateways")]
         public Output<ImmutableArray<Pulumi.Aws.Ec2.NatGateway>> NatGateways { get; private set; } = null!;
 
+        [Output("privateRouteTableIds")]
+        public Output<ImmutableArray<string>> PrivateRouteTableIds { get; private set; } = null!;
+
         [Output("privateSubnetIds")]
         public Output<ImmutableArray<string>> PrivateSubnetIds { get; private set; } = null!;
+
+        [Output("publicRouteTableIds")]
+        public Output<ImmutableArray<string>> PublicRouteTableIds { get; private set; } = null!;
 
         [Output("publicSubnetIds")]
         public Output<ImmutableArray<string>> PublicSubnetIds { get; private set; } = null!;

--- a/sdk/go/awsx/ec2/vpc.go
+++ b/sdk/go/awsx/ec2/vpc.go
@@ -17,12 +17,15 @@ type Vpc struct {
 	// The EIPs for any NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
 	Eips ec2.EipArrayOutput `pulumi:"eips"`
 	// The Internet Gateway for the VPC.
-	InternetGateway   ec2.InternetGatewayOutput `pulumi:"internetGateway"`
-	IsolatedSubnetIds pulumi.StringArrayOutput  `pulumi:"isolatedSubnetIds"`
+	InternetGateway       ec2.InternetGatewayOutput `pulumi:"internetGateway"`
+	IsolatedRouteTableIds pulumi.StringArrayOutput  `pulumi:"isolatedRouteTableIds"`
+	IsolatedSubnetIds     pulumi.StringArrayOutput  `pulumi:"isolatedSubnetIds"`
 	// The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
-	NatGateways      ec2.NatGatewayArrayOutput `pulumi:"natGateways"`
-	PrivateSubnetIds pulumi.StringArrayOutput  `pulumi:"privateSubnetIds"`
-	PublicSubnetIds  pulumi.StringArrayOutput  `pulumi:"publicSubnetIds"`
+	NatGateways          ec2.NatGatewayArrayOutput `pulumi:"natGateways"`
+	PrivateRouteTableIds pulumi.StringArrayOutput  `pulumi:"privateRouteTableIds"`
+	PrivateSubnetIds     pulumi.StringArrayOutput  `pulumi:"privateSubnetIds"`
+	PublicRouteTableIds  pulumi.StringArrayOutput  `pulumi:"publicRouteTableIds"`
+	PublicSubnetIds      pulumi.StringArrayOutput  `pulumi:"publicSubnetIds"`
 	// The Route Table Associations for the VPC.
 	RouteTableAssociations ec2.RouteTableAssociationArrayOutput `pulumi:"routeTableAssociations"`
 	// The Route Tables for the VPC.
@@ -239,6 +242,10 @@ func (o VpcOutput) InternetGateway() ec2.InternetGatewayOutput {
 	return o.ApplyT(func(v *Vpc) ec2.InternetGatewayOutput { return v.InternetGateway }).(ec2.InternetGatewayOutput)
 }
 
+func (o VpcOutput) IsolatedRouteTableIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.IsolatedRouteTableIds }).(pulumi.StringArrayOutput)
+}
+
 func (o VpcOutput) IsolatedSubnetIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.IsolatedSubnetIds }).(pulumi.StringArrayOutput)
 }
@@ -248,8 +255,16 @@ func (o VpcOutput) NatGateways() ec2.NatGatewayArrayOutput {
 	return o.ApplyT(func(v *Vpc) ec2.NatGatewayArrayOutput { return v.NatGateways }).(ec2.NatGatewayArrayOutput)
 }
 
+func (o VpcOutput) PrivateRouteTableIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PrivateRouteTableIds }).(pulumi.StringArrayOutput)
+}
+
 func (o VpcOutput) PrivateSubnetIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PrivateSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+func (o VpcOutput) PublicRouteTableIds() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PublicRouteTableIds }).(pulumi.StringArrayOutput)
 }
 
 func (o VpcOutput) PublicSubnetIds() pulumi.StringArrayOutput {

--- a/sdk/java/src/main/java/com/pulumi/awsx/ec2/Vpc.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ec2/Vpc.java
@@ -51,6 +51,12 @@ public class Vpc extends com.pulumi.resources.ComponentResource {
     public Output<InternetGateway> internetGateway() {
         return this.internetGateway;
     }
+    @Export(name="isolatedRouteTableIds", type=List.class, parameters={String.class})
+    private Output<List<String>> isolatedRouteTableIds;
+
+    public Output<List<String>> isolatedRouteTableIds() {
+        return this.isolatedRouteTableIds;
+    }
     @Export(name="isolatedSubnetIds", type=List.class, parameters={String.class})
     private Output<List<String>> isolatedSubnetIds;
 
@@ -71,11 +77,23 @@ public class Vpc extends com.pulumi.resources.ComponentResource {
     public Output<List<NatGateway>> natGateways() {
         return this.natGateways;
     }
+    @Export(name="privateRouteTableIds", type=List.class, parameters={String.class})
+    private Output<List<String>> privateRouteTableIds;
+
+    public Output<List<String>> privateRouteTableIds() {
+        return this.privateRouteTableIds;
+    }
     @Export(name="privateSubnetIds", type=List.class, parameters={String.class})
     private Output<List<String>> privateSubnetIds;
 
     public Output<List<String>> privateSubnetIds() {
         return this.privateSubnetIds;
+    }
+    @Export(name="publicRouteTableIds", type=List.class, parameters={String.class})
+    private Output<List<String>> publicRouteTableIds;
+
+    public Output<List<String>> publicRouteTableIds() {
+        return this.publicRouteTableIds;
     }
     @Export(name="publicSubnetIds", type=List.class, parameters={String.class})
     private Output<List<String>> publicSubnetIds;

--- a/sdk/nodejs/ec2/vpc.ts
+++ b/sdk/nodejs/ec2/vpc.ts
@@ -30,12 +30,15 @@ export class Vpc extends pulumi.ComponentResource {
      * The Internet Gateway for the VPC.
      */
     public /*out*/ readonly internetGateway!: pulumi.Output<pulumiAws.ec2.InternetGateway>;
+    public /*out*/ readonly isolatedRouteTableIds!: pulumi.Output<string[]>;
     public /*out*/ readonly isolatedSubnetIds!: pulumi.Output<string[]>;
     /**
      * The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
      */
     public readonly natGateways!: pulumi.Output<pulumiAws.ec2.NatGateway[]>;
+    public /*out*/ readonly privateRouteTableIds!: pulumi.Output<string[]>;
     public /*out*/ readonly privateSubnetIds!: pulumi.Output<string[]>;
+    public /*out*/ readonly publicRouteTableIds!: pulumi.Output<string[]>;
     public /*out*/ readonly publicSubnetIds!: pulumi.Output<string[]>;
     /**
      * The Route Table Associations for the VPC.
@@ -95,8 +98,11 @@ export class Vpc extends pulumi.ComponentResource {
             resourceInputs["vpcEndpointSpecs"] = args ? args.vpcEndpointSpecs : undefined;
             resourceInputs["eips"] = undefined /*out*/;
             resourceInputs["internetGateway"] = undefined /*out*/;
+            resourceInputs["isolatedRouteTableIds"] = undefined /*out*/;
             resourceInputs["isolatedSubnetIds"] = undefined /*out*/;
+            resourceInputs["privateRouteTableIds"] = undefined /*out*/;
             resourceInputs["privateSubnetIds"] = undefined /*out*/;
+            resourceInputs["publicRouteTableIds"] = undefined /*out*/;
             resourceInputs["publicSubnetIds"] = undefined /*out*/;
             resourceInputs["routeTableAssociations"] = undefined /*out*/;
             resourceInputs["routeTables"] = undefined /*out*/;
@@ -108,9 +114,12 @@ export class Vpc extends pulumi.ComponentResource {
         } else {
             resourceInputs["eips"] = undefined /*out*/;
             resourceInputs["internetGateway"] = undefined /*out*/;
+            resourceInputs["isolatedRouteTableIds"] = undefined /*out*/;
             resourceInputs["isolatedSubnetIds"] = undefined /*out*/;
             resourceInputs["natGateways"] = undefined /*out*/;
+            resourceInputs["privateRouteTableIds"] = undefined /*out*/;
             resourceInputs["privateSubnetIds"] = undefined /*out*/;
+            resourceInputs["publicRouteTableIds"] = undefined /*out*/;
             resourceInputs["publicSubnetIds"] = undefined /*out*/;
             resourceInputs["routeTableAssociations"] = undefined /*out*/;
             resourceInputs["routeTables"] = undefined /*out*/;

--- a/sdk/python/pulumi_awsx/ec2/vpc.py
+++ b/sdk/python/pulumi_awsx/ec2/vpc.py
@@ -460,8 +460,11 @@ class Vpc(pulumi.ComponentResource):
             __props__.__dict__["vpc_endpoint_specs"] = vpc_endpoint_specs
             __props__.__dict__["eips"] = None
             __props__.__dict__["internet_gateway"] = None
+            __props__.__dict__["isolated_route_table_ids"] = None
             __props__.__dict__["isolated_subnet_ids"] = None
+            __props__.__dict__["private_route_table_ids"] = None
             __props__.__dict__["private_subnet_ids"] = None
+            __props__.__dict__["public_route_table_ids"] = None
             __props__.__dict__["public_subnet_ids"] = None
             __props__.__dict__["route_table_associations"] = None
             __props__.__dict__["route_tables"] = None
@@ -494,6 +497,11 @@ class Vpc(pulumi.ComponentResource):
         return pulumi.get(self, "internet_gateway")
 
     @property
+    @pulumi.getter(name="isolatedRouteTableIds")
+    def isolated_route_table_ids(self) -> pulumi.Output[Sequence[str]]:
+        return pulumi.get(self, "isolated_route_table_ids")
+
+    @property
     @pulumi.getter(name="isolatedSubnetIds")
     def isolated_subnet_ids(self) -> pulumi.Output[Sequence[str]]:
         return pulumi.get(self, "isolated_subnet_ids")
@@ -507,9 +515,19 @@ class Vpc(pulumi.ComponentResource):
         return pulumi.get(self, "nat_gateways")
 
     @property
+    @pulumi.getter(name="privateRouteTableIds")
+    def private_route_table_ids(self) -> pulumi.Output[Sequence[str]]:
+        return pulumi.get(self, "private_route_table_ids")
+
+    @property
     @pulumi.getter(name="privateSubnetIds")
     def private_subnet_ids(self) -> pulumi.Output[Sequence[str]]:
         return pulumi.get(self, "private_subnet_ids")
+
+    @property
+    @pulumi.getter(name="publicRouteTableIds")
+    def public_route_table_ids(self) -> pulumi.Output[Sequence[str]]:
+        return pulumi.get(self, "public_route_table_ids")
 
     @property
     @pulumi.getter(name="publicSubnetIds")


### PR DESCRIPTION
Route table ids can be important for VPCs after they've been created.

Exposing the route table ids as outputs allows us to easily support resources like NAT instances (cheaper than NAT Gateways), AWS Transit Gateways and AWS Client VPNs