### PR TITLE
Remove awsx.Ecr.ImageArgs.extraOptions

### DIFF
--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -112,7 +112,6 @@ export interface ImageArgs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
-    readonly extraOptions?: pulumi.Input<pulumi.Input<string>[]>;
     readonly platform?: pulumi.Input<string>;
     readonly repositoryUrl: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
@@ -639,7 +638,6 @@ export interface DockerBuildInputs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
-    readonly extraOptions?: pulumi.Input<pulumi.Input<string>[]>;
     readonly platform?: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
 }
@@ -649,7 +647,6 @@ export interface DockerBuildOutputs {
     readonly cacheFrom?: pulumi.Output<string[]>;
     readonly context?: pulumi.Output<string>;
     readonly dockerfile?: pulumi.Output<string>;
-    readonly extraOptions?: pulumi.Output<string[]>;
     readonly platform?: pulumi.Output<string>;
     readonly target?: pulumi.Output<string>;
 }

--- a/schema.json
+++ b/schema.json
@@ -799,13 +799,6 @@
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
                 },
-                "extraOptions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`."
-                },
                 "platform": {
                     "type": "string",
                     "description": "The architecture of the platform you want to build this image for, e.g. `linux/arm64`."
@@ -2153,13 +2146,6 @@
                 "dockerfile": {
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
-                },
-                "extraOptions": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`."
                 },
                 "platform": {
                     "type": "string",

--- a/schemagen/pkg/gen/ecr.go
+++ b/schemagen/pkg/gen/ecr.go
@@ -274,15 +274,6 @@ func dockerBuildProperties(dockerSpec schema.PackageSpec) map[string]schema.Prop
 				Type: "string",
 			},
 		},
-		"extraOptions": {
-			Description: "An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.",
-			TypeSpec: schema.TypeSpec{
-				Type: "array",
-				Items: &schema.TypeSpec{
-					Type: "string",
-				},
-			},
-		},
 		"platform": {
 			Description: "The architecture of the platform you want to build this image for, e.g. `linux/arm64`.",
 			TypeSpec: schema.TypeSpec{

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -91,18 +91,6 @@ namespace Pulumi.Awsx.Ecr
         [Input("dockerfile")]
         public Input<string>? Dockerfile { get; set; }
 
-        [Input("extraOptions")]
-        private InputList<string>? _extraOptions;
-
-        /// <summary>
-        /// An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-        /// </summary>
-        public InputList<string> ExtraOptions
-        {
-            get => _extraOptions ?? (_extraOptions = new InputList<string>());
-            set => _extraOptions = value;
-        }
-
         /// <summary>
         /// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         /// </summary>

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -51,8 +51,6 @@ type imageArgs struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
-	// An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-	ExtraOptions []string `pulumi:"extraOptions"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform *string `pulumi:"platform"`
 	// Url of the repository
@@ -73,8 +71,6 @@ type ImageArgs struct {
 	Context pulumi.StringPtrInput
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile pulumi.StringPtrInput
-	// An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-	ExtraOptions pulumi.StringArrayInput
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform pulumi.StringPtrInput
 	// Url of the repository

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -26,8 +26,6 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
-	// An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-	ExtraOptions []string `pulumi:"extraOptions"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform *string `pulumi:"platform"`
 	// The target of the dockerfile to build

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -94,21 +94,6 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `[&#39;--network&#39;, &#39;host&#39;]`.
-     * 
-     */
-    @Import(name="extraOptions")
-    private @Nullable Output<List<String>> extraOptions;
-
-    /**
-     * @return An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `[&#39;--network&#39;, &#39;host&#39;]`.
-     * 
-     */
-    public Optional<Output<List<String>>> extraOptions() {
-        return Optional.ofNullable(this.extraOptions);
-    }
-
-    /**
      * The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
      * 
      */
@@ -161,7 +146,6 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
-        this.extraOptions = $.extraOptions;
         this.platform = $.platform;
         this.repositoryUrl = $.repositoryUrl;
         this.target = $.target;
@@ -288,37 +272,6 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
-        }
-
-        /**
-         * @param extraOptions An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `[&#39;--network&#39;, &#39;host&#39;]`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(@Nullable Output<List<String>> extraOptions) {
-            $.extraOptions = extraOptions;
-            return this;
-        }
-
-        /**
-         * @param extraOptions An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `[&#39;--network&#39;, &#39;host&#39;]`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(List<String> extraOptions) {
-            return extraOptions(Output.of(extraOptions));
-        }
-
-        /**
-         * @param extraOptions An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `[&#39;--network&#39;, &#39;host&#39;]`.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder extraOptions(String... extraOptions) {
-            return extraOptions(List.of(extraOptions));
         }
 
         /**

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -49,7 +49,6 @@ export class Image extends pulumi.ComponentResource {
             resourceInputs["cacheFrom"] = args ? args.cacheFrom : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["dockerfile"] = args ? args.dockerfile : undefined;
-            resourceInputs["extraOptions"] = args ? args.extraOptions : undefined;
             resourceInputs["platform"] = args ? args.platform : undefined;
             resourceInputs["repositoryUrl"] = args ? args.repositoryUrl : undefined;
             resourceInputs["target"] = args ? args.target : undefined;
@@ -86,10 +85,6 @@ export interface ImageArgs {
      * dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
      */
     dockerfile?: pulumi.Input<string>;
-    /**
-     * An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-     */
-    extraOptions?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
      */

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -21,7 +21,6 @@ class ImageArgs:
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
-                 extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
@@ -32,7 +31,6 @@ class ImageArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] extra_options: An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] target: The target of the dockerfile to build
         """
@@ -47,8 +45,6 @@ class ImageArgs:
             pulumi.set(__self__, "context", context)
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
-        if extra_options is not None:
-            pulumi.set(__self__, "extra_options", extra_options)
         if platform is not None:
             pulumi.set(__self__, "platform", platform)
         if target is not None:
@@ -127,18 +123,6 @@ class ImageArgs:
         pulumi.set(self, "dockerfile", value)
 
     @property
-    @pulumi.getter(name="extraOptions")
-    def extra_options(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
-        """
-        An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
-        """
-        return pulumi.get(self, "extra_options")
-
-    @extra_options.setter
-    def extra_options(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
-        pulumi.set(self, "extra_options", value)
-
-    @property
     @pulumi.getter
     def platform(self) -> Optional[pulumi.Input[str]]:
         """
@@ -173,7 +157,6 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
-                 extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
@@ -188,7 +171,6 @@ class Image(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] extra_options: An optional catch-all list of arguments to provide extra CLI options to the docker build command.  For example `['--network', 'host']`.
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] repository_url: Url of the repository
         :param pulumi.Input[str] target: The target of the dockerfile to build
@@ -222,7 +204,6 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
-                 extra_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
@@ -242,7 +223,6 @@ class Image(pulumi.ComponentResource):
             __props__.__dict__["cache_from"] = cache_from
             __props__.__dict__["context"] = context
             __props__.__dict__["dockerfile"] = dockerfile
-            __props__.__dict__["extra_options"] = extra_options
             __props__.__dict__["platform"] = platform
             if repository_url is None and not opts.urn:
                 raise TypeError("Missing required property 'repository_url'")


### PR DESCRIPTION
This would be a breaking change, but this argument is already not
working anymore since it was removed from the underlying Docker provider,
see pulumi/pulumi-docker#424.

Part of #1148
