### PR TITLE
Re-order tag priority in ec2.Vpc

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -84,15 +84,14 @@ export class Vpc extends schema.Vpc<VpcData> {
 
     validateNatGatewayStrategy(natGatewayStrategy, subnetSpecs);
 
+    const sharedTags = { Name: name, ...args.tags }
+    
     const vpc = new aws.ec2.Vpc(
       name,
       {
         ...args,
         cidrBlock,
-        tags: {
-          ...args.tags,
-          Name: name,
-        },
+        tags: sharedTags,
       },
       { parent: this },
     );
@@ -107,10 +106,7 @@ export class Vpc extends schema.Vpc<VpcData> {
       `${name}`,
       {
         vpcId: vpc.id,
-        tags: {
-          ...args.tags,
-          Name: name,
-        },
+        tags: sharedTags,
       },
       { parent: vpc, dependsOn: [vpc] },
     );
@@ -161,7 +157,7 @@ export class Vpc extends schema.Vpc<VpcData> {
               mapPublicIpOnLaunch: spec.type.toLowerCase() === "public",
               cidrBlock: spec.cidrBlock,
               tags: {
-                ...args.tags,
+                ...sharedTags,
                 ...spec.tags,
                 Name: spec.subnetName,
                 SubnetType: spec.type,
@@ -183,8 +179,8 @@ export class Vpc extends schema.Vpc<VpcData> {
             {
               vpcId: vpc.id,
               tags: {
+                ...sharedTags,
                 Name: spec.subnetName,
-                ...args.tags,
                 SubnetType: spec.type,
               },
             },


### PR DESCRIPTION
Fixes #967, #985

As described in the above issues it's currently impossible to actually set the name of a VPC, for two different reasons.

This PR fixes both issues. I don't _think_ it will cause a regression that anybody notices, because right now setting a name causes creation of the VPC to fail.

---

A "nice to have" would be constructing the name tag of each subnet based on the name tag of the over all VPC, but that's a bigger change/feature so I'd rather treat this PR as simply a bug fix.