### PR TITLE
Do not throw an exception when NAT gateway strategy is None.

### DIFF
--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -91,8 +91,12 @@ describe("validateNatGatewayStrategy", () => {
   );
 
   describe("strategy is None", () => {
-    it("should throw an exception if any private subnets are specified", () =>
-      runTest("None", ["Private"], true, "cannot be 'None'"));
+    // We cannot throw an exception in this case because egress for the private
+    // subnets may be accomplished by methods other than a NAT gateway. Examples
+    // include: NAT instances and centralized egress via TGW in a hub-and-spoke
+    // architecture.
+    it("should not throw an exception if any private subnets are specified", () =>
+      runTest("None", ["Private"], false));
 
     it("should succeed if only public and isolated subnets are specified", () =>
       runTest("None", ["Public", "Isolated"], false));

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -347,9 +347,6 @@ export function validateNatGatewayStrategy(
         "If NAT Gateway strategy is 'OnePerAz' or 'Single', both private and public subnets must be declared. The private subnet creates the need for a NAT Gateway, and the public subnet is required to host the NAT Gateway resource.",
       );
     case "none":
-      if (subnets.some((x) => x.type.toLowerCase() === "private")) {
-        throw new Error("If private subnets are specified, NAT Gateway strategy cannot be 'None'.");
-      }
       break;
     default:
       throw new Error(`Unknown NAT Gateway strategy '${natGatewayStrategy}'`);


### PR DESCRIPTION
Fixes #884 