### PR TITLE
feat: allow tagging public subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 * Add multi-lang component support scaffolding.
 * Fix type errors in TypeScript checking awsx-classic properties.
 * Ensure that FargateService and EC2Service default `continueBeforeSteadyState` to false.
+* Allow tagging public subnets on VPC for security group matching
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -161,6 +161,7 @@ export class Vpc extends schema.Vpc<VpcData> {
               cidrBlock: spec.cidrBlock,
               tags: {
                 Name: spec.subnetName,
+                ...(spec.type.toLowerCase() === "public" ? args.publicSubnetTags : {}),
               },
             },
             { parent: vpc, dependsOn: [vpc] },

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -97,6 +97,7 @@ export interface VpcArgs {
     readonly subnetSpecs?: SubnetSpecInputs[];
     readonly tags?: pulumi.Input<Record<string, pulumi.Input<string>>>;
     readonly vpcEndpointSpecs?: VpcEndpointSpecInputs[];
+    readonly publicSubnetTags?: pulumi.Input<Record<string, pulumi.Input<string>>>;
 }
 export abstract class Image<TData = any> extends pulumi.ComponentResource<TData> {
     public imageUri!: string | pulumi.Output<string>;

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -1848,6 +1848,12 @@
                     },
                     "plain": true,
                     "description": "A list of VPC Endpoints specs to be deployed as part of the VPC"
+                },
+                "publicSubnetTags": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "isComponent": true


### PR DESCRIPTION
Security group rules are based on tagging and it's a common use-case to allow ingress and egress based on these tags, as such we should support tagging the public subnets which are most likely to require ingress.