### PR TITLE
Support ECR images on localstack

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -30,10 +30,10 @@ export function computeImageFromAsset(
   args: pulumi.Unwrap<schema.ImageArgs>,
   parent: pulumi.Resource,
 ) {
-  const { repositoryUrl, imageTag, ...dockerInputs } = args ?? {};
+  const { repositoryUrl, registryId : inputRegistryId, imageTag, ...dockerInputs } = args ?? {};
 
   const url = new URL("https://" + repositoryUrl); // Add protocol to help it parse
-  const registryId = url.hostname.split(".")[0];
+  const registryId = inputRegistryId ?? url.hostname.split(".")[0];
 
   pulumi.log.debug(`Building container image at '${JSON.stringify(dockerInputs)}'`, parent);
 

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -116,6 +116,7 @@ export interface ImageArgs {
     readonly platform?: pulumi.Input<string>;
     readonly repositoryUrl: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
+    readonly registryId?: pulumi.Input<string>;
 }
 export abstract class Repository<TData = any> extends (pulumi.ComponentResource)<TData> {
     public lifecyclePolicy?: aws.ecr.LifecyclePolicy | pulumi.Output<aws.ecr.LifecyclePolicy>;

--- a/schema.json
+++ b/schema.json
@@ -2162,6 +2162,10 @@
                     "type": "string",
                     "description": "The architecture of the platform you want to build this image for, e.g. `linux/arm64`."
                 },
+                "registryId": {
+                    "type": "string",
+                    "description": "ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)"
+                },
                 "repositoryUrl": {
                     "type": "string",
                     "description": "Url of the repository"

--- a/schemagen/pkg/gen/ecr.go
+++ b/schemagen/pkg/gen/ecr.go
@@ -186,6 +186,12 @@ func ecrImage(awsSpec schema.PackageSpec, dockerSpec schema.PackageSpec) schema.
 			Type: "string",
 		},
 	}
+	inputs["registryId"] = schema.PropertySpec{
+		Description: "ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)",
+		TypeSpec: schema.TypeSpec{
+			Type: "string",
+		},
+	}
 	return schema.ResourceSpec{
 		IsComponent:     true,
 		InputProperties: inputs,

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -104,6 +104,12 @@ namespace Pulumi.Awsx.Ecr
         public Input<string>? Platform { get; set; }
 
         /// <summary>
+        /// ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+        /// </summary>
+        [Input("registryId")]
+        public Input<string>? RegistryId { get; set; }
+
+        /// <summary>
         /// Url of the repository
         /// </summary>
         [Input("repositoryUrl", required: true)]

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -55,6 +55,8 @@ type imageArgs struct {
 	ImageTag *string `pulumi:"imageTag"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform *string `pulumi:"platform"`
+	// ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+	RegistryId *string `pulumi:"registryId"`
 	// Url of the repository
 	RepositoryUrl string `pulumi:"repositoryUrl"`
 	// The target of the dockerfile to build
@@ -77,6 +79,8 @@ type ImageArgs struct {
 	ImageTag pulumi.StringPtrInput
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
 	Platform pulumi.StringPtrInput
+	// ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+	RegistryId pulumi.StringPtrInput
 	// Url of the repository
 	RepositoryUrl pulumi.StringInput
 	// The target of the dockerfile to build

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -124,6 +124,21 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+     * 
+     */
+    @Import(name="registryId")
+    private @Nullable Output<String> registryId;
+
+    /**
+     * @return ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+     * 
+     */
+    public Optional<Output<String>> registryId() {
+        return Optional.ofNullable(this.registryId);
+    }
+
+    /**
      * Url of the repository
      * 
      */
@@ -163,6 +178,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.dockerfile = $.dockerfile;
         this.imageTag = $.imageTag;
         this.platform = $.platform;
+        this.registryId = $.registryId;
         this.repositoryUrl = $.repositoryUrl;
         this.target = $.target;
     }
@@ -330,6 +346,27 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder platform(String platform) {
             return platform(Output.of(platform));
+        }
+
+        /**
+         * @param registryId ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+         * 
+         * @return builder
+         * 
+         */
+        public Builder registryId(@Nullable Output<String> registryId) {
+            $.registryId = registryId;
+            return this;
+        }
+
+        /**
+         * @param registryId ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+         * 
+         * @return builder
+         * 
+         */
+        public Builder registryId(String registryId) {
+            return registryId(Output.of(registryId));
         }
 
         /**

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -51,6 +51,7 @@ export class Image extends pulumi.ComponentResource {
             resourceInputs["dockerfile"] = args ? args.dockerfile : undefined;
             resourceInputs["imageTag"] = args ? args.imageTag : undefined;
             resourceInputs["platform"] = args ? args.platform : undefined;
+            resourceInputs["registryId"] = args ? args.registryId : undefined;
             resourceInputs["repositoryUrl"] = args ? args.repositoryUrl : undefined;
             resourceInputs["target"] = args ? args.target : undefined;
             resourceInputs["imageUri"] = undefined /*out*/;
@@ -94,6 +95,10 @@ export interface ImageArgs {
      * The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
      */
     platform?: pulumi.Input<string>;
+    /**
+     * ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+     */
+    registryId?: pulumi.Input<string>;
     /**
      * Url of the repository
      */

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -23,6 +23,7 @@ class ImageArgs:
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
+                 registry_id: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Image resource.
@@ -34,6 +35,7 @@ class ImageArgs:
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
         :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
+        :param pulumi.Input[str] registry_id: ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
         :param pulumi.Input[str] target: The target of the dockerfile to build
         """
         pulumi.set(__self__, "repository_url", repository_url)
@@ -51,6 +53,8 @@ class ImageArgs:
             pulumi.set(__self__, "image_tag", image_tag)
         if platform is not None:
             pulumi.set(__self__, "platform", platform)
+        if registry_id is not None:
+            pulumi.set(__self__, "registry_id", registry_id)
         if target is not None:
             pulumi.set(__self__, "target", target)
 
@@ -151,6 +155,18 @@ class ImageArgs:
         pulumi.set(self, "platform", value)
 
     @property
+    @pulumi.getter(name="registryId")
+    def registry_id(self) -> Optional[pulumi.Input[str]]:
+        """
+        ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
+        """
+        return pulumi.get(self, "registry_id")
+
+    @registry_id.setter
+    def registry_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "registry_id", value)
+
+    @property
     @pulumi.getter
     def target(self) -> Optional[pulumi.Input[str]]:
         """
@@ -175,6 +191,7 @@ class Image(pulumi.ComponentResource):
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
+                 registry_id: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -190,6 +207,7 @@ class Image(pulumi.ComponentResource):
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
         :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
+        :param pulumi.Input[str] registry_id: ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
         :param pulumi.Input[str] repository_url: Url of the repository
         :param pulumi.Input[str] target: The target of the dockerfile to build
         """
@@ -224,6 +242,7 @@ class Image(pulumi.ComponentResource):
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
+                 registry_id: Optional[pulumi.Input[str]] = None,
                  repository_url: Optional[pulumi.Input[str]] = None,
                  target: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -244,6 +263,7 @@ class Image(pulumi.ComponentResource):
             __props__.__dict__["dockerfile"] = dockerfile
             __props__.__dict__["image_tag"] = image_tag
             __props__.__dict__["platform"] = platform
+            __props__.__dict__["registry_id"] = registry_id
             if repository_url is None and not opts.urn:
                 raise TypeError("Missing required property 'repository_url'")
             __props__.__dict__["repository_url"] = repository_url


### PR DESCRIPTION
## The Issue

`aws.ecr.Image` makes assumptions about the ID of an ECR reigstry.  It assumes the registry ID [can be extracted from the repository URL](https://github.com/pulumi/pulumi-awsx/blob/9f18b3866d2a16a59d662384a0c745e2e5603463/awsx/ecr/image.ts#L36).

This assumption seems to hold true for the real AWS APIs, but I don't think AWS actually specify this behaviour in any of their documentation.

The assumption **does not** hold true for localstack, leading to [this issue](https://github.com/localstack/localstack/issues/7186).

## The Fix

This PR allows the caller to (optionally) specify a `registryId`, avoiding the inference logic mentioned above.

## Notes

I edited `awsx/schema-types.ts` by hand.  I couldn't figure out how to generate that file.