### PR TITLE
Fix continueBeforeSteadyState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Add multi-lang component support scaffolding.
 * Fix type errors in TypeScript checking awsx-classic properties.
+* Ensure that FargateService and EC2Service default `continueBeforeSteadyState` to false.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -53,8 +53,6 @@ export function computeImageFromAsset(
     target: dockerInputs.target,
   };
 
-  pulumi.log.info("dockerBuild: " + JSON.stringify(dockerBuild));
-
   const uniqueImageName = docker.buildAndPushImage(
     imageName,
     dockerBuild,

--- a/awsx/ecs/ec2Service.ts
+++ b/awsx/ecs/ec2Service.ts
@@ -60,7 +60,7 @@ export class EC2Service extends schema.EC2Service {
         cluster: aws.ecs.Cluster.isInstance(args.cluster) ? args.cluster.arn : args.cluster,
         launchType: "EC2",
         loadBalancers: args.loadBalancers ?? taskDefinition?.loadBalancers,
-        waitForSteadyState: !utils.ifUndefined(args.continueBeforeSteadyState, false),
+        waitForSteadyState: utils.ifUndefined(args.continueBeforeSteadyState, false).apply(x => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
       { parent: this },

--- a/awsx/ecs/ec2Service.ts
+++ b/awsx/ecs/ec2Service.ts
@@ -60,7 +60,9 @@ export class EC2Service extends schema.EC2Service {
         cluster: aws.ecs.Cluster.isInstance(args.cluster) ? args.cluster.arn : args.cluster,
         launchType: "EC2",
         loadBalancers: args.loadBalancers ?? taskDefinition?.loadBalancers,
-        waitForSteadyState: utils.ifUndefined(args.continueBeforeSteadyState, false).apply(x => !x),
+        waitForSteadyState: utils
+          .ifUndefined(args.continueBeforeSteadyState, false)
+          .apply((x) => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
       { parent: this },

--- a/awsx/ecs/fargateService.ts
+++ b/awsx/ecs/fargateService.ts
@@ -64,7 +64,9 @@ export class FargateService extends schema.FargateService {
         cluster: aws.ecs.Cluster.isInstance(args.cluster) ? args.cluster.arn : args.cluster,
         launchType: "FARGATE",
         loadBalancers: args.loadBalancers ?? taskDefinition?.loadBalancers,
-        waitForSteadyState: utils.ifUndefined(args.continueBeforeSteadyState, false).apply(x => !x),
+        waitForSteadyState: utils
+          .ifUndefined(args.continueBeforeSteadyState, false)
+          .apply((x) => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
       { parent: this },

--- a/awsx/ecs/fargateService.ts
+++ b/awsx/ecs/fargateService.ts
@@ -64,7 +64,7 @@ export class FargateService extends schema.FargateService {
         cluster: aws.ecs.Cluster.isInstance(args.cluster) ? args.cluster.arn : args.cluster,
         launchType: "FARGATE",
         loadBalancers: args.loadBalancers ?? taskDefinition?.loadBalancers,
-        waitForSteadyState: !utils.ifUndefined(args.continueBeforeSteadyState, false),
+        waitForSteadyState: utils.ifUndefined(args.continueBeforeSteadyState, false).apply(x => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
       { parent: this },


### PR DESCRIPTION
The docs say this should default to `false`, and the implementation appears to be trying to implement that, but it applies `!` to an `Output` value, which will always be `false`, even if the `Output` internally evaluates to `false`.  Instead, apply the `!` inside an apply.

Also remove accidentally added debug logging.

Fixes #902.

TODO: Ideally we should add tests that validate the service is available immediately after the `pulumi up` completes, without the need to retry 503s.  