### PR TITLE
propagate tags to all resources

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -222,8 +222,8 @@ export class Vpc extends schema.Vpc<VpcData> {
                 subnetId: subnet.id,
                 allocationId: createEip ? eips[i].allocationId : allocationIds[i],
                 tags: {
-                  Name: `${name}-${i + 1}`,
                   ...args.tags,
+                  Name: `${name}-${i + 1}`,
                 },
               },
               { parent: subnet, dependsOn: [subnet] },

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -108,6 +108,7 @@ export class Vpc extends schema.Vpc<VpcData> {
       {
         vpcId: vpc.id,
         tags: {
+          ...args.tags,
           Name: name,
         },
       },
@@ -160,7 +161,9 @@ export class Vpc extends schema.Vpc<VpcData> {
               mapPublicIpOnLaunch: spec.type.toLowerCase() === "public",
               cidrBlock: spec.cidrBlock,
               tags: {
+                ...args.tags,
                 Name: spec.subnetName,
+                SubnetType: spec.type,
               },
             },
             { parent: vpc, dependsOn: [vpc] },
@@ -180,6 +183,8 @@ export class Vpc extends schema.Vpc<VpcData> {
               vpcId: vpc.id,
               tags: {
                 Name: spec.subnetName,
+                ...args.tags,
+                SubnetType: spec.type,
               },
             },
             { parent: subnet, dependsOn: [subnet] },
@@ -218,6 +223,7 @@ export class Vpc extends schema.Vpc<VpcData> {
                 allocationId: createEip ? eips[i].allocationId : allocationIds[i],
                 tags: {
                   Name: `${name}-${i + 1}`,
+                  ...args.tags,
                 },
               },
               { parent: subnet, dependsOn: [subnet] },


### PR DESCRIPTION
All resources should get the tags assigned to them.

In addition, I've added the subnet type to the route tables so we can differentiate them

Fixes #922 