### PR TITLE
Ensure the resource name uses the uniquely generated name to avoid conflicts

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -81,7 +81,7 @@ export function computeImageFromAsset(
     registry: registryCredentials,
   };
 
-  const image = new docker.Image(`image`, dockerImageArgs, { parent });
+  const image = new docker.Image(imageName, dockerImageArgs, { parent });
 
   image.repoDigest.apply((d: any) =>
     pulumi.log.debug(`    build complete: ${imageName} (${d})`, parent),


### PR DESCRIPTION
By having `image` hard-coded, pulumi can never succeed with multiple images in the same stack because the name conflicts.