### PR TITLE
Stop using deprecated aws.ec2.getSubnetIds in classic

### DIFF
--- a/awsx-classic/ec2/vpc.ts
+++ b/awsx-classic/ec2/vpc.ts
@@ -317,7 +317,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
         // those subnets are used to make many downstream resource-creating decisions.
         const vpcId = await args.vpcId;
         const provider = args.provider;
-        const getSubnetsResult = await aws.ec2.getSubnets({ 
+        const getSubnetsResult = await aws.ec2.getSubnets({
             filters: [{ name: "vpc-id", values: [vpcId] }],
         }, { provider, async: true });
         const publicSubnetIds = getSubnetsResult.ids.slice(0, 2);

--- a/awsx-classic/ec2/vpc.ts
+++ b/awsx-classic/ec2/vpc.ts
@@ -317,7 +317,9 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
         // those subnets are used to make many downstream resource-creating decisions.
         const vpcId = await args.vpcId;
         const provider = args.provider;
-        const getSubnetsResult = await aws.ec2.getSubnetIds({ vpcId  }, { provider, async: true });
+        const getSubnetsResult = await aws.ec2.getSubnets({ 
+            filters: [{ name: "vpc-id", values: [vpcId] }],
+        }, { provider, async: true });
         const publicSubnetIds = getSubnetsResult.ids.slice(0, 2);
 
         return new VpcData(name, this, {

--- a/sdk/nodejs/classic/ec2/vpc.ts
+++ b/sdk/nodejs/classic/ec2/vpc.ts
@@ -317,7 +317,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
         // those subnets are used to make many downstream resource-creating decisions.
         const vpcId = await args.vpcId;
         const provider = args.provider;
-        const getSubnetsResult = await aws.ec2.getSubnets({ 
+        const getSubnetsResult = await aws.ec2.getSubnets({
             filters: [{ name: "vpc-id", values: [vpcId] }],
         }, { provider, async: true });
         const publicSubnetIds = getSubnetsResult.ids.slice(0, 2);

--- a/sdk/nodejs/classic/ec2/vpc.ts
+++ b/sdk/nodejs/classic/ec2/vpc.ts
@@ -317,7 +317,9 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
         // those subnets are used to make many downstream resource-creating decisions.
         const vpcId = await args.vpcId;
         const provider = args.provider;
-        const getSubnetsResult = await aws.ec2.getSubnetIds({ vpcId  }, { provider, async: true });
+        const getSubnetsResult = await aws.ec2.getSubnets({ 
+            filters: [{ name: "vpc-id", values: [vpcId] }],
+        }, { provider, async: true });
         const publicSubnetIds = getSubnetsResult.ids.slice(0, 2);
 
         return new VpcData(name, this, {


### PR DESCRIPTION
Fixes #925 for the classic module.