### PR TITLE
Fix hard coded subnet masks

### DIFF
--- a/awsx/ec2/subnetDistributor.test.ts
+++ b/awsx/ec2/subnetDistributor.test.ts
@@ -34,7 +34,7 @@ describe("default subnet layout", () => {
       fc.property(
         fc.record({
           vpcCidrMask: cidrMask(),
-          azs: fc.array(fc.string({ size: "xsmall" }), { minLength: 2, maxLength: 5 }),
+          azs: fc.array(fc.string({ size: "xsmall" }), { minLength: 2, maxLength: 4 }),
           subnetSpecs: fc.array(subnetSpecNoMask(), { minLength: 1, maxLength: 5 }),
         }),
         ({ vpcCidrMask, azs, subnetSpecs }) => {

--- a/awsx/ec2/subnetDistributor.test.ts
+++ b/awsx/ec2/subnetDistributor.test.ts
@@ -16,30 +16,95 @@ import fc from "fast-check";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import { getSubnetSpecs, SubnetSpec } from "./subnetDistributor";
 
-describe("subnet ranges", () => {
+function cidrMask(args?: { min?: number; max?: number }): fc.Arbitrary<number> {
+  return fc.integer({ min: args?.min ?? 16, max: args?.max ?? 27 });
+}
+
+function subnetSpecNoMask() {
+  return fc.constantFrom("Private", "Public", "Isolated").map(
+    (type): SubnetSpecInputs => ({
+      type: type as SubnetTypeInputs,
+    }),
+  );
+}
+
+describe("default subnet layout", () => {
   it("should have smaller subnets than the vpc", () => {
     fc.assert(
       fc.property(
-        fc.integer({ min: 16, max: 27 }), // vpc mask
-        fc.integer({ min: 2, max: 4 }), // az count
-        fc.integer({ min: 1, max: 4 }), // subnet count
-        (vpcMask, azCount, subnetCount) => {
-          const vpcCidr = `10.0.0.0/${vpcMask}`;
-          const azs: string[] = [];
-          for (let index = 0; index < azCount; index++) {
-            azs.push("us-east-1" + String.fromCharCode("c".charCodeAt(0) + index));
-          }
-          const subnetTypes: SubnetTypeInputs[] = ["Private", "Public", "Isolated"];
-          const specs: SubnetSpecInputs[] = [];
-          for (let index = 0; index < subnetCount; index++) {
-            specs.push({ type: subnetTypes[index % 3] });
-          }
-          const result = getSubnetSpecs("vpcName", vpcCidr, azs, specs);
+        fc.record({
+          vpcCidrMask: cidrMask(),
+          azs: fc.array(fc.string({ size: "xsmall" }), { minLength: 2, maxLength: 5 }),
+          subnetSpecs: fc.array(subnetSpecNoMask(), { minLength: 1, maxLength: 5 }),
+        }),
+        ({ vpcCidrMask, azs, subnetSpecs }) => {
+          const vpcCidr = `10.0.0.0/${vpcCidrMask}`;
+
+          const result = getSubnetSpecs("vpcName", vpcCidr, azs, subnetSpecs);
+
           for (const subnet of result) {
             const subnetMask = getCidrMask(subnet.cidrBlock);
             // Larger mask means smaller subnet
-            expect(subnetMask).toBeGreaterThan(vpcMask);
+            expect(subnetMask).toBeGreaterThan(vpcCidrMask);
           }
+        },
+      ),
+    );
+  });
+
+  it("should use whole space if there's only one subnet and VPC is small", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          vpcCidrMask: cidrMask({ min: 24 }),
+          subnetSpec: subnetSpecNoMask(),
+        }),
+        ({ vpcCidrMask, subnetSpec }) => {
+          const vpcCidr = `10.0.0.0/${vpcCidrMask}`;
+
+          const result = getSubnetSpecs("vpcName", vpcCidr, ["us-east-1a"], [subnetSpec]);
+
+          expect(result.length).toBe(1);
+          expect(result[0].cidrBlock).toBe(vpcCidr);
+        },
+      ),
+    );
+  });
+
+  it("should use default values if VPC is large", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          vpcCidrMask: cidrMask({ max: 17 }),
+          subnetSpec: subnetSpecNoMask(),
+        }),
+        ({ vpcCidrMask }) => {
+          const vpcCidr = `10.0.0.0/${vpcCidrMask}`;
+
+          const result = getSubnetSpecs(
+            "vpcName",
+            vpcCidr,
+            ["us-east-1a"],
+            [{ type: "Public" }, { type: "Private" }, { type: "Isolated" }],
+          );
+
+          expect(result).toMatchObject([
+            {
+              cidrBlock: "10.0.0.0/19",
+              subnetName: "vpcName-private-1",
+              type: "Private",
+            },
+            {
+              cidrBlock: "10.0.32.0/20",
+              subnetName: "vpcName-public-1",
+              type: "Public",
+            },
+            {
+              cidrBlock: "10.0.48.0/24",
+              subnetName: "vpcName-isolated-1",
+              type: "Isolated",
+            },
+          ]);
         },
       ),
     );

--- a/awsx/package.json
+++ b/awsx/package.json
@@ -39,6 +39,7 @@
     "@types/mime": "^3.0.0",
     "@types/node": "^18",
     "babel-jest": "^29.0.0",
+    "fast-check": "^3.13.2",
     "install-peers-cli": "^2.2.0",
     "jest": "^29.0.0",
     "json-schema-to-typescript": "^10.1.5",

--- a/awsx/yarn.lock
+++ b/awsx/yarn.lock
@@ -2636,6 +2636,13 @@ ext@^1.1.2:
   dependencies:
     type "^2.7.2"
 
+fast-check@^3.13.2:
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.13.2.tgz#1bea3b167f689b271535dde7569c2d56caa7e4ea"
+  integrity sha512-ouTiFyeMoqmNg253xqy4NSacr5sHxH6pZpLOaHgaAdgZxFWdtsfxExwolpveoAE9CJdV+WYjqErNGef6SqA5Mg==
+  dependencies:
+    pure-rand "^6.0.0"
+
 fast-glob@^3.2.9:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"


### PR DESCRIPTION
Using hard coded /19, /20 and /24 masks doesn't work when the VPC range is too small. This result in negative "new bits" and therefore subnets which are bigger than the available space. 

We need to maintain backward compatibility, so anyone generating valid subnets right now will continue with the same results. Therefore, we use an alternative, calculated mask if the minimal size block (largest mask number) is larger than the hard-coded value. 

Add a test to validate all combinations (144 possibilities) result in subnets which are not larger than the VPC's original CIDR block. This is a pretty crude test, but was used to find the deficient code.

- Related to #982 