### PR TITLE
Revert "Adopt IPAM functionality (#1014)"

### DIFF
--- a/awsx/ec2/subnetDistributor.ts
+++ b/awsx/ec2/subnetDistributor.ts
@@ -30,7 +30,7 @@ export interface SubnetSpec {
 
 export function getSubnetSpecs(
   vpcName: string,
-  vpcCidr: pulumi.Input<string>,
+  vpcCidr: string,
   azNames: string[],
   subnetInputs?: SubnetSpecInputs[],
 ): SubnetSpec[] {
@@ -42,7 +42,7 @@ export function getSubnetSpecs(
   }
 
   if (subnetInputs === undefined) {
-    return generateDefaultSubnets(vpcName, azNames, azBases);
+    return generateDefaultSubnets(vpcName, vpcCidr, azNames, azBases);
   }
 
   const ipAddress = require("ip-address");
@@ -147,6 +147,7 @@ export function getSubnetSpecs(
 
 function generateDefaultSubnets(
   vpcName: string,
+  vpcCidr: string,
   azNames: string[],
   azBases: string[],
 ): SubnetSpec[] {
@@ -177,11 +178,7 @@ function generateDefaultSubnets(
   return Array.prototype.concat(privateSubnets, publicSubnets);
 }
 
-function cidrSubnetV4(
-  ipRange: string | pulumi.Input<string>,
-  newBits: number,
-  netNum: number,
-): string {
+function cidrSubnetV4(ipRange: string, newBits: number, netNum: number): string {
   const ipAddress = require("ip-address");
   const BigInteger = require("jsbn").BigInteger;
 


### PR DESCRIPTION
This reverts commit 4a0b97b90336bae76b7a0c8d210cf271d2c8dc72 from #1014 which [fails the "cron" CI tests](https://github.com/pulumi/pulumi-awsx/actions/runs/5472516109). It needs more work because when we don't have an IPAM Pool Id, we still need to use a default CIDR block (the previous `cidrBlock = args.cidrBlock ?? "10.0.0.0/16"` line).

Resolves #1039 