### PR TITLE
Add imageTag parameter to ecr image resource v2

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -30,14 +30,14 @@ export function computeImageFromAsset(
   args: pulumi.Unwrap<schema.ImageArgs>,
   parent: pulumi.Resource,
 ) {
-  const { repositoryUrl, ...dockerInputs } = args ?? {};
+  const { repositoryUrl, imageTag, ...dockerInputs } = args ?? {};
 
   const url = new URL("https://" + repositoryUrl); // Add protocol to help it parse
   const registryId = url.hostname.split(".")[0];
 
   pulumi.log.debug(`Building container image at '${JSON.stringify(dockerInputs)}'`, parent);
 
-  const imageName = createUniqueImageName(dockerInputs);
+  const imageName = imageTag ? imageTag : createUniqueImageName(dockerInputs);
   // Note: the tag, if provided, is included in the image name.
   const canonicalImageName = `${repositoryUrl}:${imageName}`;
 

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -115,6 +115,7 @@ export interface ImageArgs {
     readonly platform?: pulumi.Input<string>;
     readonly repositoryUrl: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
+    readonly imageTag?: pulumi.Input<string>;
 }
 export abstract class Repository<TData = any> extends (pulumi.ComponentResource)<TData> {
     public lifecyclePolicy?: aws.ecr.LifecyclePolicy | pulumi.Output<aws.ecr.LifecyclePolicy>;

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -112,10 +112,10 @@ export interface ImageArgs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
+    readonly imageTag?: pulumi.Input<string>;
     readonly platform?: pulumi.Input<string>;
     readonly repositoryUrl: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
-    readonly imageTag?: pulumi.Input<string>;
 }
 export abstract class Repository<TData = any> extends (pulumi.ComponentResource)<TData> {
     public lifecyclePolicy?: aws.ecr.LifecyclePolicy | pulumi.Output<aws.ecr.LifecyclePolicy>;
@@ -639,6 +639,7 @@ export interface DockerBuildInputs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
+    readonly imageTag?: pulumi.Input<string>;
     readonly platform?: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
 }
@@ -648,6 +649,7 @@ export interface DockerBuildOutputs {
     readonly cacheFrom?: pulumi.Output<string[]>;
     readonly context?: pulumi.Output<string>;
     readonly dockerfile?: pulumi.Output<string>;
+    readonly imageTag?: pulumi.Output<string>;
     readonly platform?: pulumi.Output<string>;
     readonly target?: pulumi.Output<string>;
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -104,7 +104,7 @@
     },
     "python3@3.9": {
       "last_modified": "2022-09-12T23:24:01Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/994df04c3c700fe9edb1b69b82ba3c627e5e04ff#python39",
       "source": "devbox-search",
       "version": "3.9.13",

--- a/schema.json
+++ b/schema.json
@@ -802,6 +802,10 @@
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
                 },
+                "imageTag": {
+                    "type": "string",
+                    "description": "Custom image tag for the resulting docker image. If omitted a random string will be used"
+                },
                 "platform": {
                     "type": "string",
                     "description": "The architecture of the platform you want to build this image for, e.g. `linux/arm64`."
@@ -2149,6 +2153,10 @@
                 "dockerfile": {
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
+                },
+                "imageTag": {
+                    "type": "string",
+                    "description": "Custom image tag for the resulting docker image. If omitted a random string will be used"
                 },
                 "platform": {
                     "type": "string",

--- a/schemagen/pkg/gen/ecr.go
+++ b/schemagen/pkg/gen/ecr.go
@@ -274,6 +274,12 @@ func dockerBuildProperties(dockerSpec schema.PackageSpec) map[string]schema.Prop
 				Type: "string",
 			},
 		},
+		"imageTag": {
+			Description: "Custom image tag for the resulting docker image. If omitted a random string will be used",
+			TypeSpec: schema.TypeSpec{
+				Type: "string",
+			},
+		},
 		"platform": {
 			Description: "The architecture of the platform you want to build this image for, e.g. `linux/arm64`.",
 			TypeSpec: schema.TypeSpec{

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -92,6 +92,12 @@ namespace Pulumi.Awsx.Ecr
         public Input<string>? Dockerfile { get; set; }
 
         /// <summary>
+        /// Custom image tag for the resulting docker image. If omitted a random string will be used
+        /// </summary>
+        [Input("imageTag")]
+        public Input<string>? ImageTag { get; set; }
+
+        /// <summary>
         /// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         /// </summary>
         [Input("platform")]

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -51,6 +51,8 @@ type imageArgs struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
+	// Custom image tag for the resulting docker image. If omitted a random string will be used
+	ImageTag *string `pulumi:"imageTag"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform *string `pulumi:"platform"`
 	// Url of the repository
@@ -71,6 +73,8 @@ type ImageArgs struct {
 	Context pulumi.StringPtrInput
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile pulumi.StringPtrInput
+	// Custom image tag for the resulting docker image. If omitted a random string will be used
+	ImageTag pulumi.StringPtrInput
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform pulumi.StringPtrInput
 	// Url of the repository

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -26,6 +26,8 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
+	// Custom image tag for the resulting docker image. If omitted a random string will be used
+	ImageTag *string `pulumi:"imageTag"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform *string `pulumi:"platform"`
 	// The target of the dockerfile to build

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -94,6 +94,21 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Custom image tag for the resulting docker image. If omitted a random string will be used
+     * 
+     */
+    @Import(name="imageTag")
+    private @Nullable Output<String> imageTag;
+
+    /**
+     * @return Custom image tag for the resulting docker image. If omitted a random string will be used
+     * 
+     */
+    public Optional<Output<String>> imageTag() {
+        return Optional.ofNullable(this.imageTag);
+    }
+
+    /**
      * The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
      * 
      */
@@ -146,6 +161,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
+        this.imageTag = $.imageTag;
         this.platform = $.platform;
         this.repositoryUrl = $.repositoryUrl;
         this.target = $.target;
@@ -272,6 +288,27 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
+        }
+
+        /**
+         * @param imageTag Custom image tag for the resulting docker image. If omitted a random string will be used
+         * 
+         * @return builder
+         * 
+         */
+        public Builder imageTag(@Nullable Output<String> imageTag) {
+            $.imageTag = imageTag;
+            return this;
+        }
+
+        /**
+         * @param imageTag Custom image tag for the resulting docker image. If omitted a random string will be used
+         * 
+         * @return builder
+         * 
+         */
+        public Builder imageTag(String imageTag) {
+            return imageTag(Output.of(imageTag));
         }
 
         /**

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -49,6 +49,7 @@ export class Image extends pulumi.ComponentResource {
             resourceInputs["cacheFrom"] = args ? args.cacheFrom : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["dockerfile"] = args ? args.dockerfile : undefined;
+            resourceInputs["imageTag"] = args ? args.imageTag : undefined;
             resourceInputs["platform"] = args ? args.platform : undefined;
             resourceInputs["repositoryUrl"] = args ? args.repositoryUrl : undefined;
             resourceInputs["target"] = args ? args.target : undefined;
@@ -85,6 +86,10 @@ export interface ImageArgs {
      * dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
      */
     dockerfile?: pulumi.Input<string>;
+    /**
+     * Custom image tag for the resulting docker image. If omitted a random string will be used
+     */
+    imageTag?: pulumi.Input<string>;
     /**
      * The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
      */

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -21,6 +21,7 @@ class ImageArgs:
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
@@ -31,6 +32,7 @@ class ImageArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
+        :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] target: The target of the dockerfile to build
         """
@@ -45,6 +47,8 @@ class ImageArgs:
             pulumi.set(__self__, "context", context)
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
+        if image_tag is not None:
+            pulumi.set(__self__, "image_tag", image_tag)
         if platform is not None:
             pulumi.set(__self__, "platform", platform)
         if target is not None:
@@ -123,6 +127,18 @@ class ImageArgs:
         pulumi.set(self, "dockerfile", value)
 
     @property
+    @pulumi.getter(name="imageTag")
+    def image_tag(self) -> Optional[pulumi.Input[str]]:
+        """
+        Custom image tag for the resulting docker image. If omitted a random string will be used
+        """
+        return pulumi.get(self, "image_tag")
+
+    @image_tag.setter
+    def image_tag(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "image_tag", value)
+
+    @property
     @pulumi.getter
     def platform(self) -> Optional[pulumi.Input[str]]:
         """
@@ -157,6 +173,7 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
@@ -171,6 +188,7 @@ class Image(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
+        :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] repository_url: Url of the repository
         :param pulumi.Input[str] target: The target of the dockerfile to build
@@ -204,6 +222,7 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
@@ -223,6 +242,7 @@ class Image(pulumi.ComponentResource):
             __props__.__dict__["cache_from"] = cache_from
             __props__.__dict__["context"] = context
             __props__.__dict__["dockerfile"] = dockerfile
+            __props__.__dict__["image_tag"] = image_tag
             __props__.__dict__["platform"] = platform
             if repository_url is None and not opts.urn:
                 raise TypeError("Missing required property 'repository_url'")


### PR DESCRIPTION
Duplicate of https://github.com/pulumi/pulumi-awsx/pull/1225
Forked from a personal account to enable "Allow edits by maintainers"

> This PR aims to solve issue https://github.com/pulumi/pulumi-awsx/issues/1224
Adds the imageTag parameter to the Image resource.
The parameter is optional, if omitted the existing logic is used.