### PR TITLE
feat(classic): add GaugeWidget for cloudwatch dashboard

### DIFF
--- a/awsx-classic/cloudwatch/widgets_graph.ts
+++ b/awsx-classic/cloudwatch/widgets_graph.ts
@@ -17,6 +17,9 @@ import * as wjson from "./widgets_json";
 
 import { MetricWidget, MetricWidgetArgs } from "./widgets_simple";
 
+type DeepRequired<T> = {
+    [K in keyof T]: Required<DeepRequired<T[K]>>
+}
 // Contains all the classes for easily making graph widgets in a dashboard.
 
 export interface GraphMetricWidgetArgs extends MetricWidgetArgs {
@@ -26,6 +29,14 @@ export interface GraphMetricWidgetArgs extends MetricWidgetArgs {
      */
     yAxis?: pulumi.Input<YAxis>;
 }
+
+export interface GaugeMetricWidgetArgs extends MetricWidgetArgs {
+    /**
+     * Limits for the minimums and maximums of the y-axis. Needed for Gauge Widget.
+     */
+    yAxis: pulumi.Input<DeepRequired<YAxis>>;
+}
+
 
 export interface YAxis {
     /** Optional min and max settings for the left Y-axis.  */
@@ -91,4 +102,17 @@ export class SingleNumberMetricWidget extends MetricWidget {
     protected computedStacked = () => false;
     protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "singleValue";
     protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => undefined;
+}
+
+/**
+ * Displays a set of metrics as a gauge number.
+ */
+export class GaugeMetricWidget extends MetricWidget {
+    constructor(private readonly gaugeArgs: GaugeMetricWidgetArgs) {
+        super(gaugeArgs);
+    }
+
+    protected computedStacked = () => false;
+    protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "gauge";
+    protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => this.gaugeArgs.yAxis;
 }

--- a/awsx-classic/cloudwatch/widgets_json.ts
+++ b/awsx-classic/cloudwatch/widgets_json.ts
@@ -58,7 +58,7 @@ export interface MetricWidgetPropertiesJson {
     period: pulumi.Input<number> | undefined;
     region: pulumi.Input<string | undefined>;
     stat: pulumi.Input<string>;
-    view: pulumi.Input<"timeSeries" | "singleValue" | undefined>;
+    view: pulumi.Input<"timeSeries" | "singleValue" | "gauge" | undefined>;
     stacked: pulumi.Input<boolean | undefined>;
     yAxis: pulumi.Input<YAxis> | undefined;
 }

--- a/awsx-classic/cloudwatch/widgets_simple.ts
+++ b/awsx-classic/cloudwatch/widgets_simple.ts
@@ -397,7 +397,7 @@ export class LogWidget extends SimpleWidget {
     protected computeType(): wjson.LogWidgetJson["type"] {
         return "log";
     }
-    protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "timeSeries";
+    protected computeView = (): wjson.LogWidgetPropertiesJson["view"] => "timeSeries";
     protected computedStacked = () => false;
 
     protected computeProperties(region: pulumi.Output<aws.Region>): wjson.LogWidgetJson["properties"] {

--- a/sdk/nodejs/classic/cloudwatch/widgets_graph.ts
+++ b/sdk/nodejs/classic/cloudwatch/widgets_graph.ts
@@ -17,6 +17,9 @@ import * as wjson from "./widgets_json";
 
 import { MetricWidget, MetricWidgetArgs } from "./widgets_simple";
 
+type DeepRequired<T> = {
+    [K in keyof T]: Required<DeepRequired<T[K]>>
+}
 // Contains all the classes for easily making graph widgets in a dashboard.
 
 export interface GraphMetricWidgetArgs extends MetricWidgetArgs {
@@ -26,6 +29,14 @@ export interface GraphMetricWidgetArgs extends MetricWidgetArgs {
      */
     yAxis?: pulumi.Input<YAxis>;
 }
+
+export interface GaugeMetricWidgetArgs extends MetricWidgetArgs {
+    /**
+     * Limits for the minimums and maximums of the y-axis. Needed for Gauge Widget.
+     */
+    yAxis: pulumi.Input<DeepRequired<YAxis>>;
+}
+
 
 export interface YAxis {
     /** Optional min and max settings for the left Y-axis.  */
@@ -91,4 +102,17 @@ export class SingleNumberMetricWidget extends MetricWidget {
     protected computedStacked = () => false;
     protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "singleValue";
     protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => undefined;
+}
+
+/**
+ * Displays a set of metrics as a gauge number.
+ */
+export class GaugeMetricWidget extends MetricWidget {
+    constructor(private readonly gaugeArgs: GaugeMetricWidgetArgs) {
+        super(gaugeArgs);
+    }
+
+    protected computedStacked = () => false;
+    protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "gauge";
+    protected computeYAxis = (): wjson.MetricWidgetPropertiesJson["yAxis"] => this.gaugeArgs.yAxis;
 }

--- a/sdk/nodejs/classic/cloudwatch/widgets_json.ts
+++ b/sdk/nodejs/classic/cloudwatch/widgets_json.ts
@@ -58,7 +58,7 @@ export interface MetricWidgetPropertiesJson {
     period: pulumi.Input<number> | undefined;
     region: pulumi.Input<string | undefined>;
     stat: pulumi.Input<string>;
-    view: pulumi.Input<"timeSeries" | "singleValue" | undefined>;
+    view: pulumi.Input<"timeSeries" | "singleValue" | "gauge" | undefined>;
     stacked: pulumi.Input<boolean | undefined>;
     yAxis: pulumi.Input<YAxis> | undefined;
 }

--- a/sdk/nodejs/classic/cloudwatch/widgets_simple.ts
+++ b/sdk/nodejs/classic/cloudwatch/widgets_simple.ts
@@ -397,7 +397,7 @@ export class LogWidget extends SimpleWidget {
     protected computeType(): wjson.LogWidgetJson["type"] {
         return "log";
     }
-    protected computeView = (): wjson.MetricWidgetPropertiesJson["view"] => "timeSeries";
+    protected computeView = (): wjson.LogWidgetPropertiesJson["view"] => "timeSeries";
     protected computedStacked = () => false;
 
     protected computeProperties(region: pulumi.Output<aws.Region>): wjson.LogWidgetJson["properties"] {


### PR DESCRIPTION
Gauge Widget is missing on cloudwatch types. Here is a proposition of implementation