### PR TITLE
Pass the dockerfile option to ECR image

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -67,15 +67,16 @@ export function computeImageFromAsset(
     imageName: canonicalImageName,
     build: {
       args: dockerInputs.args,
+      builderVersion: dockerInputs.builderVersion,
       cacheFrom: dockerInputs.cacheFrom
         ? {
             images: dockerInputs.cacheFrom,
           }
         : undefined,
       context: dockerInputs.context,
+      dockerfile: dockerInputs.dockerfile,
       platform: dockerInputs.platform,
       target: dockerInputs.target,
-      builderVersion: dockerInputs.builderVersion,
     },
     registry: registryCredentials,
   };

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -103,6 +103,16 @@ func TestEcrSimple(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestEcrDockerfile(t *testing.T) {
+	test := getNodeJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			RunUpdateTest: false,
+			Dir:           filepath.Join(getCwd(t), "ts-ecr-dockerfile"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestDefaultVpc(t *testing.T) {
 	t.Skip("https://github.com/pulumi/pulumi-awsx/issues/788")
 	test := getNodeJSBaseOptions(t).

--- a/examples/ts-ecr-dockerfile/Pulumi.yaml
+++ b/examples/ts-ecr-dockerfile/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ecr-dockerfile
+runtime: nodejs
+description: A simple ecr demo with Dockerfile in a separate folder.

--- a/examples/ts-ecr-dockerfile/README.md
+++ b/examples/ts-ecr-dockerfile/README.md
@@ -1,0 +1,3 @@
+# examples/ecr-dockerfile
+
+A simple ecr demo with Dockerfile in a separate folder.

--- a/examples/ts-ecr-dockerfile/app/content/index.html
+++ b/examples/ts-ecr-dockerfile/app/content/index.html
@@ -1,0 +1,1 @@
+<h1> Hi from Pulumi </h1>

--- a/examples/ts-ecr-dockerfile/docker/Dockerfile
+++ b/examples/ts-ecr-dockerfile/docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY content /usr/share/nginx/html

--- a/examples/ts-ecr-dockerfile/index.ts
+++ b/examples/ts-ecr-dockerfile/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+
+const repository = new awsx.ecr.Repository("repository", { forceDelete: true });
+
+export const image = new awsx.ecr.Image("image", {
+  repositoryUrl: repository.repository.repositoryUrl,
+  context: "./app",
+  dockerfile: "./docker/Dockerfile",
+}).imageUri;

--- a/examples/ts-ecr-dockerfile/package.json
+++ b/examples/ts-ecr-dockerfile/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "ecr-simple",
+    "name": "ecr-dockerfile",
     "version": "0.0.1",
     "license": "Apache-2.0",
     "scripts": {

--- a/examples/ts-ecr-dockerfile/tsconfig.json
+++ b/examples/ts-ecr-dockerfile/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Apparently, we don't pass the `dockerfile` option to the ECR image. This PR is a one-line change to actually use it. I added a new E2E test to validate, let me know if you see a better testing opportunity.

Fix https://github.com/pulumi/pulumi-awsx/issues/1109