### PR TITLE
Fix build issues caused by recent aws-sdk release, fix classic tests

### DIFF
--- a/awsx-classic/ec2/vpcTopology.ts
+++ b/awsx-classic/ec2/vpcTopology.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import { SubnetArgs } from "./subnet";
 import { VpcSubnetArgs, VpcSubnetType } from "./vpc";

--- a/awsx-classic/ecs/taskDefinition.ts
+++ b/awsx-classic/ecs/taskDefinition.ts
@@ -14,7 +14,6 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import type * as awssdk from "aws-sdk";
 import * as ecssdk from "@aws-sdk/client-ecs";
 import * as ec2 from "../ec2";
 import * as lb from "../lb";
@@ -172,50 +171,50 @@ export interface RunTaskRequest {
     /**
      * A list of container overrides in JSON format that specify the name of a container in the specified task definition and the overrides it should receive. You can override the default command for a container (that is specified in the task definition or Docker image) with a command override. You can also override existing environment variables (that are specified in the task definition or Docker image) on a container or add new environment variables to it with an environment override.  A total of 8192 characters are allowed for overrides. This limit includes the JSON formatting characters of the override structure.
      */
-    overrides?: awssdk.ECS.TaskOverride;
+    overrides?: ecssdk.TaskOverride;
     /**
      * The number of instantiations of the specified task to place on your cluster. You can specify up to 10 tasks per call.
      */
-    count?: awssdk.ECS.BoxedInteger;
+    count?: number;
     /**
      * An optional tag specified when a task is started. For example, if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the startedBy parameter. You can then identify which tasks belong to that job by filtering the results of a ListTasks call with the startedBy value. Up to 36 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed. If a task is started by an Amazon ECS service, then the startedBy parameter contains the deployment ID of the service that starts it.
      */
-    startedBy?: awssdk.ECS.String;
+    startedBy?: string;
     /**
      * The name of the task group to associate with the task. The default value is the family name of the task definition (for example, family:my-family-name).
      */
-    group?: awssdk.ECS.String;
+    group?: string;
     /**
      * An array of placement constraint objects to use for the task. You can specify up to 10 constraints per task (including constraints in the task definition and those specified at runtime).
      */
-    placementConstraints?: awssdk.ECS.PlacementConstraints;
+    placementConstraints?: ecssdk.PlacementConstraint[];
     /**
      * The placement strategy objects to use for the task. You can specify a maximum of five strategy rules per task.
      */
-    placementStrategy?: awssdk.ECS.PlacementStrategies;
+    placementStrategy?: ecssdk.PlacementStrategy[];
     /**
      * The platform version the task should run. A platform version is only specified for tasks using the Fargate launch type. If one is not specified, the LATEST platform version is used by default. For more information, see AWS Fargate Platform Versions in the Amazon Elastic Container Service Developer Guide.
      */
-    platformVersion?: awssdk.ECS.String;
+    platformVersion?: string;
     /**
      * The network configuration for the task. This parameter is required for task definitions that use the awsvpc network mode to receive their own elastic network interface, and it is not supported for other network modes. For more information, see Task Networking in the Amazon Elastic Container Service Developer Guide.
      */
-    networkConfiguration?: awssdk.ECS.NetworkConfiguration;
+    networkConfiguration?: ecssdk.NetworkConfiguration;
     /**
      * The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.
      */
-    tags?: awssdk.ECS.Tags;
+    tags?: ecssdk.Tag[];
     /**
      * Specifies whether to enable Amazon ECS managed tags for the task. For more information, see Tagging Your Amazon ECS Resources in the Amazon Elastic Container Service Developer Guide.
      */
-    enableECSManagedTags?: awssdk.ECS.Boolean;
+    enableECSManagedTags?: boolean;
     /**
      * Specifies whether to propagate the tags from the task definition or the service to the task. If no value is specified, the tags are not propagated.
      */
-    propagateTags?: awssdk.ECS.PropagateTags;
+    propagateTags?: ecssdk.PropagateTags;
 }
 
-type RunTaskRequestOverrideShape = utils.Overwrite<awssdk.ECS.RunTaskRequest, {
+type RunTaskRequestOverrideShape = utils.Overwrite<ecssdk.RunTaskRequest, {
     cluster: Cluster;
     taskDefinition?: never;
     launchType?: never;
@@ -235,6 +234,7 @@ function createRunFunction(isFargate: boolean, taskDefArn: pulumi.Output<string>
 
         const subnetIds = publicSubnetIds.map(i => i.get());
         const assignPublicIp = isFargate; // && !usePrivateSubnets;
+        const assignPublicIpSdk: ecssdk.AssignPublicIp = assignPublicIp ? "ENABLED" : "DISABLED";
 
         // Run the task
         return ecs.runTask({
@@ -242,7 +242,7 @@ function createRunFunction(isFargate: boolean, taskDefArn: pulumi.Output<string>
             launchType: isFargate ? "FARGATE" : "EC2",
             networkConfiguration: {
                 awsvpcConfiguration: {
-                    assignPublicIp: assignPublicIp ? "ENABLED" : "DISABLED",
+                    assignPublicIp: assignPublicIpSdk,
                     securityGroups: securityGroupIds,
                     subnets: subnetIds,
                 },

--- a/awsx-classic/package.json
+++ b/awsx-classic/package.json
@@ -18,7 +18,7 @@
         "@pulumi/docker": "3.6.1",
         "@pulumi/pulumi": "^3.34.0",
         "aws-lambda": "^1.0.7",
-        "aws-sdk": "^2.0.0",
+        "docker-classic": "npm:@pulumi/docker@3.6.1",
         "mime": "^3.0.0"
     },
     "devDependencies": {

--- a/awsx-classic/tests/package.json
+++ b/awsx-classic/tests/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@pulumi/aws",
+    "name": "@pulumi/awsx",
     "version": "${VERSION}",
     "description": "A Pulumi package for creating and managing Amazon Web Services (AWS) cloud resources.",
     "keywords": [
@@ -14,8 +14,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^5.0.0",
-        "aws-sdk": "^2.0.0",
+        "@pulumi/aws": "^6.0.0",
         "builtin-modules": "3.0.0",
         "mime": "^2.0.0",
         "resolve": "^1.7.1",
@@ -28,9 +27,10 @@
     "devDependencies": {
         "@types/mime": "^2.0.0",
         "@types/mocha": "^2.2.42",
-        "@types/node": "^10.0.0",
+        "@types/node": "^18.0.0",
         "@types/semver": "^6.0.0",
-        "@types/js-combinatorics": "^0.5.31"
+        "@types/js-combinatorics": "^0.5.31",
+        "typescript": "^4.6.2"
     },
     "pulumi": {
         "resource": true

--- a/sdk/nodejs/classic/ec2/vpcTopology.ts
+++ b/sdk/nodejs/classic/ec2/vpcTopology.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import { SubnetArgs } from "./subnet";
 import { VpcSubnetArgs, VpcSubnetType } from "./vpc";

--- a/sdk/nodejs/classic/ecs/taskDefinition.ts
+++ b/sdk/nodejs/classic/ecs/taskDefinition.ts
@@ -14,7 +14,6 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import type * as awssdk from "aws-sdk";
 import * as ecssdk from "@aws-sdk/client-ecs";
 import * as ec2 from "../ec2";
 import * as lb from "../lb";
@@ -172,50 +171,50 @@ export interface RunTaskRequest {
     /**
      * A list of container overrides in JSON format that specify the name of a container in the specified task definition and the overrides it should receive. You can override the default command for a container (that is specified in the task definition or Docker image) with a command override. You can also override existing environment variables (that are specified in the task definition or Docker image) on a container or add new environment variables to it with an environment override.  A total of 8192 characters are allowed for overrides. This limit includes the JSON formatting characters of the override structure.
      */
-    overrides?: awssdk.ECS.TaskOverride;
+    overrides?: ecssdk.TaskOverride;
     /**
      * The number of instantiations of the specified task to place on your cluster. You can specify up to 10 tasks per call.
      */
-    count?: awssdk.ECS.BoxedInteger;
+    count?: number;
     /**
      * An optional tag specified when a task is started. For example, if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the startedBy parameter. You can then identify which tasks belong to that job by filtering the results of a ListTasks call with the startedBy value. Up to 36 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed. If a task is started by an Amazon ECS service, then the startedBy parameter contains the deployment ID of the service that starts it.
      */
-    startedBy?: awssdk.ECS.String;
+    startedBy?: string;
     /**
      * The name of the task group to associate with the task. The default value is the family name of the task definition (for example, family:my-family-name).
      */
-    group?: awssdk.ECS.String;
+    group?: string;
     /**
      * An array of placement constraint objects to use for the task. You can specify up to 10 constraints per task (including constraints in the task definition and those specified at runtime).
      */
-    placementConstraints?: awssdk.ECS.PlacementConstraints;
+    placementConstraints?: ecssdk.PlacementConstraint[];
     /**
      * The placement strategy objects to use for the task. You can specify a maximum of five strategy rules per task.
      */
-    placementStrategy?: awssdk.ECS.PlacementStrategies;
+    placementStrategy?: ecssdk.PlacementStrategy[];
     /**
      * The platform version the task should run. A platform version is only specified for tasks using the Fargate launch type. If one is not specified, the LATEST platform version is used by default. For more information, see AWS Fargate Platform Versions in the Amazon Elastic Container Service Developer Guide.
      */
-    platformVersion?: awssdk.ECS.String;
+    platformVersion?: string;
     /**
      * The network configuration for the task. This parameter is required for task definitions that use the awsvpc network mode to receive their own elastic network interface, and it is not supported for other network modes. For more information, see Task Networking in the Amazon Elastic Container Service Developer Guide.
      */
-    networkConfiguration?: awssdk.ECS.NetworkConfiguration;
+    networkConfiguration?: ecssdk.NetworkConfiguration;
     /**
      * The metadata that you apply to the task to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. Tag keys can have a maximum character length of 128 characters, and tag values can have a maximum length of 256 characters.
      */
-    tags?: awssdk.ECS.Tags;
+    tags?: ecssdk.Tag[];
     /**
      * Specifies whether to enable Amazon ECS managed tags for the task. For more information, see Tagging Your Amazon ECS Resources in the Amazon Elastic Container Service Developer Guide.
      */
-    enableECSManagedTags?: awssdk.ECS.Boolean;
+    enableECSManagedTags?: boolean;
     /**
      * Specifies whether to propagate the tags from the task definition or the service to the task. If no value is specified, the tags are not propagated.
      */
-    propagateTags?: awssdk.ECS.PropagateTags;
+    propagateTags?: ecssdk.PropagateTags;
 }
 
-type RunTaskRequestOverrideShape = utils.Overwrite<awssdk.ECS.RunTaskRequest, {
+type RunTaskRequestOverrideShape = utils.Overwrite<ecssdk.RunTaskRequest, {
     cluster: Cluster;
     taskDefinition?: never;
     launchType?: never;
@@ -235,6 +234,7 @@ function createRunFunction(isFargate: boolean, taskDefArn: pulumi.Output<string>
 
         const subnetIds = publicSubnetIds.map(i => i.get());
         const assignPublicIp = isFargate; // && !usePrivateSubnets;
+        const assignPublicIpSdk: ecssdk.AssignPublicIp = assignPublicIp ? "ENABLED" : "DISABLED";
 
         // Run the task
         return ecs.runTask({
@@ -242,7 +242,7 @@ function createRunFunction(isFargate: boolean, taskDefArn: pulumi.Output<string>
             launchType: isFargate ? "FARGATE" : "EC2",
             networkConfiguration: {
                 awsvpcConfiguration: {
-                    assignPublicIp: assignPublicIp ? "ENABLED" : "DISABLED",
+                    assignPublicIp: assignPublicIpSdk,
                     securityGroups: securityGroupIds,
                     subnets: subnetIds,
                 },


### PR DESCRIPTION
- Fix classic compilation issues due to diverging aws-sdk and aws-sdk/client-ecs
- Resurrect the istanbul_tests suite for awsx-classic
