### PR TITLE
Fix subnet overlapping

### DIFF
--- a/awsx/ec2/knownWorkingSubnets.ts
+++ b/awsx/ec2/knownWorkingSubnets.ts
@@ -1,3 +1,17 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { SubnetSpecInputs } from "../schema-types";
 
 export const knownWorkingSubnets: {

--- a/awsx/ec2/knownWorkingSubnets.ts
+++ b/awsx/ec2/knownWorkingSubnets.ts
@@ -1,0 +1,1312 @@
+import { SubnetSpecInputs } from "../schema-types";
+
+export const knownWorkingSubnets: {
+  result: string[];
+  subnetSpecs: SubnetSpecInputs[];
+  vpcCidr: string;
+}[] = [
+  {
+    result: ["10.0.0.0/21", "10.0.8.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 18,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/27", "10.0.0.32/27", "10.0.128.32/17"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 27,
+        type: "Public",
+      },
+      {
+        cidrMask: 17,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.0.128/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/21", "10.0.64.0/18", "10.0.128.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Private",
+      },
+      {
+        cidrMask: 18,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/19", "10.0.32.0/25", "10.0.40.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 19,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.64.0/18", "10.0.128.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+      {
+        cidrMask: 18,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 18,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.8.0/21", "10.0.16.0/24", "10.0.24.0/21", "10.0.32.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+      {
+        cidrMask: 21,
+        type: "Private",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+      {
+        cidrMask: 21,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.8.0/21", "10.0.16.0/25", "10.0.24.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+      {
+        cidrMask: 21,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.32.0/19", "10.0.64.0/19", "10.0.96.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/23", "10.0.2.0/25", "10.0.3.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/20",
+  },
+  {
+    result: ["10.0.0.0/27", "10.0.4.0/22", "10.0.8.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Private",
+      },
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/18", "10.0.64.0/27", "10.0.96.0/19", "10.0.128.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Public",
+      },
+      {
+        cidrMask: 18,
+        type: "Private",
+      },
+      {
+        cidrMask: 19,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/20",
+  },
+  {
+    result: ["10.0.0.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/17", "10.0.128.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 17,
+        type: "Public",
+      },
+      {
+        cidrMask: 18,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/17"],
+    subnetSpecs: [
+      {
+        cidrMask: 17,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.4.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Public",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.0.64/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/20",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.4.0/23", "10.0.12.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Public",
+      },
+      {
+        cidrMask: 23,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.2.0/23", "10.0.4.0/26", "10.0.4.64/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+      {
+        cidrMask: 23,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/25",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.0.64/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.2.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+      {
+        cidrMask: 23,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/22",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.32.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 19,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/22",
+  },
+  {
+    result: ["10.0.0.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 18,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/27", "10.0.0.64/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/23",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/20", "10.0.16.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/19", "10.0.32.0/21", "10.0.48.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Public",
+      },
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 20,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.0.128/27", "10.0.1.128/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+      {
+        cidrMask: 27,
+        type: "Public",
+      },
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/20",
+  },
+  {
+    result: ["10.0.0.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.0.64/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/25",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.32.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.4.0/26", "10.0.4.128/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 18,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/26", "10.0.1.64/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.4.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/25",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/19", "10.0.32.0/23", "10.0.96.0/18"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 18,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 19,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.0.64/26", "10.0.0.128/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 26,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/19",
+  },
+  {
+    result: ["10.0.0.0/24", "10.0.1.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 24,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/22",
+  },
+  {
+    result: ["10.0.0.0/26", "10.0.4.0/22", "10.0.32.0/20"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Private",
+      },
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+      {
+        cidrMask: 20,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/20", "10.0.16.0/24"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Private",
+      },
+      {
+        cidrMask: 24,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/22"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/27"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/21", "10.0.8.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/23"],
+    subnetSpecs: [
+      {
+        cidrMask: 23,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 21,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/17",
+  },
+  {
+    result: ["10.0.0.0/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/20", "10.0.128.0/17", "10.1.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 20,
+        type: "Private",
+      },
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 17,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/27", "10.0.72.0/21"],
+    subnetSpecs: [
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+      {
+        cidrMask: 19,
+        type: "Private",
+      },
+      {
+        cidrMask: 27,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 21,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/18",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.4.0/25", "10.0.4.128/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Private",
+      },
+      {
+        cidrMask: 25,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+    ],
+    vpcCidr: "10.0.0.0/21",
+  },
+  {
+    result: ["10.0.0.0/22", "10.0.32.0/19"],
+    subnetSpecs: [
+      {
+        cidrMask: 22,
+        type: "Isolated",
+      },
+      {
+        cidrMask: 19,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/25", "10.0.1.0/24", "10.0.2.0/27", "10.0.2.128/25"],
+    subnetSpecs: [
+      {
+        cidrMask: 27,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Public",
+      },
+      {
+        cidrMask: 25,
+        type: "Private",
+      },
+      {
+        cidrMask: 24,
+        type: "Private",
+      },
+    ],
+    vpcCidr: "10.0.0.0/16",
+  },
+  {
+    result: ["10.0.0.0/26"],
+    subnetSpecs: [
+      {
+        cidrMask: 26,
+        type: "Isolated",
+      },
+    ],
+    vpcCidr: "10.0.0.0/20",
+  },
+];

--- a/awsx/ec2/subnetDistributor.test.ts
+++ b/awsx/ec2/subnetDistributor.test.ts
@@ -15,6 +15,7 @@
 import fc from "fast-check";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import { getSubnetSpecs, SubnetSpec, validateRanges } from "./subnetDistributor";
+import { knownWorkingSubnets } from "./knownWorkingSubnets";
 
 function cidrMask(args?: { min?: number; max?: number }): fc.Arbitrary<number> {
   return fc.integer({ min: args?.min ?? 16, max: args?.max ?? 27 });
@@ -149,6 +150,24 @@ describe("default subnet layout", () => {
         },
       ),
     );
+  });
+
+  describe("known working subnets", () => {
+    for (const knownCase of knownWorkingSubnets) {
+      it(`should work for ${knownCase.vpcCidr} with subnets ${knownCase.subnetSpecs
+        .map((s) => `${s.type}:${s.cidrMask}`)
+        .join(", ")}`, () => {
+        const result = getSubnetSpecs(
+          "vpcName",
+          knownCase.vpcCidr,
+          ["us-east-1a"],
+          knownCase.subnetSpecs,
+        );
+        const actual = result.map((s) => s.cidrBlock);
+
+        expect(actual).toEqual(knownCase.result);
+      });
+    }
   });
 });
 

--- a/awsx/ec2/subnetDistributor.ts
+++ b/awsx/ec2/subnetDistributor.ts
@@ -41,7 +41,11 @@ export function validateRanges(specs: SubnetSpec[]) {
   for (const current of ranges.slice(1)) {
     if (current.start.compareTo(previous.end) <= 0) {
       throw new Error(
-        `Subnet ranges must not overlap. Found a gap between ${previous.addr.address} and ${current.addr.address}`,
+        `Subnet ranges must not overlap. ${previous.addr.address} (from ${
+          previous.addr.startAddress().address
+        } to ${previous.addr.endAddress().address}) and ${current.addr.address} (from ${
+          previous.addr.startAddress().address
+        } to ${previous.addr.endAddress().address}) overlap.)`,
       );
     }
     previous = current;

--- a/awsx/ec2/subnetDistributor.ts
+++ b/awsx/ec2/subnetDistributor.ts
@@ -18,6 +18,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import * as ipAddress from "ip-address";
+import { BigInteger } from "jsbn";
 
 export interface SubnetSpec {
   cidrBlock: string;
@@ -29,29 +30,6 @@ export interface SubnetSpec {
   }>;
 }
 
-export function validateRanges(specs: SubnetSpec[]) {
-  const ranges = specs
-    .map((spec) => new ipAddress.Address4(spec.cidrBlock))
-    .map((addr) => {
-      const start = addr.startAddress().bigInteger();
-      const end = addr.endAddress().bigInteger();
-      return { addr, start, end };
-    });
-  let previous = ranges[0];
-  for (const current of ranges.slice(1)) {
-    if (current.start.compareTo(previous.end) <= 0) {
-      throw new Error(
-        `Subnet ranges must not overlap. ${previous.addr.address} (from ${
-          previous.addr.startAddress().address
-        } to ${previous.addr.endAddress().address}) and ${current.addr.address} (from ${
-          previous.addr.startAddress().address
-        } to ${previous.addr.endAddress().address}) overlap.)`,
-      );
-    }
-    previous = current;
-  }
-}
-
 export function getSubnetSpecs(
   vpcName: string,
   vpcCidr: string,
@@ -60,9 +38,14 @@ export function getSubnetSpecs(
 ): SubnetSpec[] {
   // Design:
   // 1. Split the VPC CIDR block evenly between the AZs.
-  // 2. Assign private subnets within each AZ using /19 blocks if possible.
-  // 3. Assign public subnets within each AZ using /20 blocks if possible.
-  // 4. Assign isolated subnets within each AZ using /24 blocks if possible.
+  // 2. Assign private subnets within each AZ using /19 (or user specified) blocks if possible.
+  // 3. Assign public subnets within each AZ using /20 (or user specified) blocks if possible.
+  // 4. Assign isolated subnets within each AZ using /24 (or user specified) blocks if possible.
+
+  // Selection of the next block uses two strategies to maintain compatibility while fixing overlapping subnets:
+  // 1. Attempt to use the legacy method (cidrSubnetV4) to get the next block.
+  // 2. Check if the generated next block overlaps with the previous block.
+  // 3. If there's overlap, use the new method (nextBlock) to get the next block.
   const newBitsPerAZ = Math.log2(nextPow2(azNames.length));
 
   const azBases: string[] = [];
@@ -91,6 +74,11 @@ export function getSubnetSpecs(
     const publicSubnetsOut: SubnetSpec[] = [];
     const isolatedSubnetsOut: SubnetSpec[] = [];
 
+    // Start at one address before the base address for the AZ:
+    let currentAddress = ipAddress.Address4.fromBigInteger(
+      new ipAddress.Address4(azBases[i]).startAddress().bigInteger().subtract(BigInteger.ONE),
+    );
+
     for (let j = 0; j < privateSubnetsIn.length; j++) {
       const privateCidrMask: number =
         privateSubnetsIn[j].cidrMask ?? Math.max(baseSubnetMask + newBitsPerSubnet, 19);
@@ -100,14 +88,18 @@ export function getSubnetSpecs(
       // multiple subnets of each type per AZ. In this case, we need the
       // nth subnet of size newBits in the block for the AZ. The other
       // subnet types below have similar logic.
-      const privateSubnetCidrBlock = cidrSubnetV4(azBases[i], newBits, j);
+      let nextAddress = new ipAddress.Address4(cidrSubnetV4(azBases[i], newBits, j));
+      if (isOverlapping(currentAddress, nextAddress)) {
+        nextAddress = nextBlock(currentAddress, privateCidrMask);
+      }
       privateSubnetsOut.push({
         azName: azNames[i],
-        cidrBlock: privateSubnetCidrBlock,
+        cidrBlock: nextAddress.address,
         type: "Private",
         subnetName: `${vpcName}-${privateSubnetsIn[j].name ?? "private"}-${i + 1}`,
         tags: privateSubnetsIn[j].tags,
       });
+      currentAddress = nextAddress;
     }
 
     for (let j = 0; j < publicSubnetsIn.length; j++) {
@@ -126,14 +118,19 @@ export function getSubnetSpecs(
         publicSubnetsIn[j].cidrMask ?? Math.max(baseSubnetMask + newBitsPerSubnet, 20);
       const newBits = publicCidrMask - baseIp.subnetMask;
 
-      const publicSubnetCidrBlock = cidrSubnetV4(splitBase, newBits, j);
+      let nextAddress = new ipAddress.Address4(cidrSubnetV4(splitBase, newBits, j));
+      if (isOverlapping(currentAddress, nextAddress)) {
+        nextAddress = nextBlock(currentAddress, publicCidrMask);
+      }
+
       publicSubnetsOut.push({
         azName: azNames[i],
-        cidrBlock: publicSubnetCidrBlock,
+        cidrBlock: nextAddress.address,
         type: "Public",
         subnetName: `${vpcName}-${publicSubnetsIn[j].name ?? "public"}-${i + 1}`,
         tags: publicSubnetsIn[j].tags,
       });
+      currentAddress = nextAddress;
     }
 
     for (let j = 0; j < isolatedSubnetsIn.length; j++) {
@@ -162,15 +159,19 @@ export function getSubnetSpecs(
       const isolatedCidrMask: number =
         isolatedSubnetsIn[j].cidrMask ?? Math.max(baseSubnetMask + newBitsPerSubnet, 24);
       const newBits = isolatedCidrMask - baseIp.subnetMask;
+      let nextAddress = new ipAddress.Address4(cidrSubnetV4(splitBase, newBits, j));
+      if (isOverlapping(currentAddress, nextAddress)) {
+        nextAddress = nextBlock(currentAddress, isolatedCidrMask);
+      }
 
-      const isolatedSubnetCidrBlock = cidrSubnetV4(splitBase, newBits, j);
       isolatedSubnetsOut.push({
         azName: azNames[i],
-        cidrBlock: isolatedSubnetCidrBlock,
+        cidrBlock: nextAddress.address,
         type: "Isolated",
         subnetName: `${vpcName}-${isolatedSubnetsIn[j].name ?? "isolated"}-${i + 1}`,
         tags: isolatedSubnetsIn[j].tags,
       });
+      currentAddress = nextAddress;
     }
 
     subnetsOut = subnetsOut.concat(privateSubnetsOut, publicSubnetsOut, isolatedSubnetsOut);
@@ -232,6 +233,55 @@ function cidrSubnetV4(ipRange: string, newBits: number, netNum: number): string 
   const newAddress = ipAddress.Address4.fromBigInteger(newAddressBI).address;
 
   return `${newAddress}/${newSubnetMask}`;
+}
+
+export function validateRanges(specs: SubnetSpec[]) {
+  const ranges = specs
+    .map((spec) => new ipAddress.Address4(spec.cidrBlock))
+    .map((addr) => {
+      const start = addr.startAddress().bigInteger();
+      const end = addr.endAddress().bigInteger();
+      return { addr, start, end };
+    });
+  let previous = ranges[0];
+  for (const current of ranges.slice(1)) {
+    if (isOverlapping(previous.addr, current.addr)) {
+      throw new Error(
+        `Subnet ranges must not overlap. ${previous.addr.address} (from ${
+          previous.addr.startAddress().address
+        } to ${previous.addr.endAddress().address}) and ${current.addr.address} (from ${
+          previous.addr.startAddress().address
+        } to ${previous.addr.endAddress().address}) overlap.)`,
+      );
+    }
+    previous = current;
+  }
+}
+
+function isOverlapping(a: ipAddress.Address4, b: ipAddress.Address4): boolean {
+  const aStart = a.startAddress().bigInteger();
+  const aEnd = a.endAddress().bigInteger();
+  const bStart = b.startAddress().bigInteger();
+  const bEnd = b.endAddress().bigInteger();
+
+  return aStart.compareTo(bEnd) <= 0 && bStart.compareTo(aEnd) <= 0;
+}
+
+export function nextBlock(
+  previousCidr: ipAddress.Address4,
+  nextCidrMask: number,
+): ipAddress.Address4 {
+  // 1. Get the last address in the previous block.
+  const lastAddress = previousCidr.endAddress().address;
+  // 2. Change the size of the block to the new size in case the block is wider and overlaps.
+  const lastAddressInNewMask = new ipAddress.Address4(lastAddress + "/" + nextCidrMask);
+  // 3. Now find the last address in the new sized block.
+  const lastAddressInNewSizeBlock = lastAddressInNewMask.endAddress();
+  // 4. Add 1 to get the first address in the next block.
+  const nextAddressNumber = lastAddressInNewSizeBlock.bigInteger().add(BigInteger.ONE);
+  // 5. Create the next block and add the new mask.
+  const nextAddress = ipAddress.Address4.fromBigInteger(nextAddressNumber);
+  return new ipAddress.Address4(nextAddress.address + "/" + nextCidrMask);
 }
 
 /**

--- a/awsx/package.json
+++ b/awsx/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@types/aws-sdk": "^2.7.0",
     "@types/jest": "^29.0.0",
+    "@types/jsbn": "^1.2.32",
     "@types/mime": "^3.0.0",
     "@types/node": "^18",
     "babel-jest": "^29.0.0",

--- a/awsx/schema.json
+++ b/awsx/schema.json
@@ -1993,7 +1993,7 @@
                         "plain": true
                     },
                     "plain": true,
-                    "description": "A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC."
+                    "description": "A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last."
                 },
                 "tags": {
                     "type": "object",

--- a/awsx/yarn.lock
+++ b/awsx/yarn.lock
@@ -1727,6 +1727,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/jsbn@^1.2.32":
+  version "1.2.32"
+  resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.32.tgz#2cb8a8737abd8b264c8d29dfcccc47bbc857bc40"
+  integrity sha512-zRragkEedY3qLrwZtFqTtvRutVpQdYXicWVj8MjVuL7ahNJWmbvGV6MiRRtNmU7uZQf0ylbSsqANxD16b2GqFg==
+
 "@types/json-schema@^7.0.6":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"

--- a/schemagen/pkg/gen/ec2.go
+++ b/schemagen/pkg/gen/ec2.go
@@ -116,7 +116,7 @@ func vpcResource(awsSpec schema.PackageSpec) schema.ResourceSpec {
 			},
 		},
 		subnetSpecs: {
-			Description: fmt.Sprintf("A list of subnet specs that should be deployed to each AZ specified in %s. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.", availabilityZoneNames),
+			Description: fmt.Sprintf("A list of subnet specs that should be deployed to each AZ specified in %s. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.", availabilityZoneNames),
 			TypeSpec:    plainArrayOfPlainComplexType("SubnetSpec"),
 		},
 		"vpcEndpointSpecs": {

--- a/sdk/dotnet/Ec2/Vpc.cs
+++ b/sdk/dotnet/Ec2/Vpc.cs
@@ -206,7 +206,7 @@ namespace Pulumi.Awsx.Ec2
         private List<Inputs.SubnetSpecArgs>? _subnetSpecs;
 
         /// <summary>
-        /// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+        /// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
         /// </summary>
         public List<Inputs.SubnetSpecArgs> SubnetSpecs
         {

--- a/sdk/go/awsx/ec2/vpc.go
+++ b/sdk/go/awsx/ec2/vpc.go
@@ -87,7 +87,7 @@ type vpcArgs struct {
 	NatGateways *NatGatewayConfiguration `pulumi:"natGateways"`
 	// A number of availability zones to which the subnets defined in subnetSpecs will be deployed. Optional, defaults to the first 3 AZs in the current region.
 	NumberOfAvailabilityZones *int `pulumi:"numberOfAvailabilityZones"`
-	// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+	// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
 	SubnetSpecs []SubnetSpec `pulumi:"subnetSpecs"`
 	// A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags map[string]string `pulumi:"tags"`
@@ -127,7 +127,7 @@ type VpcArgs struct {
 	NatGateways *NatGatewayConfigurationArgs
 	// A number of availability zones to which the subnets defined in subnetSpecs will be deployed. Optional, defaults to the first 3 AZs in the current region.
 	NumberOfAvailabilityZones *int
-	// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+	// A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
 	SubnetSpecs []SubnetSpecArgs
 	// A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput

--- a/sdk/java/src/main/java/com/pulumi/awsx/ec2/VpcArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ec2/VpcArgs.java
@@ -248,14 +248,14 @@ public final class VpcArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+     * A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
      * 
      */
     @Import(name="subnetSpecs")
     private @Nullable List<SubnetSpecArgs> subnetSpecs;
 
     /**
-     * @return A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+     * @return A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
      * 
      */
     public Optional<List<SubnetSpecArgs>> subnetSpecs() {
@@ -619,7 +619,7 @@ public final class VpcArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param subnetSpecs A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+         * @param subnetSpecs A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
          * 
          * @return builder
          * 
@@ -630,7 +630,7 @@ public final class VpcArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param subnetSpecs A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+         * @param subnetSpecs A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/ec2/vpc.ts
+++ b/sdk/nodejs/ec2/vpc.ts
@@ -191,7 +191,7 @@ export interface VpcArgs {
      */
     numberOfAvailabilityZones?: number;
     /**
-     * A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+     * A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
      */
     subnetSpecs?: inputs.ec2.SubnetSpecArgs[];
     /**

--- a/sdk/python/pulumi_awsx/ec2/vpc.py
+++ b/sdk/python/pulumi_awsx/ec2/vpc.py
@@ -52,7 +52,7 @@ class VpcArgs:
         :param pulumi.Input[int] ipv6_netmask_length: Netmask length to request from IPAM Pool. Conflicts with `ipv6_cidr_block`. This can be omitted if IPAM pool as a `allocation_default_netmask_length` set. Valid values: `56`.
         :param 'NatGatewayConfigurationArgs' nat_gateways: Configuration for NAT Gateways. Optional. If private and public subnets are both specified, defaults to one gateway per availability zone. Otherwise, no gateways will be created.
         :param int number_of_availability_zones: A number of availability zones to which the subnets defined in subnetSpecs will be deployed. Optional, defaults to the first 3 AZs in the current region.
-        :param Sequence['SubnetSpecArgs'] subnet_specs: A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+        :param Sequence['SubnetSpecArgs'] subnet_specs: A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param Sequence['VpcEndpointSpecArgs'] vpc_endpoint_specs: A list of VPC Endpoints specs to be deployed as part of the VPC
         """
@@ -320,7 +320,7 @@ class VpcArgs:
     @pulumi.getter(name="subnetSpecs")
     def subnet_specs(self) -> Optional[Sequence['SubnetSpecArgs']]:
         """
-        A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+        A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
         """
         return pulumi.get(self, "subnet_specs")
 
@@ -396,7 +396,7 @@ class Vpc(pulumi.ComponentResource):
         :param pulumi.Input[int] ipv6_netmask_length: Netmask length to request from IPAM Pool. Conflicts with `ipv6_cidr_block`. This can be omitted if IPAM pool as a `allocation_default_netmask_length` set. Valid values: `56`.
         :param pulumi.InputType['NatGatewayConfigurationArgs'] nat_gateways: Configuration for NAT Gateways. Optional. If private and public subnets are both specified, defaults to one gateway per availability zone. Otherwise, no gateways will be created.
         :param int number_of_availability_zones: A number of availability zones to which the subnets defined in subnetSpecs will be deployed. Optional, defaults to the first 3 AZs in the current region.
-        :param Sequence[pulumi.InputType['SubnetSpecArgs']] subnet_specs: A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC.
+        :param Sequence[pulumi.InputType['SubnetSpecArgs']] subnet_specs: A list of subnet specs that should be deployed to each AZ specified in availabilityZoneNames. Optional. Defaults to a (smaller) public subnet and a (larger) private subnet based on the size of the CIDR block for the VPC. Private subnets are allocated CIDR block ranges first, followed by Private subnets, and Isolated subnets are allocated last.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A map of tags to assign to the resource. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         :param Sequence[pulumi.InputType['VpcEndpointSpecArgs']] vpc_endpoint_specs: A list of VPC Endpoints specs to be deployed as part of the VPC
         """


### PR DESCRIPTION
Fix a bug in the subnet distributor which causes CIDR blocks to be generated where the blocks overlap with one another - causing an undeployable configuration.

Generate 100 test cases of known working subnet configurations to ensure we don't change the ouput for existing deployments. We **only** want to change the behaviour for cases which current cause overlaps.

Combine the old broken allocation method with an additional check for overlapping the previous block. If there's an overlap, then use the new strategy. This avoids affecting anyone who's already got a working deployment. Using only the new method sometimes generates more compact arrangements hence causing breaking changes.

- This is stacked on top of https://github.com/pulumi/pulumi-awsx/pull/1130
- Fixes #982 