### PR TITLE
Pass `--schema-path` with docs-build requests to pulumi/registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,19 +367,6 @@ jobs:
       - name: Add SDK version tag
         run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
           sdk/v$(pulumictl get version --language generic)
-  create_docs_build:
-    name: Create docs build
-    needs: tag_sdk
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.1.0
-        with:
-          repo: pulumi/pulumictl
-      - env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        name: Dispatch event
-        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
 name: release
 "on":
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,6 +367,19 @@ jobs:
       - name: Add SDK version tag
         run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
           sdk/v$(pulumictl get version --language generic)
+  create_docs_build:
+    name: Create docs build
+    needs: tag_sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.1.0
+        with:
+          repo: pulumi/pulumictl
+      - env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        name: Dispatch event
+        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
 name: release
 "on":
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,7 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
         name: Dispatch event
-        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
+        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/} --schema-path awsx/schema.json
 name: release
 "on":
   push:


### PR DESCRIPTION
~~Because this repo doesn't contain a `schema.json`, these workflow-dispatch calls [always fail](https://github.com/pulumi/registry/actions/runs/5749835730/job/15585412356) (and generate [P1 issues](https://github.com/pulumi/registry/issues/2920) for the docs team), so this change just removes them.~~

Adds a flag to pass the path to `schema.json` when dispatching actions to the Registry in the `release` workflow. 

Fixes https://github.com/pulumi/registry/issues/2920.