### PR TITLE
Bump min required version of `pulumi` PyPi package to 3.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
   provide a top-level way to set the default target group's port.
 * Change the behavior of `ecs.FargateTaskDefinition` and `ecs.EC2TaskDefinition` to always respect the passed-in
   `hostPort`, regardless of the target group's port.
+* Python: Bump the min required version of `pulumi` PyPi package to 3.47.2.
 
 ## 0.40.0 (2022-03-24)
 * Compatibility with pulumi-aws v5.0.0

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -2895,7 +2895,7 @@
             "liftSingleValueMethodReturns": true,
             "readme": "Pulumi Amazon Web Services (AWS) AWSX Components.",
             "requires": {
-                "pulumi": "\u003e=3.0.0,\u003c4.0.0",
+                "pulumi": "\u003e=3.47.2,\u003c4.0.0",
                 "pulumi-aws": "\u003e=5.3.0,\u003c6.0.0",
                 "pulumi-docker": "\u003e=3.0.0,\u003c4.0.0"
             },

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -86,7 +86,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"python": rawMessage(map[string]interface{}{
 				"requires": map[string]string{
-					"pulumi":        ">=3.0.0,<4.0.0",
+					"pulumi":        ">=3.47.2,<4.0.0",
 					"pulumi-aws":    ">=5.3.0,<6.0.0",
 					"pulumi-docker": ">=3.0.0,<4.0.0",
 				},

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -60,7 +60,7 @@ setup(name='pulumi_awsx',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.0.0,<4.0.0',
+          'pulumi>=3.47.2,<4.0.0',
           'pulumi-aws>=5.3.0,<6.0.0',
           'pulumi-docker>=3.0.0,<4.0.0',
           'semver>=2.8.1'


### PR DESCRIPTION
v3.47.2 of the `pulumi` package has been released.

Fixes #929