### PR TITLE
Fix order of code generation in schema-types.ts

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -30,7 +30,7 @@ export function computeImageFromAsset(
   args: pulumi.Unwrap<schema.ImageArgs>,
   parent: pulumi.Resource,
 ) {
-  const { repositoryUrl, registryId : inputRegistryId, imageTag, ...dockerInputs } = args ?? {};
+  const { repositoryUrl, registryId: inputRegistryId, imageTag, ...dockerInputs } = args ?? {};
 
   const url = new URL("https://" + repositoryUrl); // Add protocol to help it parse
   const registryId = inputRegistryId ?? url.hostname.split(".")[0];

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -114,9 +114,9 @@ export interface ImageArgs {
     readonly dockerfile?: pulumi.Input<string>;
     readonly imageTag?: pulumi.Input<string>;
     readonly platform?: pulumi.Input<string>;
+    readonly registryId?: pulumi.Input<string>;
     readonly repositoryUrl: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
-    readonly registryId?: pulumi.Input<string>;
 }
 export abstract class Repository<TData = any> extends (pulumi.ComponentResource)<TData> {
     public lifecyclePolicy?: aws.ecr.LifecyclePolicy | pulumi.Output<aws.ecr.LifecyclePolicy>;


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-awsx/issues/1244

I've ran `make build provider` locally and it had the same diff as the CI.