### PR TITLE
Add imageName param to ECR image args

### DIFF
--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -37,7 +37,9 @@ export function computeImageFromAsset(
 
   pulumi.log.debug(`Building container image at '${JSON.stringify(dockerInputs)}'`, parent);
 
-  const imageName = imageTag ? imageTag : createUniqueImageName(dockerInputs);
+  const imageName = args.imageName ? args.imageName :
+    (imageTag ? imageTag : createUniqueImageName(dockerInputs));
+
   // Note: the tag, if provided, is included in the image name.
   const canonicalImageName = `${repositoryUrl}:${imageName}`;
 

--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -37,8 +37,11 @@ export function computeImageFromAsset(
 
   pulumi.log.debug(`Building container image at '${JSON.stringify(dockerInputs)}'`, parent);
 
-  const imageName = args.imageName ? args.imageName :
-    (imageTag ? imageTag : createUniqueImageName(dockerInputs));
+  const imageName = args.imageName
+    ? args.imageName
+    : imageTag
+    ? imageTag
+    : createUniqueImageName(dockerInputs);
 
   // Note: the tag, if provided, is included in the image name.
   const canonicalImageName = `${repositoryUrl}:${imageName}`;

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -641,6 +641,7 @@ export interface DockerBuildInputs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
+    readonly imageName?: pulumi.Input<string>;
     readonly imageTag?: pulumi.Input<string>;
     readonly platform?: pulumi.Input<string>;
     readonly target?: pulumi.Input<string>;
@@ -651,6 +652,7 @@ export interface DockerBuildOutputs {
     readonly cacheFrom?: pulumi.Output<string[]>;
     readonly context?: pulumi.Output<string>;
     readonly dockerfile?: pulumi.Output<string>;
+    readonly imageName?: pulumi.Output<string>;
     readonly imageTag?: pulumi.Output<string>;
     readonly platform?: pulumi.Output<string>;
     readonly target?: pulumi.Output<string>;

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -112,6 +112,7 @@ export interface ImageArgs {
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
+    readonly imageName?: pulumi.Input<string>;
     readonly imageTag?: pulumi.Input<string>;
     readonly platform?: pulumi.Input<string>;
     readonly registryId?: pulumi.Input<string>;

--- a/schema.json
+++ b/schema.json
@@ -2154,6 +2154,10 @@
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
                 },
+                "imageName": {
+                    "type": "string",
+                    "description": "Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used"
+                },
                 "imageTag": {
                     "type": "string",
                     "description": "Custom image tag for the resulting docker image. If omitted a random string will be used"

--- a/schema.json
+++ b/schema.json
@@ -802,6 +802,10 @@
                     "type": "string",
                     "description": "dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context."
                 },
+                "imageName": {
+                    "type": "string",
+                    "description": "Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used"
+                },
                 "imageTag": {
                     "type": "string",
                     "description": "Custom image tag for the resulting docker image. If omitted a random string will be used"

--- a/schemagen/pkg/gen/ecr.go
+++ b/schemagen/pkg/gen/ecr.go
@@ -281,7 +281,7 @@ func dockerBuildProperties(dockerSpec schema.PackageSpec) map[string]schema.Prop
 			},
 		},
 		"imageName": {
-           Description: "Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used",
+			Description: "Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used",
 			TypeSpec: schema.TypeSpec{
 				Type: "string",
 			},

--- a/schemagen/pkg/gen/ecr.go
+++ b/schemagen/pkg/gen/ecr.go
@@ -280,6 +280,12 @@ func dockerBuildProperties(dockerSpec schema.PackageSpec) map[string]schema.Prop
 				Type: "string",
 			},
 		},
+		"imageName": {
+           Description: "Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used",
+			TypeSpec: schema.TypeSpec{
+				Type: "string",
+			},
+		},
 		"imageTag": {
 			Description: "Custom image tag for the resulting docker image. If omitted a random string will be used",
 			TypeSpec: schema.TypeSpec{

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -92,6 +92,12 @@ namespace Pulumi.Awsx.Ecr
         public Input<string>? Dockerfile { get; set; }
 
         /// <summary>
+        /// Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+        /// </summary>
+        [Input("imageName")]
+        public Input<string>? ImageName { get; set; }
+
+        /// <summary>
         /// Custom image tag for the resulting docker image. If omitted a random string will be used
         /// </summary>
         [Input("imageTag")]

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -51,6 +51,8 @@ type imageArgs struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
+	// Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+	ImageName *string `pulumi:"imageName"`
 	// Custom image tag for the resulting docker image. If omitted a random string will be used
 	ImageTag *string `pulumi:"imageTag"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
@@ -75,6 +77,8 @@ type ImageArgs struct {
 	Context pulumi.StringPtrInput
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile pulumi.StringPtrInput
+	// Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+	ImageName pulumi.StringPtrInput
 	// Custom image tag for the resulting docker image. If omitted a random string will be used
 	ImageTag pulumi.StringPtrInput
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -26,6 +26,8 @@ type DockerBuild struct {
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
 	Dockerfile *string `pulumi:"dockerfile"`
+	// Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+	ImageName *string `pulumi:"imageName"`
 	// Custom image tag for the resulting docker image. If omitted a random string will be used
 	ImageTag *string `pulumi:"imageTag"`
 	// The architecture of the platform you want to build this image for, e.g. `linux/arm64`.

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -94,6 +94,21 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+     * 
+     */
+    @Import(name="imageName")
+    private @Nullable Output<String> imageName;
+
+    /**
+     * @return Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+     * 
+     */
+    public Optional<Output<String>> imageName() {
+        return Optional.ofNullable(this.imageName);
+    }
+
+    /**
      * Custom image tag for the resulting docker image. If omitted a random string will be used
      * 
      */
@@ -176,6 +191,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.cacheFrom = $.cacheFrom;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
+        this.imageName = $.imageName;
         this.imageTag = $.imageTag;
         this.platform = $.platform;
         this.registryId = $.registryId;
@@ -304,6 +320,27 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder dockerfile(String dockerfile) {
             return dockerfile(Output.of(dockerfile));
+        }
+
+        /**
+         * @param imageName Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+         * 
+         * @return builder
+         * 
+         */
+        public Builder imageName(@Nullable Output<String> imageName) {
+            $.imageName = imageName;
+            return this;
+        }
+
+        /**
+         * @param imageName Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+         * 
+         * @return builder
+         * 
+         */
+        public Builder imageName(String imageName) {
+            return imageName(Output.of(imageName));
         }
 
         /**

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -49,6 +49,7 @@ export class Image extends pulumi.ComponentResource {
             resourceInputs["cacheFrom"] = args ? args.cacheFrom : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["dockerfile"] = args ? args.dockerfile : undefined;
+            resourceInputs["imageName"] = args ? args.imageName : undefined;
             resourceInputs["imageTag"] = args ? args.imageTag : undefined;
             resourceInputs["platform"] = args ? args.platform : undefined;
             resourceInputs["registryId"] = args ? args.registryId : undefined;
@@ -87,6 +88,10 @@ export interface ImageArgs {
      * dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
      */
     dockerfile?: pulumi.Input<string>;
+    /**
+     * Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+     */
+    imageName?: pulumi.Input<string>;
     /**
      * Custom image tag for the resulting docker image. If omitted a random string will be used
      */

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -21,6 +21,7 @@ class ImageArgs:
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_name: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  registry_id: Optional[pulumi.Input[str]] = None,
@@ -33,6 +34,7 @@ class ImageArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
+        :param pulumi.Input[str] image_name: Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
         :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] registry_id: ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
@@ -49,6 +51,8 @@ class ImageArgs:
             pulumi.set(__self__, "context", context)
         if dockerfile is not None:
             pulumi.set(__self__, "dockerfile", dockerfile)
+        if image_name is not None:
+            pulumi.set(__self__, "image_name", image_name)
         if image_tag is not None:
             pulumi.set(__self__, "image_tag", image_tag)
         if platform is not None:
@@ -131,6 +135,18 @@ class ImageArgs:
         pulumi.set(self, "dockerfile", value)
 
     @property
+    @pulumi.getter(name="imageName")
+    def image_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
+        """
+        return pulumi.get(self, "image_name")
+
+    @image_name.setter
+    def image_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "image_name", value)
+
+    @property
     @pulumi.getter(name="imageTag")
     def image_tag(self) -> Optional[pulumi.Input[str]]:
         """
@@ -189,6 +205,7 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_name: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  registry_id: Optional[pulumi.Input[str]] = None,
@@ -205,6 +222,7 @@ class Image(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
+        :param pulumi.Input[str] image_name: Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
         :param pulumi.Input[str] image_tag: Custom image tag for the resulting docker image. If omitted a random string will be used
         :param pulumi.Input[str] platform: The architecture of the platform you want to build this image for, e.g. `linux/arm64`.
         :param pulumi.Input[str] registry_id: ID of the ECR registry in which to store the image.  If not provided, this will be inferred from the repository URL)
@@ -240,6 +258,7 @@ class Image(pulumi.ComponentResource):
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
+                 image_name: Optional[pulumi.Input[str]] = None,
                  image_tag: Optional[pulumi.Input[str]] = None,
                  platform: Optional[pulumi.Input[str]] = None,
                  registry_id: Optional[pulumi.Input[str]] = None,
@@ -261,6 +280,7 @@ class Image(pulumi.ComponentResource):
             __props__.__dict__["cache_from"] = cache_from
             __props__.__dict__["context"] = context
             __props__.__dict__["dockerfile"] = dockerfile
+            __props__.__dict__["image_name"] = image_name
             __props__.__dict__["image_tag"] = image_tag
             __props__.__dict__["platform"] = platform
             __props__.__dict__["registry_id"] = registry_id


### PR DESCRIPTION
Fixes #1171

This allows the user to manually choose the name of the underlying Pulumi Docker image resource

When not defined it will fall back to the original behavior (use the image tag as the name of the underlying resource)