### PR TITLE
Remove internal attribute

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -186,9 +186,10 @@ jobs:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        uses: GoTestTools/gotestfmt-action@v2
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -185,9 +185,10 @@ jobs:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        uses: GoTestTools/gotestfmt-action@v2
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -185,9 +185,10 @@ jobs:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        uses: GoTestTools/gotestfmt-action@v2
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,9 +184,10 @@ jobs:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        uses: GoTestTools/gotestfmt-action@v2
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -211,9 +211,10 @@ jobs:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
       - name: Install gotestfmt
-        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        uses: GoTestTools/gotestfmt-action@v2
         with:
-          repo: haveyoudebuggedit/gotestfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.4.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/awsx-classic/ec2/vpcTopology.ts
+++ b/awsx-classic/ec2/vpcTopology.ts
@@ -21,7 +21,6 @@ import { Cidr32Block, getIPv4Address } from "./cidr";
 
 import * as utils from "../utils";
 
-/** @internal */
 export interface AvailabilityZoneDescription {
     name: string;
     id: string;

--- a/sdk/nodejs/classic/ec2/vpcTopology.ts
+++ b/sdk/nodejs/classic/ec2/vpcTopology.ts
@@ -21,7 +21,6 @@ import { Cidr32Block, getIPv4Address } from "./cidr";
 
 import * as utils from "../utils";
 
-/** @internal */
 export interface AvailabilityZoneDescription {
     name: string;
     id: string;


### PR DESCRIPTION
Causes the declaration files to have errors due to the type being excluded by the `"stripInternal": true,` option.

Fixes #924

It appears everything used to be internal, but was [recentlly made public](https://github.com/pulumi/pulumi-awsx/commit/a76d499d1e948dd9850e9c25c4fc5e5422ede296). Give this type is refered to by public types, this must also be exposed.