### PR TITLE
Revert "Remove explicit dotnet install"

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -149,6 +149,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -173,7 +177,8 @@ jobs:
       - name: Check worktree clean
         run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Compress SDK folder
-        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
+        run:
+          tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -202,6 +207,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         pythonversion:
           - 3.8
         nodeversion:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -149,6 +149,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -202,6 +206,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -281,6 +287,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -344,6 +354,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         nodeversion:
           - 16.x
         pythonversion:
@@ -360,4 +372,4 @@ name: master
     tags-ignore:
       - v*
       - sdk/*
-      - "**"
+      - '**'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -149,6 +149,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -202,6 +206,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -289,6 +295,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -352,6 +362,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         nodeversion:
           - 16.x
         pythonversion:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -201,6 +205,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         pythonversion:
           - 3.8
         nodeversion:
@@ -287,6 +293,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -350,6 +360,8 @@ jobs:
       matrix:
         goversion:
           - 1.19.x
+        dotnetversion:
+          - 3.1
         nodeversion:
           - 16.x
         pythonversion:
@@ -388,5 +400,5 @@ name: release
   push:
     tags:
       - v*.*.*
-      - "!v*.*.*-**"
-      - "!v0.x.x"
+      - '!v*.*.*-**'
+      - '!v0.x.x'

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -175,6 +175,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Reverts pulumi/pulumi-awsx#957

My assumption here was incorrect ... we explicitly target 3.1.0 somewhere so might need to revert this.

Alternatively, we might just be able to upgrade these projects, but opening this in case.

```
  Diagnostics:
    pulumi:pulumi:Stack (cloudtrail-dotnet-p-it-fv-az575-4-dotnet-acbe76d1):
      error: an unhandled error occurred: Program exited with non-zero exit code: 150
  
      You must install or update .NET to run this application.
      App: /tmp/p-it-fv-az575-4-dotnet-acbe76d1-1081780372/bin/Debug/netcoreapp3.1/cloudtrail-dotnet
      Architecture: x64
      Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
      .NET location: /usr/share/dotnet
      The following frameworks were found:
        6.0.11 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
        7.0.0 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
      Learn about framework resolution:
      https://aka.ms/dotnet/app-launch-failed
      To install missing framework, download:
      https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=ubuntu.22.04-x64
```