### PR TITLE
Revert "Revert "Ensure the resource name uses the uniquely generated name to avoid conflicts (#1126)" (#1141)"

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -81,7 +81,7 @@ export function computeImageFromAsset(
     registry: registryCredentials,
   };
 
-  const image = new docker.Image(`image`, dockerImageArgs, { parent });
+  const image = new docker.Image(imageName, dockerImageArgs, { parent });
 
   image.repoDigest.apply((d: any) =>
     pulumi.log.debug(`    build complete: ${imageName} (${d})`, parent),


### PR DESCRIPTION
This reverts commit af69664ec8c6a46edfdbd4cca079d3c652381015.

Revive PR #1126 by @JoeStead since it was actually sound. The hard-coded image name was only introduced in v2, so backwards compatibility is not a concern.
