### PR TITLE
Create tags on vpc subnets from tags in subnet spec

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -162,6 +162,7 @@ export class Vpc extends schema.Vpc<VpcData> {
               cidrBlock: spec.cidrBlock,
               tags: {
                 ...args.tags,
+                ...spec.tags,
                 Name: spec.subnetName,
                 SubnetType: spec.type,
               },

--- a/examples/vpc/nodejs/vpc-subnets-with-tags/Pulumi.yaml
+++ b/examples/vpc/nodejs/vpc-subnets-with-tags/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nodejs
+runtime: nodejs
+description: AWSX VPC - specifying vpcs with tags

--- a/examples/vpc/nodejs/vpc-subnets-with-tags/index.ts
+++ b/examples/vpc/nodejs/vpc-subnets-with-tags/index.ts
@@ -1,0 +1,31 @@
+import * as awsx from "@pulumi/awsx";
+
+const myVpc = new awsx.ec2.Vpc("awsx-nodejs-subnets-with-tags", {
+    tags: {
+        isoverridden: "false"
+    },
+    subnetSpecs: [
+        {
+            type: awsx.ec2.SubnetType.Public,
+            cidrMask: 22,
+            tags: {
+                isoverridden: "true",
+                custom_tag_subnet_type: "subnet_public",
+                custom_tag_one: "1"
+            }
+        },
+        {
+            type: awsx.ec2.SubnetType.Private,
+            cidrMask: 21,
+            tags: {
+                custom_tag_subnet_type: "subnet_private",
+                custom_tag_two: "2",
+                custom_tag_three: "3"
+            }
+        },
+    ],
+});
+
+export const vpcId = myVpc.vpcId;
+export const publicSubnetIds = myVpc.publicSubnetIds;
+export const privateSubnetIds = myVpc.privateSubnetIds;

--- a/examples/vpc/nodejs/vpc-subnets-with-tags/package.json
+++ b/examples/vpc/nodejs/vpc-subnets-with-tags/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "nodejs",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/vpc/nodejs/vpc-subnets-with-tags/tsconfig.json
+++ b/examples/vpc/nodejs/vpc-subnets-with-tags/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.ts"
+    ]
+}


### PR DESCRIPTION
Tags in the SubnetSpec for a VPC were not being applied to subnets.

This PR adds the SubnetSpec tags to the VPC subnets _after_ the top-level (VPC-spec) tags, so that matching SubnetSpec tags will take precedence.

Fixes #922 