### PR TITLE
Use imageName for the docker image

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -81,7 +81,7 @@ export function computeImageFromAsset(
     registry: registryCredentials,
   };
 
-  const image = new docker.Image(`image`, dockerImageArgs, { parent });
+  const image = new docker.Image(imageName, dockerImageArgs, { parent });
 
   image.repoDigest.apply((d: any) =>
     pulumi.log.debug(`    build complete: ${imageName} (${d})`, parent),


### PR DESCRIPTION
When attempting to build and push multiple docker images to ECR I was getting a duplicate resource name issue.

This appeared to be because the docker build was always using a name of "index".

Using the created imageName variable has fixed my issue and seems a better solution that the fixed name of "index"