### PR TITLE
[internal] Add a release script that will work for the v0.40.x series

### DIFF
--- a/.github/workflows/old-release.yml
+++ b/.github/workflows/old-release.yml
@@ -1,0 +1,206 @@
+env:
+  AWS_REGION: us-west-2
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GO111MODULE: "on"
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  PROVIDER: awsx
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  PULUMI_API: https://api.pulumi-staging.io
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TRAVIS_OS_NAME: linux
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
+      - name: Install Yarn
+        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Update PATH for Yarn
+        run: |
+          echo "$HOME/.yarn/bin" >> $GITHUB_PATH
+          echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
+      - name: Run lint
+        run: make --makefile=Makefile.old lint
+  build_sdk:
+    name: build_sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.goversion }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
+      - name: Build SDK
+        run: make --makefile=Makefile.old build_${{ matrix.language }}
+      - name: Check worktree clean
+        run: ./ci-scripts/ci/check-worktree-is-clean
+      - name: Compress SDK folder
+        run: tar -zcf ${{ matrix.language }}/${{ matrix.language }}.tar.gz -C ${{ matrix.language }}/awsx
+          .
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.language  }}-sdk.tar.gz
+          path: ${{ github.workspace}}/${{ matrix.language }}/${{ matrix.language }}.tar.gz
+      - name: Run SDK tests
+        run: make --makefile=Makefile.old istanbul_tests
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+          - 1.16.x
+        language:
+          - nodejs
+        nodeversion:
+          - 13.x
+  publish_sdk:
+    name: publish_sdk
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.goversion }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          always-auth: true
+          registry-url: https://registry.npmjs.org
+      - name: Download NodeJS SDK
+        uses: actions/download-artifact@v2
+        with:
+          name: nodejs-sdk.tar.gz
+          path: ${{ github.workspace}}/nodejs
+      - name: Uncompress SDK folder
+        run: tar -zxf ${{ github.workspace}}/nodejs/nodejs.tar.gz -C ${{
+          github.workspace}}/nodejs/awsx
+      - env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        name: Publish SDK
+        run: ./scripts/publish_packages.sh
+  create_docs_build:
+    name: Create docs build
+    needs: publish_sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        name: Dispatch event
+        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
+  test:
+    name: test
+    needs: build_sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.goversion }}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
+      - name: Download SDK
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ github.workspace}}/${{ matrix.language }}/
+      - name: Uncompress SDK folder
+        run: tar -zxf ${{ github.workspace}}/${{ matrix.language }}/${{ matrix.language }}.tar.gz -C ${{
+          github.workspace}}/${{ matrix.language}}/awsx
+      - name: Install dependencies
+        run: make --makefile=Makefile.old install_${{ matrix.language}}_sdk
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-session-name: ${{ env.PROVIDER }}@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - name: Run tests
+        run: make --makefile=Makefile.old test_${{ matrix.language}}
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+          - 1.16.x
+        language:
+          - nodejs
+        nodeversion:
+          - 13.x
+name: release
+"on":
+  push:
+    tags:
+      - v0.*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,3 +400,4 @@ name: release
     tags:
       - v*.*.*
       - '!v*.*.*-**'
+      - '!v0.x.x'

--- a/Makefile.old
+++ b/Makefile.old
@@ -1,0 +1,38 @@
+PROJECT_NAME := Pulumi Infrastructure Components for AWS
+
+VERSION         := $(shell pulumictl get version)
+TESTPARALLELISM := 10
+
+WORKING_DIR     := $(shell pwd)
+
+build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
+build_nodejs::
+	cd nodejs/awsx && \
+		yarn install && \
+		yarn run install-peers -f && \
+		yarn run tsc && \
+		tsc --version && \
+		sed -e 's/\$${VERSION}/$(VERSION)/g' < package.json > bin/package.json && \
+		cp ../../README.md ../../LICENSE bin/
+
+istanbul_tests::
+	cd nodejs/awsx/tests && \
+		yarn && yarn run build && yarn run mocha $$(find bin -name '*.spec.js')
+
+test_nodejs::
+	cd nodejs/awsx && go test -v -count=1 -cover -timeout 2h -parallel ${TESTPARALLELISM} .
+
+install_nodejs_sdk::
+	cd $(WORKING_DIR)/nodejs/awsx/bin && yarn install
+	yarn link --cwd $(WORKING_DIR)/nodejs/awsx/bin
+
+lint:
+	yarn global add tslint typescript
+	cd nodejs/awsx && \
+		yarn install && \
+		yarn run install-peers -f && \
+		tslint -c ../tslint.json -p tsconfig.json
+
+dev:: lint build_nodejs istanbul_tests
+
+test:: install_nodejs_sdk test_nodejs


### PR DESCRIPTION
We need to push a patch of a regression of the v0.40.x series but
our currently release machinery is specifically set up for the
new way of working
