### PR TITLE
Remove explicit dotnet install

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -149,10 +149,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -177,8 +173,7 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Compress SDK folder
-        run:
-          tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
+        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -207,8 +202,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         pythonversion:
           - 3.8
         nodeversion:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -149,10 +149,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -206,8 +202,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -287,10 +281,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -354,8 +344,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         nodeversion:
           - 16.x
         pythonversion:
@@ -372,4 +360,4 @@ name: master
     tags-ignore:
       - v*
       - sdk/*
-      - '**'
+      - "**"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -149,10 +149,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -206,8 +202,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -295,10 +289,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -362,8 +352,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         nodeversion:
           - 16.x
         pythonversion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -205,8 +201,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -293,10 +287,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -360,8 +350,6 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
-        dotnetversion:
-          - 3.1
         nodeversion:
           - 16.x
         pythonversion:
@@ -400,5 +388,5 @@ name: release
   push:
     tags:
       - v*.*.*
-      - '!v*.*.*-**'
-      - '!v0.x.x'
+      - "!v*.*.*-**"
+      - "!v0.x.x"

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -175,10 +175,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
We're installing 3.1 on an image which already has 6.0. This has no effect as dotnet will automatically choose the newest version.

This was found because were getting an error on the acceptance tests where we used the install action but failed to specify the matrix.dotnetversion which meant the action automatically installed the latest version (7.0) which caused build errors.