### PR TITLE
Fix cron test failure: restore CIDR default

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -80,6 +80,7 @@ export class Vpc extends schema.Vpc<VpcData> {
     if (args.cidrBlock && args.ipv4IpamPoolId) {
       throw new Error("Only one of [cidrBlock] and [ipv4IpamPoolId] can be specified");
     }
+    const cidrBlock = args.cidrBlock ?? "10.0.0.0/16";
 
     const sharedTags = { Name: name, ...args.tags };
 
@@ -87,6 +88,7 @@ export class Vpc extends schema.Vpc<VpcData> {
       name,
       {
         ...args,
+        cidrBlock,
         tags: sharedTags,
       },
       { parent: this },


### PR DESCRIPTION
Fixes
```
    aws:ec2:Vpc (dev-vpc):
      error: 1 error occurred:
      	* creating EC2 VPC: MissingParameter: Either 'cidrBlock' or 'ipv4IpamPoolId' should be provided.
      	status code: 400, request id: 195e3a50-bf4b-48cf-94e9-4efc02000de5
```

Probably a regression from #1014.

Tests are still failing with another error but the above error is gone from the logs.