### PR TITLE
awsx.ec2.Vpc: Make cidrMask option when specifying subnetSpecs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         nodeversion:
           - 16.x
   acceptance-test:
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         pythonversion:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         nodeversion:
           - 16.x
   acceptance-test:
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         pythonversion:
@@ -352,7 +352,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         nodeversion:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         nodeversion:
           - 16.x
   acceptance-test:
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         pythonversion:
@@ -360,7 +360,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         nodeversion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         nodeversion:
           - 16.x
   acceptance-test:
@@ -203,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         pythonversion:
@@ -358,7 +358,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         dotnetversion:
           - 3.1
         nodeversion:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         nodeversion:
           - 16.x
   acceptance-test:
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-          - 1.17.x
+          - 1.19.x
         pythonversion:
           - 3.8
         nodeversion:

--- a/awsx/ec2/subnetDistributor.ts
+++ b/awsx/ec2/subnetDistributor.ts
@@ -57,7 +57,8 @@ export function getSubnetSpecs(
     const isolatedSubnetsOut: SubnetSpec[] = [];
 
     for (let j = 0; j < privateSubnetsIn.length; j++) {
-      const newBits = privateSubnetsIn[j].cidrMask - baseSubnetMask;
+      const privateCidrMask: number = privateSubnetsIn[j].cidrMask ?? 19;
+      const newBits = privateCidrMask - baseSubnetMask;
 
       // The "j" input to cidrSubnetV4 below covers the case where we have
       // multiple subnets of each type per AZ. In this case, we need the
@@ -84,7 +85,8 @@ export function getSubnetSpecs(
       const baseIp = new ipAddress.Address4(baseCidr);
 
       const splitBase = privateSubnetsOut.length > 0 ? cidrSubnetV4(baseCidr, 0, 1) : azBases[i];
-      const newBits = publicSubnetsIn[j].cidrMask - baseIp.subnetMask;
+      const publicCidrMask: number = publicSubnetsIn[j].cidrMask ?? 20;
+      const newBits = publicCidrMask - baseIp.subnetMask;
 
       const publicSubnetCidrBlock = cidrSubnetV4(splitBase, newBits, j);
       publicSubnetsOut.push({
@@ -118,7 +120,8 @@ export function getSubnetSpecs(
         splitBase = azBases[i];
       }
 
-      const newBits = isolatedSubnetsIn[j].cidrMask - baseIp.subnetMask;
+      const isolatedCidrMask: number = isolatedSubnetsIn[j].cidrMask ?? 24;
+      const newBits = isolatedCidrMask - baseIp.subnetMask;
 
       const isolatedSubnetCidrBlock = cidrSubnetV4(splitBase, newBits, j);
       isolatedSubnetsOut.push({

--- a/awsx/ec2/subnetsIntegration.test.ts
+++ b/awsx/ec2/subnetsIntegration.test.ts
@@ -49,6 +49,31 @@ describe("subnet creation integration tests", () => {
     expect(getOverlappingSubnets(subnetSpecs)).toEqual([]);
   });
 
+  it("should return default cidrMasksFor Subnet Types", () => {
+    const inputs: SubnetSpecInputs[] = [
+      {
+        type: "Public",
+      },
+      {
+        type: "Private",
+      },
+      {
+        type: "Isolated",
+      },
+    ];
+
+    const subnetSpecs = getSubnetSpecs(
+      "dummy",
+      "10.0.0.0/16",
+      ["us-east-1a", "us-east-1b", "us-east-1c"],
+      inputs,
+    );
+
+    console.log(JSON.stringify(subnetSpecs));
+
+    expect(getOverlappingSubnets(subnetSpecs)).toEqual([]);
+  });
+
   it("should return no overlapping subnets 2 private subnets per AZ", () => {
     const inputs: SubnetSpecInputs[] = [
       {

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -547,12 +547,12 @@ export interface NatGatewayConfigurationOutputs {
 export type NatGatewayStrategyInputs = "None" | "Single" | "OnePerAz";
 export type NatGatewayStrategyOutputs = "None" | "Single" | "OnePerAz";
 export interface SubnetSpecInputs {
-    readonly cidrMask: number;
+    readonly cidrMask?: number;
     readonly name?: string;
     readonly type: SubnetTypeInputs;
 }
 export interface SubnetSpecOutputs {
-    readonly cidrMask: number;
+    readonly cidrMask?: number;
     readonly name?: string;
     readonly type: SubnetTypeOutputs;
 }

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -518,8 +518,7 @@
             },
             "type": "object",
             "required": [
-                "type",
-                "cidrMask"
+                "type"
             ]
         },
         "awsx:ec2:SubnetType": {

--- a/schemagen/pkg/gen/ec2.go
+++ b/schemagen/pkg/gen/ec2.go
@@ -316,7 +316,6 @@ func subnetSpecType() schema.ComplexTypeSpec {
 			},
 			Required: []string{
 				"type",
-				"cidrMask",
 			},
 		},
 	}

--- a/sdk/dotnet/Ec2/Inputs/SubnetSpecArgs.cs
+++ b/sdk/dotnet/Ec2/Inputs/SubnetSpecArgs.cs
@@ -18,8 +18,8 @@ namespace Pulumi.Awsx.Ec2.Inputs
         /// <summary>
         /// The bitmask for the subnet's CIDR block.
         /// </summary>
-        [Input("cidrMask", required: true)]
-        public int CidrMask { get; set; }
+        [Input("cidrMask")]
+        public int? CidrMask { get; set; }
 
         /// <summary>
         /// The subnet's name. Will be templated upon creation.

--- a/sdk/go/awsx/awsx/pulumiTypes.go
+++ b/sdk/go/awsx/awsx/pulumiTypes.go
@@ -65,7 +65,7 @@ type Bucket struct {
 // BucketInput is an input type that accepts BucketArgs and BucketOutput values.
 // You can construct a concrete instance of `BucketInput` via:
 //
-//          BucketArgs{...}
+//	BucketArgs{...}
 type BucketInput interface {
 	pulumi.Input
 
@@ -145,11 +145,11 @@ func (i BucketArgs) ToBucketPtrOutputWithContext(ctx context.Context) BucketPtrO
 // BucketPtrInput is an input type that accepts BucketArgs, BucketPtr and BucketPtrOutput values.
 // You can construct a concrete instance of `BucketPtrInput` via:
 //
-//          BucketArgs{...}
+//	        BucketArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type BucketPtrInput interface {
 	pulumi.Input
 
@@ -568,7 +568,7 @@ type DefaultLogGroup struct {
 // DefaultLogGroupInput is an input type that accepts DefaultLogGroupArgs and DefaultLogGroupOutput values.
 // You can construct a concrete instance of `DefaultLogGroupInput` via:
 //
-//          DefaultLogGroupArgs{...}
+//	DefaultLogGroupArgs{...}
 type DefaultLogGroupInput interface {
 	pulumi.Input
 
@@ -609,11 +609,11 @@ func (i DefaultLogGroupArgs) ToDefaultLogGroupPtrOutputWithContext(ctx context.C
 // DefaultLogGroupPtrInput is an input type that accepts DefaultLogGroupArgs, DefaultLogGroupPtr and DefaultLogGroupPtrOutput values.
 // You can construct a concrete instance of `DefaultLogGroupPtrInput` via:
 //
-//          DefaultLogGroupArgs{...}
+//	        DefaultLogGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type DefaultLogGroupPtrInput interface {
 	pulumi.Input
 
@@ -746,7 +746,7 @@ type DefaultRoleWithPolicy struct {
 // DefaultRoleWithPolicyInput is an input type that accepts DefaultRoleWithPolicyArgs and DefaultRoleWithPolicyOutput values.
 // You can construct a concrete instance of `DefaultRoleWithPolicyInput` via:
 //
-//          DefaultRoleWithPolicyArgs{...}
+//	DefaultRoleWithPolicyArgs{...}
 type DefaultRoleWithPolicyInput interface {
 	pulumi.Input
 
@@ -787,11 +787,11 @@ func (i DefaultRoleWithPolicyArgs) ToDefaultRoleWithPolicyPtrOutputWithContext(c
 // DefaultRoleWithPolicyPtrInput is an input type that accepts DefaultRoleWithPolicyArgs, DefaultRoleWithPolicyPtr and DefaultRoleWithPolicyPtrOutput values.
 // You can construct a concrete instance of `DefaultRoleWithPolicyPtrInput` via:
 //
-//          DefaultRoleWithPolicyArgs{...}
+//	        DefaultRoleWithPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type DefaultRoleWithPolicyPtrInput interface {
 	pulumi.Input
 
@@ -935,7 +935,7 @@ func (val *DefaultSecurityGroup) Defaults() *DefaultSecurityGroup {
 // DefaultSecurityGroupInput is an input type that accepts DefaultSecurityGroupArgs and DefaultSecurityGroupOutput values.
 // You can construct a concrete instance of `DefaultSecurityGroupInput` via:
 //
-//          DefaultSecurityGroupArgs{...}
+//	DefaultSecurityGroupArgs{...}
 type DefaultSecurityGroupInput interface {
 	pulumi.Input
 
@@ -986,11 +986,11 @@ func (i DefaultSecurityGroupArgs) ToDefaultSecurityGroupPtrOutputWithContext(ctx
 // DefaultSecurityGroupPtrInput is an input type that accepts DefaultSecurityGroupArgs, DefaultSecurityGroupPtr and DefaultSecurityGroupPtrOutput values.
 // You can construct a concrete instance of `DefaultSecurityGroupPtrInput` via:
 //
-//          DefaultSecurityGroupArgs{...}
+//	        DefaultSecurityGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type DefaultSecurityGroupPtrInput interface {
 	pulumi.Input
 
@@ -1121,7 +1121,7 @@ type ExistingBucket struct {
 // ExistingBucketInput is an input type that accepts ExistingBucketArgs and ExistingBucketOutput values.
 // You can construct a concrete instance of `ExistingBucketInput` via:
 //
-//          ExistingBucketArgs{...}
+//	ExistingBucketArgs{...}
 type ExistingBucketInput interface {
 	pulumi.Input
 
@@ -1160,11 +1160,11 @@ func (i ExistingBucketArgs) ToExistingBucketPtrOutputWithContext(ctx context.Con
 // ExistingBucketPtrInput is an input type that accepts ExistingBucketArgs, ExistingBucketPtr and ExistingBucketPtrOutput values.
 // You can construct a concrete instance of `ExistingBucketPtrInput` via:
 //
-//          ExistingBucketArgs{...}
+//	        ExistingBucketArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ExistingBucketPtrInput interface {
 	pulumi.Input
 
@@ -1282,7 +1282,7 @@ type ExistingLogGroup struct {
 // ExistingLogGroupInput is an input type that accepts ExistingLogGroupArgs and ExistingLogGroupOutput values.
 // You can construct a concrete instance of `ExistingLogGroupInput` via:
 //
-//          ExistingLogGroupArgs{...}
+//	ExistingLogGroupArgs{...}
 type ExistingLogGroupInput interface {
 	pulumi.Input
 
@@ -1323,11 +1323,11 @@ func (i ExistingLogGroupArgs) ToExistingLogGroupPtrOutputWithContext(ctx context
 // ExistingLogGroupPtrInput is an input type that accepts ExistingLogGroupArgs, ExistingLogGroupPtr and ExistingLogGroupPtrOutput values.
 // You can construct a concrete instance of `ExistingLogGroupPtrInput` via:
 //
-//          ExistingLogGroupArgs{...}
+//	        ExistingLogGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ExistingLogGroupPtrInput interface {
 	pulumi.Input
 
@@ -1468,7 +1468,7 @@ type LogGroup struct {
 // LogGroupInput is an input type that accepts LogGroupArgs and LogGroupOutput values.
 // You can construct a concrete instance of `LogGroupInput` via:
 //
-//          LogGroupArgs{...}
+//	LogGroupArgs{...}
 type LogGroupInput interface {
 	pulumi.Input
 
@@ -1517,11 +1517,11 @@ func (i LogGroupArgs) ToLogGroupPtrOutputWithContext(ctx context.Context) LogGro
 // LogGroupPtrInput is an input type that accepts LogGroupArgs, LogGroupPtr and LogGroupPtrOutput values.
 // You can construct a concrete instance of `LogGroupPtrInput` via:
 //
-//          LogGroupArgs{...}
+//	        LogGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type LogGroupPtrInput interface {
 	pulumi.Input
 
@@ -1692,7 +1692,7 @@ type OptionalLogGroup struct {
 // OptionalLogGroupInput is an input type that accepts OptionalLogGroupArgs and OptionalLogGroupOutput values.
 // You can construct a concrete instance of `OptionalLogGroupInput` via:
 //
-//          OptionalLogGroupArgs{...}
+//	OptionalLogGroupArgs{...}
 type OptionalLogGroupInput interface {
 	pulumi.Input
 
@@ -1733,11 +1733,11 @@ func (i OptionalLogGroupArgs) ToOptionalLogGroupPtrOutputWithContext(ctx context
 // OptionalLogGroupPtrInput is an input type that accepts OptionalLogGroupArgs, OptionalLogGroupPtr and OptionalLogGroupPtrOutput values.
 // You can construct a concrete instance of `OptionalLogGroupPtrInput` via:
 //
-//          OptionalLogGroupArgs{...}
+//	        OptionalLogGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type OptionalLogGroupPtrInput interface {
 	pulumi.Input
 
@@ -1868,7 +1868,7 @@ type RequiredBucket struct {
 // RequiredBucketInput is an input type that accepts RequiredBucketArgs and RequiredBucketOutput values.
 // You can construct a concrete instance of `RequiredBucketInput` via:
 //
-//          RequiredBucketArgs{...}
+//	RequiredBucketArgs{...}
 type RequiredBucketInput interface {
 	pulumi.Input
 
@@ -1907,11 +1907,11 @@ func (i RequiredBucketArgs) ToRequiredBucketPtrOutputWithContext(ctx context.Con
 // RequiredBucketPtrInput is an input type that accepts RequiredBucketArgs, RequiredBucketPtr and RequiredBucketPtrOutput values.
 // You can construct a concrete instance of `RequiredBucketPtrInput` via:
 //
-//          RequiredBucketArgs{...}
+//	        RequiredBucketArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type RequiredBucketPtrInput interface {
 	pulumi.Input
 
@@ -2053,7 +2053,7 @@ type RoleWithPolicy struct {
 // RoleWithPolicyInput is an input type that accepts RoleWithPolicyArgs and RoleWithPolicyOutput values.
 // You can construct a concrete instance of `RoleWithPolicyInput` via:
 //
-//          RoleWithPolicyArgs{...}
+//	RoleWithPolicyArgs{...}
 type RoleWithPolicyInput interface {
 	pulumi.Input
 
@@ -2110,11 +2110,11 @@ func (i RoleWithPolicyArgs) ToRoleWithPolicyPtrOutputWithContext(ctx context.Con
 // RoleWithPolicyPtrInput is an input type that accepts RoleWithPolicyArgs, RoleWithPolicyPtr and RoleWithPolicyPtrOutput values.
 // You can construct a concrete instance of `RoleWithPolicyPtrInput` via:
 //
-//          RoleWithPolicyArgs{...}
+//	        RoleWithPolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type RoleWithPolicyPtrInput interface {
 	pulumi.Input
 
@@ -2390,7 +2390,7 @@ func (val *SecurityGroup) Defaults() *SecurityGroup {
 // SecurityGroupInput is an input type that accepts SecurityGroupArgs and SecurityGroupOutput values.
 // You can construct a concrete instance of `SecurityGroupInput` via:
 //
-//          SecurityGroupArgs{...}
+//	SecurityGroupArgs{...}
 type SecurityGroupInput interface {
 	pulumi.Input
 
@@ -2452,11 +2452,11 @@ func (i SecurityGroupArgs) ToSecurityGroupPtrOutputWithContext(ctx context.Conte
 // SecurityGroupPtrInput is an input type that accepts SecurityGroupArgs, SecurityGroupPtr and SecurityGroupPtrOutput values.
 // You can construct a concrete instance of `SecurityGroupPtrInput` via:
 //
-//          SecurityGroupArgs{...}
+//	        SecurityGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type SecurityGroupPtrInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/cloudtrail/trail.go
+++ b/sdk/go/awsx/cloudtrail/trail.go
@@ -133,7 +133,7 @@ func (i *Trail) ToTrailOutputWithContext(ctx context.Context) TrailOutput {
 // TrailArrayInput is an input type that accepts TrailArray and TrailArrayOutput values.
 // You can construct a concrete instance of `TrailArrayInput` via:
 //
-//          TrailArray{ TrailArgs{...} }
+//	TrailArray{ TrailArgs{...} }
 type TrailArrayInput interface {
 	pulumi.Input
 
@@ -158,7 +158,7 @@ func (i TrailArray) ToTrailArrayOutputWithContext(ctx context.Context) TrailArra
 // TrailMapInput is an input type that accepts TrailMap and TrailMapOutput values.
 // You can construct a concrete instance of `TrailMapInput` via:
 //
-//          TrailMap{ "key": TrailArgs{...} }
+//	TrailMap{ "key": TrailArgs{...} }
 type TrailMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/doc.go
+++ b/sdk/go/awsx/doc.go
@@ -1,3 +1,2 @@
 // Pulumi Amazon Web Services (AWS) AWSX Components.
-//
 package awsx

--- a/sdk/go/awsx/ec2/defaultVpc.go
+++ b/sdk/go/awsx/ec2/defaultVpc.go
@@ -68,7 +68,7 @@ func (i *DefaultVpc) ToDefaultVpcOutputWithContext(ctx context.Context) DefaultV
 // DefaultVpcArrayInput is an input type that accepts DefaultVpcArray and DefaultVpcArrayOutput values.
 // You can construct a concrete instance of `DefaultVpcArrayInput` via:
 //
-//          DefaultVpcArray{ DefaultVpcArgs{...} }
+//	DefaultVpcArray{ DefaultVpcArgs{...} }
 type DefaultVpcArrayInput interface {
 	pulumi.Input
 
@@ -93,7 +93,7 @@ func (i DefaultVpcArray) ToDefaultVpcArrayOutputWithContext(ctx context.Context)
 // DefaultVpcMapInput is an input type that accepts DefaultVpcMap and DefaultVpcMapOutput values.
 // You can construct a concrete instance of `DefaultVpcMapInput` via:
 //
-//          DefaultVpcMap{ "key": DefaultVpcArgs{...} }
+//	DefaultVpcMap{ "key": DefaultVpcArgs{...} }
 type DefaultVpcMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ec2/pulumiEnums.go
+++ b/sdk/go/awsx/ec2/pulumiEnums.go
@@ -144,7 +144,7 @@ func (o NatGatewayStrategyPtrOutput) ToStringPtrOutputWithContext(ctx context.Co
 // NatGatewayStrategyInput is an input type that accepts NatGatewayStrategyArgs and NatGatewayStrategyOutput values.
 // You can construct a concrete instance of `NatGatewayStrategyInput` via:
 //
-//          NatGatewayStrategyArgs{...}
+//	NatGatewayStrategyArgs{...}
 type NatGatewayStrategyInput interface {
 	pulumi.Input
 
@@ -313,7 +313,7 @@ func (o SubnetTypePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) p
 // SubnetTypeInput is an input type that accepts SubnetTypeArgs and SubnetTypeOutput values.
 // You can construct a concrete instance of `SubnetTypeInput` via:
 //
-//          SubnetTypeArgs{...}
+//	SubnetTypeArgs{...}
 type SubnetTypeInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ec2/pulumiTypes.go
+++ b/sdk/go/awsx/ec2/pulumiTypes.go
@@ -21,7 +21,7 @@ type NatGatewayConfiguration struct {
 // NatGatewayConfigurationInput is an input type that accepts NatGatewayConfigurationArgs and NatGatewayConfigurationOutput values.
 // You can construct a concrete instance of `NatGatewayConfigurationInput` via:
 //
-//          NatGatewayConfigurationArgs{...}
+//	NatGatewayConfigurationArgs{...}
 type NatGatewayConfigurationInput interface {
 	pulumi.Input
 
@@ -60,11 +60,11 @@ func (i NatGatewayConfigurationArgs) ToNatGatewayConfigurationPtrOutputWithConte
 // NatGatewayConfigurationPtrInput is an input type that accepts NatGatewayConfigurationArgs, NatGatewayConfigurationPtr and NatGatewayConfigurationPtrOutput values.
 // You can construct a concrete instance of `NatGatewayConfigurationPtrInput` via:
 //
-//          NatGatewayConfigurationArgs{...}
+//	        NatGatewayConfigurationArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type NatGatewayConfigurationPtrInput interface {
 	pulumi.Input
 
@@ -172,7 +172,7 @@ func (o NatGatewayConfigurationPtrOutput) Strategy() NatGatewayStrategyPtrOutput
 // Configuration for a VPC subnet.
 type SubnetSpec struct {
 	// The bitmask for the subnet's CIDR block.
-	CidrMask int `pulumi:"cidrMask"`
+	CidrMask *int `pulumi:"cidrMask"`
 	// The subnet's name. Will be templated upon creation.
 	Name *string `pulumi:"name"`
 	// The type of subnet.
@@ -182,7 +182,7 @@ type SubnetSpec struct {
 // SubnetSpecInput is an input type that accepts SubnetSpecArgs and SubnetSpecOutput values.
 // You can construct a concrete instance of `SubnetSpecInput` via:
 //
-//          SubnetSpecArgs{...}
+//	SubnetSpecArgs{...}
 type SubnetSpecInput interface {
 	pulumi.Input
 
@@ -193,7 +193,7 @@ type SubnetSpecInput interface {
 // Configuration for a VPC subnet.
 type SubnetSpecArgs struct {
 	// The bitmask for the subnet's CIDR block.
-	CidrMask int `pulumi:"cidrMask"`
+	CidrMask *int `pulumi:"cidrMask"`
 	// The subnet's name. Will be templated upon creation.
 	Name *string `pulumi:"name"`
 	// The type of subnet.
@@ -215,7 +215,7 @@ func (i SubnetSpecArgs) ToSubnetSpecOutputWithContext(ctx context.Context) Subne
 // SubnetSpecArrayInput is an input type that accepts SubnetSpecArray and SubnetSpecArrayOutput values.
 // You can construct a concrete instance of `SubnetSpecArrayInput` via:
 //
-//          SubnetSpecArray{ SubnetSpecArgs{...} }
+//	SubnetSpecArray{ SubnetSpecArgs{...} }
 type SubnetSpecArrayInput interface {
 	pulumi.Input
 
@@ -253,8 +253,8 @@ func (o SubnetSpecOutput) ToSubnetSpecOutputWithContext(ctx context.Context) Sub
 }
 
 // The bitmask for the subnet's CIDR block.
-func (o SubnetSpecOutput) CidrMask() pulumi.IntOutput {
-	return o.ApplyT(func(v SubnetSpec) int { return v.CidrMask }).(pulumi.IntOutput)
+func (o SubnetSpecOutput) CidrMask() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v SubnetSpec) *int { return v.CidrMask }).(pulumi.IntPtrOutput)
 }
 
 // The subnet's name. Will be templated upon creation.
@@ -293,117 +293,129 @@ func (o SubnetSpecArrayOutput) Index(i pulumi.IntInput) SubnetSpecOutput {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Basic w/ Tags
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 			Tags: pulumi.StringMap{
-// 				"Environment": pulumi.String("test"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//				Tags: pulumi.StringMap{
+//					"Environment": pulumi.String("test"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Interface Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
-// 			VpcId:           pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
-// 			VpcEndpointType: pulumi.String("Interface"),
-// 			SecurityGroupIds: pulumi.StringArray{
-// 				pulumi.Any(aws_security_group.Sg1.Id),
-// 			},
-// 			PrivateDnsEnabled: pulumi.Bool(true),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
+//				VpcId:           pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
+//				VpcEndpointType: pulumi.String("Interface"),
+//				SecurityGroupIds: pulumi.StringArray{
+//					pulumi.Any(aws_security_group.Sg1.Id),
+//				},
+//				PrivateDnsEnabled: pulumi.Bool(true),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		current, err := aws.GetCallerIdentity(ctx, nil, nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
-// 			AcceptanceRequired: pulumi.Bool(false),
-// 			AllowedPrincipals: pulumi.StringArray{
-// 				pulumi.String(current.Arn),
-// 			},
-// 			GatewayLoadBalancerArns: pulumi.StringArray{
-// 				pulumi.Any(aws_lb.Example.Arn),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
-// 			ServiceName: exampleVpcEndpointService.ServiceName,
-// 			SubnetIds: pulumi.StringArray{
-// 				pulumi.Any(aws_subnet.Example.Id),
-// 			},
-// 			VpcEndpointType: exampleVpcEndpointService.ServiceType,
-// 			VpcId:           pulumi.Any(aws_vpc.Example.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			current, err := aws.GetCallerIdentity(ctx, nil, nil)
+//			if err != nil {
+//				return err
+//			}
+//			exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
+//				AcceptanceRequired: pulumi.Bool(false),
+//				AllowedPrincipals: pulumi.StringArray{
+//					pulumi.String(current.Arn),
+//				},
+//				GatewayLoadBalancerArns: pulumi.StringArray{
+//					pulumi.Any(aws_lb.Example.Arn),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
+//				ServiceName: exampleVpcEndpointService.ServiceName,
+//				SubnetIds: pulumi.StringArray{
+//					pulumi.Any(aws_subnet.Example.Id),
+//				},
+//				VpcEndpointType: exampleVpcEndpointService.ServiceType,
+//				VpcId:           pulumi.Any(aws_vpc.Example.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -411,7 +423,9 @@ func (o SubnetSpecArrayOutput) Index(i pulumi.IntInput) SubnetSpecOutput {
 // VPC Endpoints can be imported using the `vpc endpoint id`, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
+//	$ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
 // ```
 type VpcEndpointSpec struct {
 	// Accept the VPC endpoint (the VPC endpoint and service need to be in the same AWS account).
@@ -438,7 +452,7 @@ type VpcEndpointSpec struct {
 // VpcEndpointSpecInput is an input type that accepts VpcEndpointSpecArgs and VpcEndpointSpecOutput values.
 // You can construct a concrete instance of `VpcEndpointSpecInput` via:
 //
-//          VpcEndpointSpecArgs{...}
+//	VpcEndpointSpecArgs{...}
 type VpcEndpointSpecInput interface {
 	pulumi.Input
 
@@ -452,117 +466,129 @@ type VpcEndpointSpecInput interface {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Basic w/ Tags
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 			Tags: pulumi.StringMap{
-// 				"Environment": pulumi.String("test"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//				Tags: pulumi.StringMap{
+//					"Environment": pulumi.String("test"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Interface Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
-// 			VpcId:           pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
-// 			VpcEndpointType: pulumi.String("Interface"),
-// 			SecurityGroupIds: pulumi.StringArray{
-// 				pulumi.Any(aws_security_group.Sg1.Id),
-// 			},
-// 			PrivateDnsEnabled: pulumi.Bool(true),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
+//				VpcId:           pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
+//				VpcEndpointType: pulumi.String("Interface"),
+//				SecurityGroupIds: pulumi.StringArray{
+//					pulumi.Any(aws_security_group.Sg1.Id),
+//				},
+//				PrivateDnsEnabled: pulumi.Bool(true),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		current, err := aws.GetCallerIdentity(ctx, nil, nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
-// 			AcceptanceRequired: pulumi.Bool(false),
-// 			AllowedPrincipals: pulumi.StringArray{
-// 				pulumi.String(current.Arn),
-// 			},
-// 			GatewayLoadBalancerArns: pulumi.StringArray{
-// 				pulumi.Any(aws_lb.Example.Arn),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
-// 			ServiceName: exampleVpcEndpointService.ServiceName,
-// 			SubnetIds: pulumi.StringArray{
-// 				pulumi.Any(aws_subnet.Example.Id),
-// 			},
-// 			VpcEndpointType: exampleVpcEndpointService.ServiceType,
-// 			VpcId:           pulumi.Any(aws_vpc.Example.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			current, err := aws.GetCallerIdentity(ctx, nil, nil)
+//			if err != nil {
+//				return err
+//			}
+//			exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
+//				AcceptanceRequired: pulumi.Bool(false),
+//				AllowedPrincipals: pulumi.StringArray{
+//					pulumi.String(current.Arn),
+//				},
+//				GatewayLoadBalancerArns: pulumi.StringArray{
+//					pulumi.Any(aws_lb.Example.Arn),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
+//				ServiceName: exampleVpcEndpointService.ServiceName,
+//				SubnetIds: pulumi.StringArray{
+//					pulumi.Any(aws_subnet.Example.Id),
+//				},
+//				VpcEndpointType: exampleVpcEndpointService.ServiceType,
+//				VpcId:           pulumi.Any(aws_vpc.Example.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -570,7 +596,9 @@ type VpcEndpointSpecInput interface {
 // VPC Endpoints can be imported using the `vpc endpoint id`, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
+//	$ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
 // ```
 type VpcEndpointSpecArgs struct {
 	// Accept the VPC endpoint (the VPC endpoint and service need to be in the same AWS account).
@@ -609,7 +637,7 @@ func (i VpcEndpointSpecArgs) ToVpcEndpointSpecOutputWithContext(ctx context.Cont
 // VpcEndpointSpecArrayInput is an input type that accepts VpcEndpointSpecArray and VpcEndpointSpecArrayOutput values.
 // You can construct a concrete instance of `VpcEndpointSpecArrayInput` via:
 //
-//          VpcEndpointSpecArray{ VpcEndpointSpecArgs{...} }
+//	VpcEndpointSpecArray{ VpcEndpointSpecArgs{...} }
 type VpcEndpointSpecArrayInput interface {
 	pulumi.Input
 
@@ -637,117 +665,129 @@ func (i VpcEndpointSpecArray) ToVpcEndpointSpecArrayOutputWithContext(ctx contex
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Basic w/ Tags
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
-// 			VpcId:       pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
-// 			Tags: pulumi.StringMap{
-// 				"Environment": pulumi.String("test"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "s3", &ec2.VpcEndpointArgs{
+//				VpcId:       pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName: pulumi.String("com.amazonaws.us-west-2.s3"),
+//				Tags: pulumi.StringMap{
+//					"Environment": pulumi.String("test"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Interface Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
-// 			VpcId:           pulumi.Any(aws_vpc.Main.Id),
-// 			ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
-// 			VpcEndpointType: pulumi.String("Interface"),
-// 			SecurityGroupIds: pulumi.StringArray{
-// 				pulumi.Any(aws_security_group.Sg1.Id),
-// 			},
-// 			PrivateDnsEnabled: pulumi.Bool(true),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := ec2.NewVpcEndpoint(ctx, "ec2", &ec2.VpcEndpointArgs{
+//				VpcId:           pulumi.Any(aws_vpc.Main.Id),
+//				ServiceName:     pulumi.String("com.amazonaws.us-west-2.ec2"),
+//				VpcEndpointType: pulumi.String("Interface"),
+//				SecurityGroupIds: pulumi.StringArray{
+//					pulumi.Any(aws_security_group.Sg1.Id),
+//				},
+//				PrivateDnsEnabled: pulumi.Bool(true),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Endpoint Type
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		current, err := aws.GetCallerIdentity(ctx, nil, nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
-// 			AcceptanceRequired: pulumi.Bool(false),
-// 			AllowedPrincipals: pulumi.StringArray{
-// 				pulumi.String(current.Arn),
-// 			},
-// 			GatewayLoadBalancerArns: pulumi.StringArray{
-// 				pulumi.Any(aws_lb.Example.Arn),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
-// 			ServiceName: exampleVpcEndpointService.ServiceName,
-// 			SubnetIds: pulumi.StringArray{
-// 				pulumi.Any(aws_subnet.Example.Id),
-// 			},
-// 			VpcEndpointType: exampleVpcEndpointService.ServiceType,
-// 			VpcId:           pulumi.Any(aws_vpc.Example.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			current, err := aws.GetCallerIdentity(ctx, nil, nil)
+//			if err != nil {
+//				return err
+//			}
+//			exampleVpcEndpointService, err := ec2.NewVpcEndpointService(ctx, "exampleVpcEndpointService", &ec2.VpcEndpointServiceArgs{
+//				AcceptanceRequired: pulumi.Bool(false),
+//				AllowedPrincipals: pulumi.StringArray{
+//					pulumi.String(current.Arn),
+//				},
+//				GatewayLoadBalancerArns: pulumi.StringArray{
+//					pulumi.Any(aws_lb.Example.Arn),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = ec2.NewVpcEndpoint(ctx, "exampleVpcEndpoint", &ec2.VpcEndpointArgs{
+//				ServiceName: exampleVpcEndpointService.ServiceName,
+//				SubnetIds: pulumi.StringArray{
+//					pulumi.Any(aws_subnet.Example.Id),
+//				},
+//				VpcEndpointType: exampleVpcEndpointService.ServiceType,
+//				VpcId:           pulumi.Any(aws_vpc.Example.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -755,7 +795,9 @@ func (i VpcEndpointSpecArray) ToVpcEndpointSpecArrayOutputWithContext(ctx contex
 // VPC Endpoints can be imported using the `vpc endpoint id`, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
+//	$ pulumi import aws:ec2/vpcEndpoint:VpcEndpoint endpoint1 vpce-3ecf2a57
+//
 // ```
 type VpcEndpointSpecOutput struct{ *pulumi.OutputState }
 

--- a/sdk/go/awsx/ec2/vpc.go
+++ b/sdk/go/awsx/ec2/vpc.go
@@ -168,7 +168,7 @@ func (i *Vpc) ToVpcOutputWithContext(ctx context.Context) VpcOutput {
 // VpcArrayInput is an input type that accepts VpcArray and VpcArrayOutput values.
 // You can construct a concrete instance of `VpcArrayInput` via:
 //
-//          VpcArray{ VpcArgs{...} }
+//	VpcArray{ VpcArgs{...} }
 type VpcArrayInput interface {
 	pulumi.Input
 
@@ -193,7 +193,7 @@ func (i VpcArray) ToVpcArrayOutputWithContext(ctx context.Context) VpcArrayOutpu
 // VpcMapInput is an input type that accepts VpcMap and VpcMapOutput values.
 // You can construct a concrete instance of `VpcMapInput` via:
 //
-//          VpcMap{ "key": VpcArgs{...} }
+//	VpcMap{ "key": VpcArgs{...} }
 type VpcMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -102,7 +102,7 @@ func (i *Image) ToImageOutputWithContext(ctx context.Context) ImageOutput {
 // ImageArrayInput is an input type that accepts ImageArray and ImageArrayOutput values.
 // You can construct a concrete instance of `ImageArrayInput` via:
 //
-//          ImageArray{ ImageArgs{...} }
+//	ImageArray{ ImageArgs{...} }
 type ImageArrayInput interface {
 	pulumi.Input
 
@@ -127,7 +127,7 @@ func (i ImageArray) ToImageArrayOutputWithContext(ctx context.Context) ImageArra
 // ImageMapInput is an input type that accepts ImageMap and ImageMapOutput values.
 // You can construct a concrete instance of `ImageMapInput` via:
 //
-//          ImageMap{ "key": ImageArgs{...} }
+//	ImageMap{ "key": ImageArgs{...} }
 type ImageMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecr/pulumiEnums.go
+++ b/sdk/go/awsx/ecr/pulumiEnums.go
@@ -143,7 +143,7 @@ func (o LifecycleTagStatusPtrOutput) ToStringPtrOutputWithContext(ctx context.Co
 // LifecycleTagStatusInput is an input type that accepts LifecycleTagStatusArgs and LifecycleTagStatusOutput values.
 // You can construct a concrete instance of `LifecycleTagStatusInput` via:
 //
-//          LifecycleTagStatusArgs{...}
+//	LifecycleTagStatusArgs{...}
 type LifecycleTagStatusInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -39,7 +39,7 @@ type LifecyclePolicy struct {
 // LifecyclePolicyInput is an input type that accepts LifecyclePolicyArgs and LifecyclePolicyOutput values.
 // You can construct a concrete instance of `LifecyclePolicyInput` via:
 //
-//          LifecyclePolicyArgs{...}
+//	LifecyclePolicyArgs{...}
 type LifecyclePolicyInput interface {
 	pulumi.Input
 
@@ -78,11 +78,11 @@ func (i LifecyclePolicyArgs) ToLifecyclePolicyPtrOutputWithContext(ctx context.C
 // LifecyclePolicyPtrInput is an input type that accepts LifecyclePolicyArgs, LifecyclePolicyPtr and LifecyclePolicyPtrOutput values.
 // You can construct a concrete instance of `LifecyclePolicyPtrInput` via:
 //
-//          LifecyclePolicyArgs{...}
+//	        LifecyclePolicyArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type LifecyclePolicyPtrInput interface {
 	pulumi.Input
 
@@ -204,7 +204,7 @@ type LifecyclePolicyRule struct {
 // LifecyclePolicyRuleInput is an input type that accepts LifecyclePolicyRuleArgs and LifecyclePolicyRuleOutput values.
 // You can construct a concrete instance of `LifecyclePolicyRuleInput` via:
 //
-//          LifecyclePolicyRuleArgs{...}
+//	LifecyclePolicyRuleArgs{...}
 type LifecyclePolicyRuleInput interface {
 	pulumi.Input
 
@@ -241,7 +241,7 @@ func (i LifecyclePolicyRuleArgs) ToLifecyclePolicyRuleOutputWithContext(ctx cont
 // LifecyclePolicyRuleArrayInput is an input type that accepts LifecyclePolicyRuleArray and LifecyclePolicyRuleArrayOutput values.
 // You can construct a concrete instance of `LifecyclePolicyRuleArrayInput` via:
 //
-//          LifecyclePolicyRuleArray{ LifecyclePolicyRuleArgs{...} }
+//	LifecyclePolicyRuleArray{ LifecyclePolicyRuleArgs{...} }
 type LifecyclePolicyRuleArrayInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecr/repository.go
+++ b/sdk/go/awsx/ecr/repository.go
@@ -97,7 +97,7 @@ func (i *Repository) ToRepositoryOutputWithContext(ctx context.Context) Reposito
 // RepositoryArrayInput is an input type that accepts RepositoryArray and RepositoryArrayOutput values.
 // You can construct a concrete instance of `RepositoryArrayInput` via:
 //
-//          RepositoryArray{ RepositoryArgs{...} }
+//	RepositoryArray{ RepositoryArgs{...} }
 type RepositoryArrayInput interface {
 	pulumi.Input
 
@@ -122,7 +122,7 @@ func (i RepositoryArray) ToRepositoryArrayOutputWithContext(ctx context.Context)
 // RepositoryMapInput is an input type that accepts RepositoryMap and RepositoryMapOutput values.
 // You can construct a concrete instance of `RepositoryMapInput` via:
 //
-//          RepositoryMap{ "key": RepositoryArgs{...} }
+//	RepositoryMap{ "key": RepositoryArgs{...} }
 type RepositoryMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecs/ec2service.go
+++ b/sdk/go/awsx/ecs/ec2service.go
@@ -170,7 +170,7 @@ func (i *EC2Service) ToEC2ServiceOutputWithContext(ctx context.Context) EC2Servi
 // EC2ServiceArrayInput is an input type that accepts EC2ServiceArray and EC2ServiceArrayOutput values.
 // You can construct a concrete instance of `EC2ServiceArrayInput` via:
 //
-//          EC2ServiceArray{ EC2ServiceArgs{...} }
+//	EC2ServiceArray{ EC2ServiceArgs{...} }
 type EC2ServiceArrayInput interface {
 	pulumi.Input
 
@@ -195,7 +195,7 @@ func (i EC2ServiceArray) ToEC2ServiceArrayOutputWithContext(ctx context.Context)
 // EC2ServiceMapInput is an input type that accepts EC2ServiceMap and EC2ServiceMapOutput values.
 // You can construct a concrete instance of `EC2ServiceMapInput` via:
 //
-//          EC2ServiceMap{ "key": EC2ServiceArgs{...} }
+//	EC2ServiceMap{ "key": EC2ServiceArgs{...} }
 type EC2ServiceMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecs/ec2taskDefinition.go
+++ b/sdk/go/awsx/ecs/ec2taskDefinition.go
@@ -172,7 +172,7 @@ func (i *EC2TaskDefinition) ToEC2TaskDefinitionOutputWithContext(ctx context.Con
 // EC2TaskDefinitionArrayInput is an input type that accepts EC2TaskDefinitionArray and EC2TaskDefinitionArrayOutput values.
 // You can construct a concrete instance of `EC2TaskDefinitionArrayInput` via:
 //
-//          EC2TaskDefinitionArray{ EC2TaskDefinitionArgs{...} }
+//	EC2TaskDefinitionArray{ EC2TaskDefinitionArgs{...} }
 type EC2TaskDefinitionArrayInput interface {
 	pulumi.Input
 
@@ -197,7 +197,7 @@ func (i EC2TaskDefinitionArray) ToEC2TaskDefinitionArrayOutputWithContext(ctx co
 // EC2TaskDefinitionMapInput is an input type that accepts EC2TaskDefinitionMap and EC2TaskDefinitionMapOutput values.
 // You can construct a concrete instance of `EC2TaskDefinitionMapInput` via:
 //
-//          EC2TaskDefinitionMap{ "key": EC2TaskDefinitionArgs{...} }
+//	EC2TaskDefinitionMap{ "key": EC2TaskDefinitionArgs{...} }
 type EC2TaskDefinitionMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecs/fargateService.go
+++ b/sdk/go/awsx/ecs/fargateService.go
@@ -162,7 +162,7 @@ func (i *FargateService) ToFargateServiceOutputWithContext(ctx context.Context) 
 // FargateServiceArrayInput is an input type that accepts FargateServiceArray and FargateServiceArrayOutput values.
 // You can construct a concrete instance of `FargateServiceArrayInput` via:
 //
-//          FargateServiceArray{ FargateServiceArgs{...} }
+//	FargateServiceArray{ FargateServiceArgs{...} }
 type FargateServiceArrayInput interface {
 	pulumi.Input
 
@@ -187,7 +187,7 @@ func (i FargateServiceArray) ToFargateServiceArrayOutputWithContext(ctx context.
 // FargateServiceMapInput is an input type that accepts FargateServiceMap and FargateServiceMapOutput values.
 // You can construct a concrete instance of `FargateServiceMapInput` via:
 //
-//          FargateServiceMap{ "key": FargateServiceArgs{...} }
+//	FargateServiceMap{ "key": FargateServiceArgs{...} }
 type FargateServiceMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecs/fargateTaskDefinition.go
+++ b/sdk/go/awsx/ecs/fargateTaskDefinition.go
@@ -168,7 +168,7 @@ func (i *FargateTaskDefinition) ToFargateTaskDefinitionOutputWithContext(ctx con
 // FargateTaskDefinitionArrayInput is an input type that accepts FargateTaskDefinitionArray and FargateTaskDefinitionArrayOutput values.
 // You can construct a concrete instance of `FargateTaskDefinitionArrayInput` via:
 //
-//          FargateTaskDefinitionArray{ FargateTaskDefinitionArgs{...} }
+//	FargateTaskDefinitionArray{ FargateTaskDefinitionArgs{...} }
 type FargateTaskDefinitionArrayInput interface {
 	pulumi.Input
 
@@ -193,7 +193,7 @@ func (i FargateTaskDefinitionArray) ToFargateTaskDefinitionArrayOutputWithContex
 // FargateTaskDefinitionMapInput is an input type that accepts FargateTaskDefinitionMap and FargateTaskDefinitionMapOutput values.
 // You can construct a concrete instance of `FargateTaskDefinitionMapInput` via:
 //
-//          FargateTaskDefinitionMap{ "key": FargateTaskDefinitionArgs{...} }
+//	FargateTaskDefinitionMap{ "key": FargateTaskDefinitionArgs{...} }
 type FargateTaskDefinitionMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/ecs/pulumiTypes.go
+++ b/sdk/go/awsx/ecs/pulumiTypes.go
@@ -68,7 +68,7 @@ type EC2ServiceTaskDefinition struct {
 // EC2ServiceTaskDefinitionInput is an input type that accepts EC2ServiceTaskDefinitionArgs and EC2ServiceTaskDefinitionOutput values.
 // You can construct a concrete instance of `EC2ServiceTaskDefinitionInput` via:
 //
-//          EC2ServiceTaskDefinitionArgs{...}
+//	EC2ServiceTaskDefinitionArgs{...}
 type EC2ServiceTaskDefinitionInput interface {
 	pulumi.Input
 
@@ -151,11 +151,11 @@ func (i EC2ServiceTaskDefinitionArgs) ToEC2ServiceTaskDefinitionPtrOutputWithCon
 // EC2ServiceTaskDefinitionPtrInput is an input type that accepts EC2ServiceTaskDefinitionArgs, EC2ServiceTaskDefinitionPtr and EC2ServiceTaskDefinitionPtrOutput values.
 // You can construct a concrete instance of `EC2ServiceTaskDefinitionPtrInput` via:
 //
-//          EC2ServiceTaskDefinitionArgs{...}
+//	        EC2ServiceTaskDefinitionArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type EC2ServiceTaskDefinitionPtrInput interface {
 	pulumi.Input
 
@@ -590,7 +590,7 @@ type FargateServiceTaskDefinition struct {
 // FargateServiceTaskDefinitionInput is an input type that accepts FargateServiceTaskDefinitionArgs and FargateServiceTaskDefinitionOutput values.
 // You can construct a concrete instance of `FargateServiceTaskDefinitionInput` via:
 //
-//          FargateServiceTaskDefinitionArgs{...}
+//	FargateServiceTaskDefinitionArgs{...}
 type FargateServiceTaskDefinitionInput interface {
 	pulumi.Input
 
@@ -671,11 +671,11 @@ func (i FargateServiceTaskDefinitionArgs) ToFargateServiceTaskDefinitionPtrOutpu
 // FargateServiceTaskDefinitionPtrInput is an input type that accepts FargateServiceTaskDefinitionArgs, FargateServiceTaskDefinitionPtr and FargateServiceTaskDefinitionPtrOutput values.
 // You can construct a concrete instance of `FargateServiceTaskDefinitionPtrInput` via:
 //
-//          FargateServiceTaskDefinitionArgs{...}
+//	        FargateServiceTaskDefinitionArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type FargateServiceTaskDefinitionPtrInput interface {
 	pulumi.Input
 
@@ -1096,7 +1096,7 @@ type TaskDefinitionContainerDefinition struct {
 // TaskDefinitionContainerDefinitionInput is an input type that accepts TaskDefinitionContainerDefinitionArgs and TaskDefinitionContainerDefinitionOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDefinitionInput` via:
 //
-//          TaskDefinitionContainerDefinitionArgs{...}
+//	TaskDefinitionContainerDefinitionArgs{...}
 type TaskDefinitionContainerDefinitionInput interface {
 	pulumi.Input
 
@@ -1176,11 +1176,11 @@ func (i TaskDefinitionContainerDefinitionArgs) ToTaskDefinitionContainerDefiniti
 // TaskDefinitionContainerDefinitionPtrInput is an input type that accepts TaskDefinitionContainerDefinitionArgs, TaskDefinitionContainerDefinitionPtr and TaskDefinitionContainerDefinitionPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDefinitionPtrInput` via:
 //
-//          TaskDefinitionContainerDefinitionArgs{...}
+//	        TaskDefinitionContainerDefinitionArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionContainerDefinitionPtrInput interface {
 	pulumi.Input
 
@@ -1209,7 +1209,7 @@ func (i *taskDefinitionContainerDefinitionPtrType) ToTaskDefinitionContainerDefi
 // TaskDefinitionContainerDefinitionMapInput is an input type that accepts TaskDefinitionContainerDefinitionMap and TaskDefinitionContainerDefinitionMapOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDefinitionMapInput` via:
 //
-//          TaskDefinitionContainerDefinitionMap{ "key": TaskDefinitionContainerDefinitionArgs{...} }
+//	TaskDefinitionContainerDefinitionMap{ "key": TaskDefinitionContainerDefinitionArgs{...} }
 type TaskDefinitionContainerDefinitionMapInput interface {
 	pulumi.Input
 
@@ -1833,7 +1833,7 @@ type TaskDefinitionContainerDependency struct {
 // TaskDefinitionContainerDependencyInput is an input type that accepts TaskDefinitionContainerDependencyArgs and TaskDefinitionContainerDependencyOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDependencyInput` via:
 //
-//          TaskDefinitionContainerDependencyArgs{...}
+//	TaskDefinitionContainerDependencyArgs{...}
 type TaskDefinitionContainerDependencyInput interface {
 	pulumi.Input
 
@@ -1861,7 +1861,7 @@ func (i TaskDefinitionContainerDependencyArgs) ToTaskDefinitionContainerDependen
 // TaskDefinitionContainerDependencyArrayInput is an input type that accepts TaskDefinitionContainerDependencyArray and TaskDefinitionContainerDependencyArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionContainerDependencyArrayInput` via:
 //
-//          TaskDefinitionContainerDependencyArray{ TaskDefinitionContainerDependencyArgs{...} }
+//	TaskDefinitionContainerDependencyArray{ TaskDefinitionContainerDependencyArgs{...} }
 type TaskDefinitionContainerDependencyArrayInput interface {
 	pulumi.Input
 
@@ -1934,7 +1934,7 @@ type TaskDefinitionDevice struct {
 // TaskDefinitionDeviceInput is an input type that accepts TaskDefinitionDeviceArgs and TaskDefinitionDeviceOutput values.
 // You can construct a concrete instance of `TaskDefinitionDeviceInput` via:
 //
-//          TaskDefinitionDeviceArgs{...}
+//	TaskDefinitionDeviceArgs{...}
 type TaskDefinitionDeviceInput interface {
 	pulumi.Input
 
@@ -1963,7 +1963,7 @@ func (i TaskDefinitionDeviceArgs) ToTaskDefinitionDeviceOutputWithContext(ctx co
 // TaskDefinitionDeviceArrayInput is an input type that accepts TaskDefinitionDeviceArray and TaskDefinitionDeviceArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionDeviceArrayInput` via:
 //
-//          TaskDefinitionDeviceArray{ TaskDefinitionDeviceArgs{...} }
+//	TaskDefinitionDeviceArray{ TaskDefinitionDeviceArgs{...} }
 type TaskDefinitionDeviceArrayInput interface {
 	pulumi.Input
 
@@ -2039,7 +2039,7 @@ type TaskDefinitionEnvironmentFile struct {
 // TaskDefinitionEnvironmentFileInput is an input type that accepts TaskDefinitionEnvironmentFileArgs and TaskDefinitionEnvironmentFileOutput values.
 // You can construct a concrete instance of `TaskDefinitionEnvironmentFileInput` via:
 //
-//          TaskDefinitionEnvironmentFileArgs{...}
+//	TaskDefinitionEnvironmentFileArgs{...}
 type TaskDefinitionEnvironmentFileInput interface {
 	pulumi.Input
 
@@ -2067,7 +2067,7 @@ func (i TaskDefinitionEnvironmentFileArgs) ToTaskDefinitionEnvironmentFileOutput
 // TaskDefinitionEnvironmentFileArrayInput is an input type that accepts TaskDefinitionEnvironmentFileArray and TaskDefinitionEnvironmentFileArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionEnvironmentFileArrayInput` via:
 //
-//          TaskDefinitionEnvironmentFileArray{ TaskDefinitionEnvironmentFileArgs{...} }
+//	TaskDefinitionEnvironmentFileArray{ TaskDefinitionEnvironmentFileArgs{...} }
 type TaskDefinitionEnvironmentFileArrayInput interface {
 	pulumi.Input
 
@@ -2139,7 +2139,7 @@ type TaskDefinitionFirelensConfiguration struct {
 // TaskDefinitionFirelensConfigurationInput is an input type that accepts TaskDefinitionFirelensConfigurationArgs and TaskDefinitionFirelensConfigurationOutput values.
 // You can construct a concrete instance of `TaskDefinitionFirelensConfigurationInput` via:
 //
-//          TaskDefinitionFirelensConfigurationArgs{...}
+//	TaskDefinitionFirelensConfigurationArgs{...}
 type TaskDefinitionFirelensConfigurationInput interface {
 	pulumi.Input
 
@@ -2175,11 +2175,11 @@ func (i TaskDefinitionFirelensConfigurationArgs) ToTaskDefinitionFirelensConfigu
 // TaskDefinitionFirelensConfigurationPtrInput is an input type that accepts TaskDefinitionFirelensConfigurationArgs, TaskDefinitionFirelensConfigurationPtr and TaskDefinitionFirelensConfigurationPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionFirelensConfigurationPtrInput` via:
 //
-//          TaskDefinitionFirelensConfigurationArgs{...}
+//	        TaskDefinitionFirelensConfigurationArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionFirelensConfigurationPtrInput interface {
 	pulumi.Input
 
@@ -2296,7 +2296,7 @@ type TaskDefinitionHealthCheck struct {
 // TaskDefinitionHealthCheckInput is an input type that accepts TaskDefinitionHealthCheckArgs and TaskDefinitionHealthCheckOutput values.
 // You can construct a concrete instance of `TaskDefinitionHealthCheckInput` via:
 //
-//          TaskDefinitionHealthCheckArgs{...}
+//	TaskDefinitionHealthCheckArgs{...}
 type TaskDefinitionHealthCheckInput interface {
 	pulumi.Input
 
@@ -2341,11 +2341,11 @@ func (i TaskDefinitionHealthCheckArgs) ToTaskDefinitionHealthCheckPtrOutputWithC
 // TaskDefinitionHealthCheckPtrInput is an input type that accepts TaskDefinitionHealthCheckArgs, TaskDefinitionHealthCheckPtr and TaskDefinitionHealthCheckPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionHealthCheckPtrInput` via:
 //
-//          TaskDefinitionHealthCheckArgs{...}
+//	        TaskDefinitionHealthCheckArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionHealthCheckPtrInput interface {
 	pulumi.Input
 
@@ -2503,7 +2503,7 @@ type TaskDefinitionHostEntry struct {
 // TaskDefinitionHostEntryInput is an input type that accepts TaskDefinitionHostEntryArgs and TaskDefinitionHostEntryOutput values.
 // You can construct a concrete instance of `TaskDefinitionHostEntryInput` via:
 //
-//          TaskDefinitionHostEntryArgs{...}
+//	TaskDefinitionHostEntryArgs{...}
 type TaskDefinitionHostEntryInput interface {
 	pulumi.Input
 
@@ -2531,7 +2531,7 @@ func (i TaskDefinitionHostEntryArgs) ToTaskDefinitionHostEntryOutputWithContext(
 // TaskDefinitionHostEntryArrayInput is an input type that accepts TaskDefinitionHostEntryArray and TaskDefinitionHostEntryArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionHostEntryArrayInput` via:
 //
-//          TaskDefinitionHostEntryArray{ TaskDefinitionHostEntryArgs{...} }
+//	TaskDefinitionHostEntryArray{ TaskDefinitionHostEntryArgs{...} }
 type TaskDefinitionHostEntryArrayInput interface {
 	pulumi.Input
 
@@ -2603,7 +2603,7 @@ type TaskDefinitionKernelCapabilities struct {
 // TaskDefinitionKernelCapabilitiesInput is an input type that accepts TaskDefinitionKernelCapabilitiesArgs and TaskDefinitionKernelCapabilitiesOutput values.
 // You can construct a concrete instance of `TaskDefinitionKernelCapabilitiesInput` via:
 //
-//          TaskDefinitionKernelCapabilitiesArgs{...}
+//	TaskDefinitionKernelCapabilitiesArgs{...}
 type TaskDefinitionKernelCapabilitiesInput interface {
 	pulumi.Input
 
@@ -2639,11 +2639,11 @@ func (i TaskDefinitionKernelCapabilitiesArgs) ToTaskDefinitionKernelCapabilities
 // TaskDefinitionKernelCapabilitiesPtrInput is an input type that accepts TaskDefinitionKernelCapabilitiesArgs, TaskDefinitionKernelCapabilitiesPtr and TaskDefinitionKernelCapabilitiesPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionKernelCapabilitiesPtrInput` via:
 //
-//          TaskDefinitionKernelCapabilitiesArgs{...}
+//	        TaskDefinitionKernelCapabilitiesArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionKernelCapabilitiesPtrInput interface {
 	pulumi.Input
 
@@ -2751,7 +2751,7 @@ type TaskDefinitionKeyValuePair struct {
 // TaskDefinitionKeyValuePairInput is an input type that accepts TaskDefinitionKeyValuePairArgs and TaskDefinitionKeyValuePairOutput values.
 // You can construct a concrete instance of `TaskDefinitionKeyValuePairInput` via:
 //
-//          TaskDefinitionKeyValuePairArgs{...}
+//	TaskDefinitionKeyValuePairArgs{...}
 type TaskDefinitionKeyValuePairInput interface {
 	pulumi.Input
 
@@ -2779,7 +2779,7 @@ func (i TaskDefinitionKeyValuePairArgs) ToTaskDefinitionKeyValuePairOutputWithCo
 // TaskDefinitionKeyValuePairArrayInput is an input type that accepts TaskDefinitionKeyValuePairArray and TaskDefinitionKeyValuePairArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionKeyValuePairArrayInput` via:
 //
-//          TaskDefinitionKeyValuePairArray{ TaskDefinitionKeyValuePairArgs{...} }
+//	TaskDefinitionKeyValuePairArray{ TaskDefinitionKeyValuePairArgs{...} }
 type TaskDefinitionKeyValuePairArrayInput interface {
 	pulumi.Input
 
@@ -2856,7 +2856,7 @@ type TaskDefinitionLinuxParameters struct {
 // TaskDefinitionLinuxParametersInput is an input type that accepts TaskDefinitionLinuxParametersArgs and TaskDefinitionLinuxParametersOutput values.
 // You can construct a concrete instance of `TaskDefinitionLinuxParametersInput` via:
 //
-//          TaskDefinitionLinuxParametersArgs{...}
+//	TaskDefinitionLinuxParametersArgs{...}
 type TaskDefinitionLinuxParametersInput interface {
 	pulumi.Input
 
@@ -2897,11 +2897,11 @@ func (i TaskDefinitionLinuxParametersArgs) ToTaskDefinitionLinuxParametersPtrOut
 // TaskDefinitionLinuxParametersPtrInput is an input type that accepts TaskDefinitionLinuxParametersArgs, TaskDefinitionLinuxParametersPtr and TaskDefinitionLinuxParametersPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionLinuxParametersPtrInput` via:
 //
-//          TaskDefinitionLinuxParametersArgs{...}
+//	        TaskDefinitionLinuxParametersArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionLinuxParametersPtrInput interface {
 	pulumi.Input
 
@@ -3075,7 +3075,7 @@ type TaskDefinitionLogConfiguration struct {
 // TaskDefinitionLogConfigurationInput is an input type that accepts TaskDefinitionLogConfigurationArgs and TaskDefinitionLogConfigurationOutput values.
 // You can construct a concrete instance of `TaskDefinitionLogConfigurationInput` via:
 //
-//          TaskDefinitionLogConfigurationArgs{...}
+//	TaskDefinitionLogConfigurationArgs{...}
 type TaskDefinitionLogConfigurationInput interface {
 	pulumi.Input
 
@@ -3112,11 +3112,11 @@ func (i TaskDefinitionLogConfigurationArgs) ToTaskDefinitionLogConfigurationPtrO
 // TaskDefinitionLogConfigurationPtrInput is an input type that accepts TaskDefinitionLogConfigurationArgs, TaskDefinitionLogConfigurationPtr and TaskDefinitionLogConfigurationPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionLogConfigurationPtrInput` via:
 //
-//          TaskDefinitionLogConfigurationArgs{...}
+//	        TaskDefinitionLogConfigurationArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionLogConfigurationPtrInput interface {
 	pulumi.Input
 
@@ -3238,7 +3238,7 @@ type TaskDefinitionMountPoint struct {
 // TaskDefinitionMountPointInput is an input type that accepts TaskDefinitionMountPointArgs and TaskDefinitionMountPointOutput values.
 // You can construct a concrete instance of `TaskDefinitionMountPointInput` via:
 //
-//          TaskDefinitionMountPointArgs{...}
+//	TaskDefinitionMountPointArgs{...}
 type TaskDefinitionMountPointInput interface {
 	pulumi.Input
 
@@ -3267,7 +3267,7 @@ func (i TaskDefinitionMountPointArgs) ToTaskDefinitionMountPointOutputWithContex
 // TaskDefinitionMountPointArrayInput is an input type that accepts TaskDefinitionMountPointArray and TaskDefinitionMountPointArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionMountPointArrayInput` via:
 //
-//          TaskDefinitionMountPointArray{ TaskDefinitionMountPointArgs{...} }
+//	TaskDefinitionMountPointArray{ TaskDefinitionMountPointArgs{...} }
 type TaskDefinitionMountPointArrayInput interface {
 	pulumi.Input
 
@@ -3345,7 +3345,7 @@ type TaskDefinitionPortMapping struct {
 // TaskDefinitionPortMappingInput is an input type that accepts TaskDefinitionPortMappingArgs and TaskDefinitionPortMappingOutput values.
 // You can construct a concrete instance of `TaskDefinitionPortMappingInput` via:
 //
-//          TaskDefinitionPortMappingArgs{...}
+//	TaskDefinitionPortMappingArgs{...}
 type TaskDefinitionPortMappingInput interface {
 	pulumi.Input
 
@@ -3375,7 +3375,7 @@ func (i TaskDefinitionPortMappingArgs) ToTaskDefinitionPortMappingOutputWithCont
 // TaskDefinitionPortMappingArrayInput is an input type that accepts TaskDefinitionPortMappingArray and TaskDefinitionPortMappingArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionPortMappingArrayInput` via:
 //
-//          TaskDefinitionPortMappingArray{ TaskDefinitionPortMappingArgs{...} }
+//	TaskDefinitionPortMappingArray{ TaskDefinitionPortMappingArgs{...} }
 type TaskDefinitionPortMappingArrayInput interface {
 	pulumi.Input
 
@@ -3454,7 +3454,7 @@ type TaskDefinitionRepositoryCredentials struct {
 // TaskDefinitionRepositoryCredentialsInput is an input type that accepts TaskDefinitionRepositoryCredentialsArgs and TaskDefinitionRepositoryCredentialsOutput values.
 // You can construct a concrete instance of `TaskDefinitionRepositoryCredentialsInput` via:
 //
-//          TaskDefinitionRepositoryCredentialsArgs{...}
+//	TaskDefinitionRepositoryCredentialsArgs{...}
 type TaskDefinitionRepositoryCredentialsInput interface {
 	pulumi.Input
 
@@ -3489,11 +3489,11 @@ func (i TaskDefinitionRepositoryCredentialsArgs) ToTaskDefinitionRepositoryCrede
 // TaskDefinitionRepositoryCredentialsPtrInput is an input type that accepts TaskDefinitionRepositoryCredentialsArgs, TaskDefinitionRepositoryCredentialsPtr and TaskDefinitionRepositoryCredentialsPtrOutput values.
 // You can construct a concrete instance of `TaskDefinitionRepositoryCredentialsPtrInput` via:
 //
-//          TaskDefinitionRepositoryCredentialsArgs{...}
+//	        TaskDefinitionRepositoryCredentialsArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TaskDefinitionRepositoryCredentialsPtrInput interface {
 	pulumi.Input
 
@@ -3588,7 +3588,7 @@ type TaskDefinitionResourceRequirement struct {
 // TaskDefinitionResourceRequirementInput is an input type that accepts TaskDefinitionResourceRequirementArgs and TaskDefinitionResourceRequirementOutput values.
 // You can construct a concrete instance of `TaskDefinitionResourceRequirementInput` via:
 //
-//          TaskDefinitionResourceRequirementArgs{...}
+//	TaskDefinitionResourceRequirementArgs{...}
 type TaskDefinitionResourceRequirementInput interface {
 	pulumi.Input
 
@@ -3616,7 +3616,7 @@ func (i TaskDefinitionResourceRequirementArgs) ToTaskDefinitionResourceRequireme
 // TaskDefinitionResourceRequirementArrayInput is an input type that accepts TaskDefinitionResourceRequirementArray and TaskDefinitionResourceRequirementArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionResourceRequirementArrayInput` via:
 //
-//          TaskDefinitionResourceRequirementArray{ TaskDefinitionResourceRequirementArgs{...} }
+//	TaskDefinitionResourceRequirementArray{ TaskDefinitionResourceRequirementArgs{...} }
 type TaskDefinitionResourceRequirementArrayInput interface {
 	pulumi.Input
 
@@ -3688,7 +3688,7 @@ type TaskDefinitionSecret struct {
 // TaskDefinitionSecretInput is an input type that accepts TaskDefinitionSecretArgs and TaskDefinitionSecretOutput values.
 // You can construct a concrete instance of `TaskDefinitionSecretInput` via:
 //
-//          TaskDefinitionSecretArgs{...}
+//	TaskDefinitionSecretArgs{...}
 type TaskDefinitionSecretInput interface {
 	pulumi.Input
 
@@ -3716,7 +3716,7 @@ func (i TaskDefinitionSecretArgs) ToTaskDefinitionSecretOutputWithContext(ctx co
 // TaskDefinitionSecretArrayInput is an input type that accepts TaskDefinitionSecretArray and TaskDefinitionSecretArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionSecretArrayInput` via:
 //
-//          TaskDefinitionSecretArray{ TaskDefinitionSecretArgs{...} }
+//	TaskDefinitionSecretArray{ TaskDefinitionSecretArgs{...} }
 type TaskDefinitionSecretArrayInput interface {
 	pulumi.Input
 
@@ -3788,7 +3788,7 @@ type TaskDefinitionSystemControl struct {
 // TaskDefinitionSystemControlInput is an input type that accepts TaskDefinitionSystemControlArgs and TaskDefinitionSystemControlOutput values.
 // You can construct a concrete instance of `TaskDefinitionSystemControlInput` via:
 //
-//          TaskDefinitionSystemControlArgs{...}
+//	TaskDefinitionSystemControlArgs{...}
 type TaskDefinitionSystemControlInput interface {
 	pulumi.Input
 
@@ -3816,7 +3816,7 @@ func (i TaskDefinitionSystemControlArgs) ToTaskDefinitionSystemControlOutputWith
 // TaskDefinitionSystemControlArrayInput is an input type that accepts TaskDefinitionSystemControlArray and TaskDefinitionSystemControlArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionSystemControlArrayInput` via:
 //
-//          TaskDefinitionSystemControlArray{ TaskDefinitionSystemControlArgs{...} }
+//	TaskDefinitionSystemControlArray{ TaskDefinitionSystemControlArgs{...} }
 type TaskDefinitionSystemControlArrayInput interface {
 	pulumi.Input
 
@@ -3889,7 +3889,7 @@ type TaskDefinitionTmpfs struct {
 // TaskDefinitionTmpfsInput is an input type that accepts TaskDefinitionTmpfsArgs and TaskDefinitionTmpfsOutput values.
 // You can construct a concrete instance of `TaskDefinitionTmpfsInput` via:
 //
-//          TaskDefinitionTmpfsArgs{...}
+//	TaskDefinitionTmpfsArgs{...}
 type TaskDefinitionTmpfsInput interface {
 	pulumi.Input
 
@@ -3918,7 +3918,7 @@ func (i TaskDefinitionTmpfsArgs) ToTaskDefinitionTmpfsOutputWithContext(ctx cont
 // TaskDefinitionTmpfsArrayInput is an input type that accepts TaskDefinitionTmpfsArray and TaskDefinitionTmpfsArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionTmpfsArrayInput` via:
 //
-//          TaskDefinitionTmpfsArray{ TaskDefinitionTmpfsArgs{...} }
+//	TaskDefinitionTmpfsArray{ TaskDefinitionTmpfsArgs{...} }
 type TaskDefinitionTmpfsArrayInput interface {
 	pulumi.Input
 
@@ -3995,7 +3995,7 @@ type TaskDefinitionUlimit struct {
 // TaskDefinitionUlimitInput is an input type that accepts TaskDefinitionUlimitArgs and TaskDefinitionUlimitOutput values.
 // You can construct a concrete instance of `TaskDefinitionUlimitInput` via:
 //
-//          TaskDefinitionUlimitArgs{...}
+//	TaskDefinitionUlimitArgs{...}
 type TaskDefinitionUlimitInput interface {
 	pulumi.Input
 
@@ -4024,7 +4024,7 @@ func (i TaskDefinitionUlimitArgs) ToTaskDefinitionUlimitOutputWithContext(ctx co
 // TaskDefinitionUlimitArrayInput is an input type that accepts TaskDefinitionUlimitArray and TaskDefinitionUlimitArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionUlimitArrayInput` via:
 //
-//          TaskDefinitionUlimitArray{ TaskDefinitionUlimitArgs{...} }
+//	TaskDefinitionUlimitArray{ TaskDefinitionUlimitArgs{...} }
 type TaskDefinitionUlimitArrayInput interface {
 	pulumi.Input
 
@@ -4100,7 +4100,7 @@ type TaskDefinitionVolumeFrom struct {
 // TaskDefinitionVolumeFromInput is an input type that accepts TaskDefinitionVolumeFromArgs and TaskDefinitionVolumeFromOutput values.
 // You can construct a concrete instance of `TaskDefinitionVolumeFromInput` via:
 //
-//          TaskDefinitionVolumeFromArgs{...}
+//	TaskDefinitionVolumeFromArgs{...}
 type TaskDefinitionVolumeFromInput interface {
 	pulumi.Input
 
@@ -4128,7 +4128,7 @@ func (i TaskDefinitionVolumeFromArgs) ToTaskDefinitionVolumeFromOutputWithContex
 // TaskDefinitionVolumeFromArrayInput is an input type that accepts TaskDefinitionVolumeFromArray and TaskDefinitionVolumeFromArrayOutput values.
 // You can construct a concrete instance of `TaskDefinitionVolumeFromArrayInput` via:
 //
-//          TaskDefinitionVolumeFromArray{ TaskDefinitionVolumeFromArgs{...} }
+//	TaskDefinitionVolumeFromArray{ TaskDefinitionVolumeFromArgs{...} }
 type TaskDefinitionVolumeFromArrayInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/lb/applicationLoadBalancer.go
+++ b/sdk/go/awsx/lb/applicationLoadBalancer.go
@@ -174,7 +174,7 @@ func (i *ApplicationLoadBalancer) ToApplicationLoadBalancerOutputWithContext(ctx
 // ApplicationLoadBalancerArrayInput is an input type that accepts ApplicationLoadBalancerArray and ApplicationLoadBalancerArrayOutput values.
 // You can construct a concrete instance of `ApplicationLoadBalancerArrayInput` via:
 //
-//          ApplicationLoadBalancerArray{ ApplicationLoadBalancerArgs{...} }
+//	ApplicationLoadBalancerArray{ ApplicationLoadBalancerArgs{...} }
 type ApplicationLoadBalancerArrayInput interface {
 	pulumi.Input
 
@@ -199,7 +199,7 @@ func (i ApplicationLoadBalancerArray) ToApplicationLoadBalancerArrayOutputWithCo
 // ApplicationLoadBalancerMapInput is an input type that accepts ApplicationLoadBalancerMap and ApplicationLoadBalancerMapOutput values.
 // You can construct a concrete instance of `ApplicationLoadBalancerMapInput` via:
 //
-//          ApplicationLoadBalancerMap{ "key": ApplicationLoadBalancerArgs{...} }
+//	ApplicationLoadBalancerMap{ "key": ApplicationLoadBalancerArgs{...} }
 type ApplicationLoadBalancerMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/lb/networkLoadBalancer.go
+++ b/sdk/go/awsx/lb/networkLoadBalancer.go
@@ -162,7 +162,7 @@ func (i *NetworkLoadBalancer) ToNetworkLoadBalancerOutputWithContext(ctx context
 // NetworkLoadBalancerArrayInput is an input type that accepts NetworkLoadBalancerArray and NetworkLoadBalancerArrayOutput values.
 // You can construct a concrete instance of `NetworkLoadBalancerArrayInput` via:
 //
-//          NetworkLoadBalancerArray{ NetworkLoadBalancerArgs{...} }
+//	NetworkLoadBalancerArray{ NetworkLoadBalancerArgs{...} }
 type NetworkLoadBalancerArrayInput interface {
 	pulumi.Input
 
@@ -187,7 +187,7 @@ func (i NetworkLoadBalancerArray) ToNetworkLoadBalancerArrayOutputWithContext(ct
 // NetworkLoadBalancerMapInput is an input type that accepts NetworkLoadBalancerMap and NetworkLoadBalancerMapOutput values.
 // You can construct a concrete instance of `NetworkLoadBalancerMapInput` via:
 //
-//          NetworkLoadBalancerMap{ "key": NetworkLoadBalancerArgs{...} }
+//	NetworkLoadBalancerMap{ "key": NetworkLoadBalancerArgs{...} }
 type NetworkLoadBalancerMapInput interface {
 	pulumi.Input
 

--- a/sdk/go/awsx/lb/pulumiTypes.go
+++ b/sdk/go/awsx/lb/pulumiTypes.go
@@ -21,39 +21,42 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("HTTPS"),
-// 			SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("HTTPS"),
+//				SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // To a NLB:
@@ -61,261 +64,279 @@ import (
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
-// 			LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("TLS"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			AlpnPolicy:      pulumi.String("HTTP2Preferred"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
+//				LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("TLS"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				AlpnPolicy:      pulumi.String("HTTP2Preferred"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Redirect Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("redirect"),
-// 					Redirect: &lb.ListenerDefaultActionRedirectArgs{
-// 						Port:       pulumi.String("443"),
-// 						Protocol:   pulumi.String("HTTPS"),
-// 						StatusCode: pulumi.String("HTTP_301"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("redirect"),
+//						Redirect: &lb.ListenerDefaultActionRedirectArgs{
+//							Port:       pulumi.String("443"),
+//							Protocol:   pulumi.String("HTTPS"),
+//							StatusCode: pulumi.String("HTTP_301"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Fixed-response Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("fixed-response"),
-// 					FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
-// 						ContentType: pulumi.String("text/plain"),
-// 						MessageBody: pulumi.String("Fixed response content"),
-// 						StatusCode:  pulumi.String("200"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("fixed-response"),
+//						FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
+//							ContentType: pulumi.String("text/plain"),
+//							MessageBody: pulumi.String("Fixed response content"),
+//							StatusCode:  pulumi.String("200"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-cognito Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		pool, err := cognito.NewUserPool(ctx, "pool", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		client, err := cognito.NewUserPoolClient(ctx, "client", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-cognito"),
-// 					AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
-// 						UserPoolArn:      pool.Arn,
-// 						UserPoolClientId: client.ID(),
-// 						UserPoolDomain:   domain.Domain,
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			pool, err := cognito.NewUserPool(ctx, "pool", nil)
+//			if err != nil {
+//				return err
+//			}
+//			client, err := cognito.NewUserPoolClient(ctx, "client", nil)
+//			if err != nil {
+//				return err
+//			}
+//			domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-cognito"),
+//						AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
+//							UserPoolArn:      pool.Arn,
+//							UserPoolClientId: client.ID(),
+//							UserPoolDomain:   domain.Domain,
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-OIDC Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-oidc"),
-// 					AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
-// 						AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
-// 						ClientId:              pulumi.String("client_id"),
-// 						ClientSecret:          pulumi.String("client_secret"),
-// 						Issuer:                pulumi.String("https://example.com"),
-// 						TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
-// 						UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-oidc"),
+//						AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
+//							AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
+//							ClientId:              pulumi.String("client_id"),
+//							ClientSecret:          pulumi.String("client_secret"),
+//							Issuer:                pulumi.String("https://example.com"),
+//							TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
+//							UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Listener
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
-// 			LoadBalancerType: pulumi.String("gateway"),
-// 			SubnetMappings: lb.LoadBalancerSubnetMappingArray{
-// 				&lb.LoadBalancerSubnetMappingArgs{
-// 					SubnetId: pulumi.Any(aws_subnet.Example.Id),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(6081),
-// 			Protocol: pulumi.String("GENEVE"),
-// 			VpcId:    pulumi.Any(aws_vpc.Example.Id),
-// 			HealthCheck: &lb.TargetGroupHealthCheckArgs{
-// 				Port:     pulumi.String("80"),
-// 				Protocol: pulumi.String("HTTP"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: exampleLoadBalancer.ID(),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					TargetGroupArn: exampleTargetGroup.ID(),
-// 					Type:           pulumi.String("forward"),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
+//				LoadBalancerType: pulumi.String("gateway"),
+//				SubnetMappings: lb.LoadBalancerSubnetMappingArray{
+//					&lb.LoadBalancerSubnetMappingArgs{
+//						SubnetId: pulumi.Any(aws_subnet.Example.Id),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(6081),
+//				Protocol: pulumi.String("GENEVE"),
+//				VpcId:    pulumi.Any(aws_vpc.Example.Id),
+//				HealthCheck: &lb.TargetGroupHealthCheckArgs{
+//					Port:     pulumi.String("80"),
+//					Protocol: pulumi.String("HTTP"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
+//				LoadBalancerArn: exampleLoadBalancer.ID(),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						TargetGroupArn: exampleTargetGroup.ID(),
+//						Type:           pulumi.String("forward"),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -323,7 +344,9 @@ import (
 // Listeners can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
+//	$ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
 // ```
 type Listener struct {
 	// Name of the Application-Layer Protocol Negotiation (ALPN) policy. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`.
@@ -345,7 +368,7 @@ type Listener struct {
 // ListenerInput is an input type that accepts ListenerArgs and ListenerOutput values.
 // You can construct a concrete instance of `ListenerInput` via:
 //
-//          ListenerArgs{...}
+//	ListenerArgs{...}
 type ListenerInput interface {
 	pulumi.Input
 
@@ -363,39 +386,42 @@ type ListenerInput interface {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("HTTPS"),
-// 			SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("HTTPS"),
+//				SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // To a NLB:
@@ -403,261 +429,279 @@ type ListenerInput interface {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
-// 			LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("TLS"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			AlpnPolicy:      pulumi.String("HTTP2Preferred"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
+//				LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("TLS"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				AlpnPolicy:      pulumi.String("HTTP2Preferred"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Redirect Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("redirect"),
-// 					Redirect: &lb.ListenerDefaultActionRedirectArgs{
-// 						Port:       pulumi.String("443"),
-// 						Protocol:   pulumi.String("HTTPS"),
-// 						StatusCode: pulumi.String("HTTP_301"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("redirect"),
+//						Redirect: &lb.ListenerDefaultActionRedirectArgs{
+//							Port:       pulumi.String("443"),
+//							Protocol:   pulumi.String("HTTPS"),
+//							StatusCode: pulumi.String("HTTP_301"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Fixed-response Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("fixed-response"),
-// 					FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
-// 						ContentType: pulumi.String("text/plain"),
-// 						MessageBody: pulumi.String("Fixed response content"),
-// 						StatusCode:  pulumi.String("200"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("fixed-response"),
+//						FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
+//							ContentType: pulumi.String("text/plain"),
+//							MessageBody: pulumi.String("Fixed response content"),
+//							StatusCode:  pulumi.String("200"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-cognito Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		pool, err := cognito.NewUserPool(ctx, "pool", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		client, err := cognito.NewUserPoolClient(ctx, "client", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-cognito"),
-// 					AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
-// 						UserPoolArn:      pool.Arn,
-// 						UserPoolClientId: client.ID(),
-// 						UserPoolDomain:   domain.Domain,
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			pool, err := cognito.NewUserPool(ctx, "pool", nil)
+//			if err != nil {
+//				return err
+//			}
+//			client, err := cognito.NewUserPoolClient(ctx, "client", nil)
+//			if err != nil {
+//				return err
+//			}
+//			domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-cognito"),
+//						AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
+//							UserPoolArn:      pool.Arn,
+//							UserPoolClientId: client.ID(),
+//							UserPoolDomain:   domain.Domain,
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-OIDC Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-oidc"),
-// 					AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
-// 						AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
-// 						ClientId:              pulumi.String("client_id"),
-// 						ClientSecret:          pulumi.String("client_secret"),
-// 						Issuer:                pulumi.String("https://example.com"),
-// 						TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
-// 						UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-oidc"),
+//						AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
+//							AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
+//							ClientId:              pulumi.String("client_id"),
+//							ClientSecret:          pulumi.String("client_secret"),
+//							Issuer:                pulumi.String("https://example.com"),
+//							TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
+//							UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Listener
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
-// 			LoadBalancerType: pulumi.String("gateway"),
-// 			SubnetMappings: lb.LoadBalancerSubnetMappingArray{
-// 				&lb.LoadBalancerSubnetMappingArgs{
-// 					SubnetId: pulumi.Any(aws_subnet.Example.Id),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(6081),
-// 			Protocol: pulumi.String("GENEVE"),
-// 			VpcId:    pulumi.Any(aws_vpc.Example.Id),
-// 			HealthCheck: &lb.TargetGroupHealthCheckArgs{
-// 				Port:     pulumi.String("80"),
-// 				Protocol: pulumi.String("HTTP"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: exampleLoadBalancer.ID(),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					TargetGroupArn: exampleTargetGroup.ID(),
-// 					Type:           pulumi.String("forward"),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
+//				LoadBalancerType: pulumi.String("gateway"),
+//				SubnetMappings: lb.LoadBalancerSubnetMappingArray{
+//					&lb.LoadBalancerSubnetMappingArgs{
+//						SubnetId: pulumi.Any(aws_subnet.Example.Id),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(6081),
+//				Protocol: pulumi.String("GENEVE"),
+//				VpcId:    pulumi.Any(aws_vpc.Example.Id),
+//				HealthCheck: &lb.TargetGroupHealthCheckArgs{
+//					Port:     pulumi.String("80"),
+//					Protocol: pulumi.String("HTTP"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
+//				LoadBalancerArn: exampleLoadBalancer.ID(),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						TargetGroupArn: exampleTargetGroup.ID(),
+//						Type:           pulumi.String("forward"),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -665,7 +709,9 @@ type ListenerInput interface {
 // Listeners can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
+//	$ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
 // ```
 type ListenerArgs struct {
 	// Name of the Application-Layer Protocol Negotiation (ALPN) policy. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`.
@@ -707,11 +753,11 @@ func (i ListenerArgs) ToListenerPtrOutputWithContext(ctx context.Context) Listen
 // ListenerPtrInput is an input type that accepts ListenerArgs, ListenerPtr and ListenerPtrOutput values.
 // You can construct a concrete instance of `ListenerPtrInput` via:
 //
-//          ListenerArgs{...}
+//	        ListenerArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type ListenerPtrInput interface {
 	pulumi.Input
 
@@ -740,7 +786,7 @@ func (i *listenerPtrType) ToListenerPtrOutputWithContext(ctx context.Context) Li
 // ListenerArrayInput is an input type that accepts ListenerArray and ListenerArrayOutput values.
 // You can construct a concrete instance of `ListenerArrayInput` via:
 //
-//          ListenerArray{ ListenerArgs{...} }
+//	ListenerArray{ ListenerArgs{...} }
 type ListenerArrayInput interface {
 	pulumi.Input
 
@@ -772,39 +818,42 @@ func (i ListenerArray) ToListenerArrayOutputWithContext(ctx context.Context) Lis
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("HTTPS"),
-// 			SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("HTTPS"),
+//				SslPolicy:       pulumi.String("ELBSecurityPolicy-2016-08"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // To a NLB:
@@ -812,261 +861,279 @@ func (i ListenerArray) ToListenerArrayOutputWithContext(ctx context.Context) Lis
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
-// 			LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
-// 			Port:            pulumi.Int(443),
-// 			Protocol:        pulumi.String("TLS"),
-// 			CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
-// 			AlpnPolicy:      pulumi.String("HTTP2Preferred"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewListener(ctx, "frontEnd", &lb.ListenerArgs{
+//				LoadBalancerArn: pulumi.Any(aws_lb.Front_end.Arn),
+//				Port:            pulumi.Int(443),
+//				Protocol:        pulumi.String("TLS"),
+//				CertificateArn:  pulumi.String("arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"),
+//				AlpnPolicy:      pulumi.String("HTTP2Preferred"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: pulumi.Any(aws_lb_target_group.Front_end.Arn),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Redirect Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("redirect"),
-// 					Redirect: &lb.ListenerDefaultActionRedirectArgs{
-// 						Port:       pulumi.String("443"),
-// 						Protocol:   pulumi.String("HTTPS"),
-// 						StatusCode: pulumi.String("HTTP_301"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("redirect"),
+//						Redirect: &lb.ListenerDefaultActionRedirectArgs{
+//							Port:       pulumi.String("443"),
+//							Protocol:   pulumi.String("HTTPS"),
+//							StatusCode: pulumi.String("HTTP_301"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Fixed-response Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("fixed-response"),
-// 					FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
-// 						ContentType: pulumi.String("text/plain"),
-// 						MessageBody: pulumi.String("Fixed response content"),
-// 						StatusCode:  pulumi.String("200"),
-// 					},
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("fixed-response"),
+//						FixedResponse: &lb.ListenerDefaultActionFixedResponseArgs{
+//							ContentType: pulumi.String("text/plain"),
+//							MessageBody: pulumi.String("Fixed response content"),
+//							StatusCode:  pulumi.String("200"),
+//						},
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-cognito Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/cognito"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		pool, err := cognito.NewUserPool(ctx, "pool", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		client, err := cognito.NewUserPoolClient(ctx, "client", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-cognito"),
-// 					AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
-// 						UserPoolArn:      pool.Arn,
-// 						UserPoolClientId: client.ID(),
-// 						UserPoolDomain:   domain.Domain,
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			pool, err := cognito.NewUserPool(ctx, "pool", nil)
+//			if err != nil {
+//				return err
+//			}
+//			client, err := cognito.NewUserPoolClient(ctx, "client", nil)
+//			if err != nil {
+//				return err
+//			}
+//			domain, err := cognito.NewUserPoolDomain(ctx, "domain", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-cognito"),
+//						AuthenticateCognito: &lb.ListenerDefaultActionAuthenticateCognitoArgs{
+//							UserPoolArn:      pool.Arn,
+//							UserPoolClientId: client.ID(),
+//							UserPoolDomain:   domain.Domain,
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Authenticate-OIDC Action
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: frontEndLoadBalancer.Arn,
-// 			Port:            pulumi.Int(80),
-// 			Protocol:        pulumi.String("HTTP"),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type: pulumi.String("authenticate-oidc"),
-// 					AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
-// 						AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
-// 						ClientId:              pulumi.String("client_id"),
-// 						ClientSecret:          pulumi.String("client_secret"),
-// 						Issuer:                pulumi.String("https://example.com"),
-// 						TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
-// 						UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
-// 					},
-// 				},
-// 				&lb.ListenerDefaultActionArgs{
-// 					Type:           pulumi.String("forward"),
-// 					TargetGroupArn: frontEndTargetGroup.Arn,
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			frontEndLoadBalancer, err := lb.NewLoadBalancer(ctx, "frontEndLoadBalancer", nil)
+//			if err != nil {
+//				return err
+//			}
+//			frontEndTargetGroup, err := lb.NewTargetGroup(ctx, "frontEndTargetGroup", nil)
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "frontEndListener", &lb.ListenerArgs{
+//				LoadBalancerArn: frontEndLoadBalancer.Arn,
+//				Port:            pulumi.Int(80),
+//				Protocol:        pulumi.String("HTTP"),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						Type: pulumi.String("authenticate-oidc"),
+//						AuthenticateOidc: &lb.ListenerDefaultActionAuthenticateOidcArgs{
+//							AuthorizationEndpoint: pulumi.String("https://example.com/authorization_endpoint"),
+//							ClientId:              pulumi.String("client_id"),
+//							ClientSecret:          pulumi.String("client_secret"),
+//							Issuer:                pulumi.String("https://example.com"),
+//							TokenEndpoint:         pulumi.String("https://example.com/token_endpoint"),
+//							UserInfoEndpoint:      pulumi.String("https://example.com/user_info_endpoint"),
+//						},
+//					},
+//					&lb.ListenerDefaultActionArgs{
+//						Type:           pulumi.String("forward"),
+//						TargetGroupArn: frontEndTargetGroup.Arn,
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Gateway Load Balancer Listener
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
-// 			LoadBalancerType: pulumi.String("gateway"),
-// 			SubnetMappings: lb.LoadBalancerSubnetMappingArray{
-// 				&lb.LoadBalancerSubnetMappingArgs{
-// 					SubnetId: pulumi.Any(aws_subnet.Example.Id),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(6081),
-// 			Protocol: pulumi.String("GENEVE"),
-// 			VpcId:    pulumi.Any(aws_vpc.Example.Id),
-// 			HealthCheck: &lb.TargetGroupHealthCheckArgs{
-// 				Port:     pulumi.String("80"),
-// 				Protocol: pulumi.String("HTTP"),
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
-// 			LoadBalancerArn: exampleLoadBalancer.ID(),
-// 			DefaultActions: lb.ListenerDefaultActionArray{
-// 				&lb.ListenerDefaultActionArgs{
-// 					TargetGroupArn: exampleTargetGroup.ID(),
-// 					Type:           pulumi.String("forward"),
-// 				},
-// 			},
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			exampleLoadBalancer, err := lb.NewLoadBalancer(ctx, "exampleLoadBalancer", &lb.LoadBalancerArgs{
+//				LoadBalancerType: pulumi.String("gateway"),
+//				SubnetMappings: lb.LoadBalancerSubnetMappingArray{
+//					&lb.LoadBalancerSubnetMappingArgs{
+//						SubnetId: pulumi.Any(aws_subnet.Example.Id),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			exampleTargetGroup, err := lb.NewTargetGroup(ctx, "exampleTargetGroup", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(6081),
+//				Protocol: pulumi.String("GENEVE"),
+//				VpcId:    pulumi.Any(aws_vpc.Example.Id),
+//				HealthCheck: &lb.TargetGroupHealthCheckArgs{
+//					Port:     pulumi.String("80"),
+//					Protocol: pulumi.String("HTTP"),
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewListener(ctx, "exampleListener", &lb.ListenerArgs{
+//				LoadBalancerArn: exampleLoadBalancer.ID(),
+//				DefaultActions: lb.ListenerDefaultActionArray{
+//					&lb.ListenerDefaultActionArgs{
+//						TargetGroupArn: exampleTargetGroup.ID(),
+//						Type:           pulumi.String("forward"),
+//					},
+//				},
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -1074,7 +1141,9 @@ func (i ListenerArray) ToListenerArrayOutputWithContext(ctx context.Context) Lis
 // Listeners can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
+//	$ pulumi import aws:lb/listener:Listener front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:listener/app/front-end-alb/8e4497da625e2d8a/9ab28ade35828f96
+//
 // ```
 type ListenerOutput struct{ *pulumi.OutputState }
 
@@ -1259,106 +1328,118 @@ func (o ListenerArrayOutput) Index(i pulumi.IntInput) ListenerOutput {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(80),
-// 			Protocol: pulumi.String("HTTP"),
-// 			VpcId:    main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(80),
+//				Protocol: pulumi.String("HTTP"),
+//				VpcId:    main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### IP Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("HTTP"),
-// 			TargetType: pulumi.String("ip"),
-// 			VpcId:      main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("HTTP"),
+//				TargetType: pulumi.String("ip"),
+//				VpcId:      main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Lambda Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("lambda"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("lambda"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### ALB Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("alb"),
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("TCP"),
-// 			VpcId:      pulumi.Any(aws_vpc.Main.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("alb"),
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("TCP"),
+//				VpcId:      pulumi.Any(aws_vpc.Main.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -1366,7 +1447,9 @@ func (o ListenerArrayOutput) Index(i pulumi.IntInput) ListenerOutput {
 // Target Groups can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
+//	$ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
 // ```
 type TargetGroup struct {
 	// Whether to terminate connections at the end of the deregistration timeout on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#deregistration-delay) for more information. Default is `false`.
@@ -1408,7 +1491,7 @@ type TargetGroup struct {
 // TargetGroupInput is an input type that accepts TargetGroupArgs and TargetGroupOutput values.
 // You can construct a concrete instance of `TargetGroupInput` via:
 //
-//          TargetGroupArgs{...}
+//	TargetGroupArgs{...}
 type TargetGroupInput interface {
 	pulumi.Input
 
@@ -1426,106 +1509,118 @@ type TargetGroupInput interface {
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(80),
-// 			Protocol: pulumi.String("HTTP"),
-// 			VpcId:    main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(80),
+//				Protocol: pulumi.String("HTTP"),
+//				VpcId:    main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### IP Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("HTTP"),
-// 			TargetType: pulumi.String("ip"),
-// 			VpcId:      main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("HTTP"),
+//				TargetType: pulumi.String("ip"),
+//				VpcId:      main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Lambda Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("lambda"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("lambda"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### ALB Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("alb"),
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("TCP"),
-// 			VpcId:      pulumi.Any(aws_vpc.Main.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("alb"),
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("TCP"),
+//				VpcId:      pulumi.Any(aws_vpc.Main.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -1533,7 +1628,9 @@ type TargetGroupInput interface {
 // Target Groups can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
+//	$ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
 // ```
 type TargetGroupArgs struct {
 	// Whether to terminate connections at the end of the deregistration timeout on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#deregistration-delay) for more information. Default is `false`.
@@ -1595,11 +1692,11 @@ func (i TargetGroupArgs) ToTargetGroupPtrOutputWithContext(ctx context.Context) 
 // TargetGroupPtrInput is an input type that accepts TargetGroupArgs, TargetGroupPtr and TargetGroupPtrOutput values.
 // You can construct a concrete instance of `TargetGroupPtrInput` via:
 //
-//          TargetGroupArgs{...}
+//	        TargetGroupArgs{...}
 //
-//  or:
+//	or:
 //
-//          nil
+//	        nil
 type TargetGroupPtrInput interface {
 	pulumi.Input
 
@@ -1635,106 +1732,118 @@ func (i *targetGroupPtrType) ToTargetGroupPtrOutputWithContext(ctx context.Conte
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
-// 			Port:     pulumi.Int(80),
-// 			Protocol: pulumi.String("HTTP"),
-// 			VpcId:    main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "test", &lb.TargetGroupArgs{
+//				Port:     pulumi.Int(80),
+//				Protocol: pulumi.String("HTTP"),
+//				VpcId:    main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### IP Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
-// 			CidrBlock: pulumi.String("10.0.0.0/16"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("HTTP"),
-// 			TargetType: pulumi.String("ip"),
-// 			VpcId:      main.ID(),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			main, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
+//				CidrBlock: pulumi.String("10.0.0.0/16"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			_, err = lb.NewTargetGroup(ctx, "ip-example", &lb.TargetGroupArgs{
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("HTTP"),
+//				TargetType: pulumi.String("ip"),
+//				VpcId:      main.ID(),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### Lambda Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("lambda"),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("lambda"),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 // ### ALB Target Group
 // ```go
 // package main
 //
 // import (
-// 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
-// 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+//	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
 // )
 //
-// func main() {
-// 	pulumi.Run(func(ctx *pulumi.Context) error {
-// 		_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
-// 			TargetType: pulumi.String("alb"),
-// 			Port:       pulumi.Int(80),
-// 			Protocol:   pulumi.String("TCP"),
-// 			VpcId:      pulumi.Any(aws_vpc.Main.Id),
-// 		})
-// 		if err != nil {
-// 			return err
-// 		}
-// 		return nil
-// 	})
-// }
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := lb.NewTargetGroup(ctx, "lambda-example", &lb.TargetGroupArgs{
+//				TargetType: pulumi.String("alb"),
+//				Port:       pulumi.Int(80),
+//				Protocol:   pulumi.String("TCP"),
+//				VpcId:      pulumi.Any(aws_vpc.Main.Id),
+//			})
+//			if err != nil {
+//				return err
+//			}
+//			return nil
+//		})
+//	}
+//
 // ```
 //
 // ## Import
@@ -1742,7 +1851,9 @@ func (i *targetGroupPtrType) ToTargetGroupPtrOutputWithContext(ctx context.Conte
 // Target Groups can be imported using their ARN, e.g.,
 //
 // ```sh
-//  $ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
+//	$ pulumi import aws:lb/targetGroup:TargetGroup app_front_end arn:aws:elasticloadbalancing:us-west-2:187416307283:targetgroup/app-front-end/20cfe21448b66314
+//
 // ```
 type TargetGroupOutput struct{ *pulumi.OutputState }
 

--- a/sdk/go/awsx/lb/targetGroupAttachment.go
+++ b/sdk/go/awsx/lb/targetGroupAttachment.go
@@ -95,7 +95,7 @@ func (i *TargetGroupAttachment) ToTargetGroupAttachmentOutputWithContext(ctx con
 // TargetGroupAttachmentArrayInput is an input type that accepts TargetGroupAttachmentArray and TargetGroupAttachmentArrayOutput values.
 // You can construct a concrete instance of `TargetGroupAttachmentArrayInput` via:
 //
-//          TargetGroupAttachmentArray{ TargetGroupAttachmentArgs{...} }
+//	TargetGroupAttachmentArray{ TargetGroupAttachmentArgs{...} }
 type TargetGroupAttachmentArrayInput interface {
 	pulumi.Input
 
@@ -120,7 +120,7 @@ func (i TargetGroupAttachmentArray) ToTargetGroupAttachmentArrayOutputWithContex
 // TargetGroupAttachmentMapInput is an input type that accepts TargetGroupAttachmentMap and TargetGroupAttachmentMapOutput values.
 // You can construct a concrete instance of `TargetGroupAttachmentMapInput` via:
 //
-//          TargetGroupAttachmentMap{ "key": TargetGroupAttachmentArgs{...} }
+//	TargetGroupAttachmentMap{ "key": TargetGroupAttachmentArgs{...} }
 type TargetGroupAttachmentMapInput interface {
 	pulumi.Input
 

--- a/sdk/java/src/main/java/com/pulumi/awsx/ec2/inputs/SubnetSpecArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ec2/inputs/SubnetSpecArgs.java
@@ -24,15 +24,15 @@ public final class SubnetSpecArgs extends com.pulumi.resources.ResourceArgs {
      * The bitmask for the subnet&#39;s CIDR block.
      * 
      */
-    @Import(name="cidrMask", required=true)
-    private Integer cidrMask;
+    @Import(name="cidrMask")
+    private @Nullable Integer cidrMask;
 
     /**
      * @return The bitmask for the subnet&#39;s CIDR block.
      * 
      */
-    public Integer cidrMask() {
-        return this.cidrMask;
+    public Optional<Integer> cidrMask() {
+        return Optional.ofNullable(this.cidrMask);
     }
 
     /**
@@ -97,7 +97,7 @@ public final class SubnetSpecArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder cidrMask(Integer cidrMask) {
+        public Builder cidrMask(@Nullable Integer cidrMask) {
             $.cidrMask = cidrMask;
             return this;
         }
@@ -125,7 +125,6 @@ public final class SubnetSpecArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public SubnetSpecArgs build() {
-            $.cidrMask = Objects.requireNonNull($.cidrMask, "expected parameter 'cidrMask' to be non-null");
             $.type = Objects.requireNonNull($.type, "expected parameter 'type' to be non-null");
             return $;
         }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -381,7 +381,7 @@ export namespace ec2 {
         /**
          * The bitmask for the subnet's CIDR block.
          */
-        cidrMask: number;
+        cidrMask?: number;
         /**
          * The subnet's name. Will be templated upon creation.
          */
@@ -1332,7 +1332,6 @@ export namespace ecs {
         readOnly?: pulumi.Input<boolean>;
         sourceContainer?: pulumi.Input<string>;
     }
-
 }
 
 export namespace lb {

--- a/sdk/python/pulumi_awsx/ec2/_inputs.py
+++ b/sdk/python/pulumi_awsx/ec2/_inputs.py
@@ -57,31 +57,20 @@ class NatGatewayConfigurationArgs:
 @pulumi.input_type
 class SubnetSpecArgs:
     def __init__(__self__, *,
-                 cidr_mask: int,
                  type: 'SubnetType',
+                 cidr_mask: Optional[int] = None,
                  name: Optional[str] = None):
         """
         Configuration for a VPC subnet.
-        :param int cidr_mask: The bitmask for the subnet's CIDR block.
         :param 'SubnetType' type: The type of subnet.
+        :param int cidr_mask: The bitmask for the subnet's CIDR block.
         :param str name: The subnet's name. Will be templated upon creation.
         """
-        pulumi.set(__self__, "cidr_mask", cidr_mask)
         pulumi.set(__self__, "type", type)
+        if cidr_mask is not None:
+            pulumi.set(__self__, "cidr_mask", cidr_mask)
         if name is not None:
             pulumi.set(__self__, "name", name)
-
-    @property
-    @pulumi.getter(name="cidrMask")
-    def cidr_mask(self) -> int:
-        """
-        The bitmask for the subnet's CIDR block.
-        """
-        return pulumi.get(self, "cidr_mask")
-
-    @cidr_mask.setter
-    def cidr_mask(self, value: int):
-        pulumi.set(self, "cidr_mask", value)
 
     @property
     @pulumi.getter
@@ -94,6 +83,18 @@ class SubnetSpecArgs:
     @type.setter
     def type(self, value: 'SubnetType'):
         pulumi.set(self, "type", value)
+
+    @property
+    @pulumi.getter(name="cidrMask")
+    def cidr_mask(self) -> Optional[int]:
+        """
+        The bitmask for the subnet's CIDR block.
+        """
+        return pulumi.get(self, "cidr_mask")
+
+    @cidr_mask.setter
+    def cidr_mask(self, value: Optional[int]):
+        pulumi.set(self, "cidr_mask", value)
 
     @property
     @pulumi.getter


### PR DESCRIPTION
Fixes: #886

We now default to private being 19 cidrMask, public being 20 cidrMask
and isolated being 24 cidrMask
