### PR TITLE
Revert "Ensure the resource name uses the uniquely generated name to avoid conflicts (#1126)"

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -81,7 +81,7 @@ export function computeImageFromAsset(
     registry: registryCredentials,
   };
 
-  const image = new docker.Image(imageName, dockerImageArgs, { parent });
+  const image = new docker.Image(`image`, dockerImageArgs, { parent });
 
   image.repoDigest.apply((d: any) =>
     pulumi.log.debug(`    build complete: ${imageName} (${d})`, parent),


### PR DESCRIPTION
This PR was merged prematurely. As is, it would cause existing image resources to be replaced due to the name change.

This reverts commit 43bb1447a20e804f6f7015df00ea8e26d8625aa9.
