### PR TITLE
fix: targetGroup errors appear in containerDefinition diff

### DIFF
--- a/awsx/ecs/container.test.ts
+++ b/awsx/ecs/container.test.ts
@@ -57,7 +57,6 @@ describe("port mappings", () => {
       hostPort: 2,
       name: "test-mapping-1-2",
       protocol: "tcp",
-      targetGroup,
     });
   });
 });

--- a/awsx/ecs/containers.ts
+++ b/awsx/ecs/containers.ts
@@ -101,7 +101,9 @@ export function getMappingInputs(
   tgPort: number | undefined,
 ): schema.TaskDefinitionPortMappingInputs {
   return {
-    ...mappingInput,
+    name: mappingInput.name,
+    containerPortRange: mappingInput.containerPortRange,
+    appProtocol: mappingInput.appProtocol,
     containerPort: mappingInput.containerPort ?? mappingInput.hostPort ?? tgPort,
     hostPort: mappingInput.hostPort ?? tgPort ?? mappingInput.containerPort,
     protocol: mappingInput.protocol,

--- a/awsx/ecs/fargateTaskDefinition.ts
+++ b/awsx/ecs/fargateTaskDefinition.ts
@@ -149,7 +149,6 @@ function buildTaskDefinitionArgs(
   if (mutableArgs.memory === undefined) {
     mutableArgs.memory = requiredMemoryAndCPU.memory;
   }
-
   const containerString = containerDefinitions.apply((d) => JSON.stringify(d));
   const defaultFamily = containerString.apply(
     (s) => name + "-" + utils.sha1hash(pulumi.getStack() + s),

--- a/awsx/ecs/fargateTaskDefinition.ts
+++ b/awsx/ecs/fargateTaskDefinition.ts
@@ -150,33 +150,7 @@ function buildTaskDefinitionArgs(
     mutableArgs.memory = requiredMemoryAndCPU.memory;
   }
 
-  // containerDefinitions is of type TaskDefinitionContainerDefinitionInputs[],
-  // but this type does not match 1:1 with what the actual container definition
-  // JSON string expects. Specifically the portMappings field contains an extra
-  // `targetGroup` field which is a reference to the target group resource. We
-  // need to remove this field from the container definition JSON string,
-  // otherwise the diff will contain a lot of noise.
-  const containerString = containerDefinitions.apply((d) =>
-    JSON.stringify(
-      d.map((c) => {
-        return {
-          ...c,
-          portMappings: pulumi.output(c.portMappings).apply((mappings) => {
-            return mappings?.map((mappingInput) => {
-              return {
-                appProtocol: mappingInput.appProtocol,
-                containerPort: mappingInput.containerPort,
-                containerPortRange: mappingInput.containerPortRange,
-                hostPort: mappingInput.hostPort,
-                name: mappingInput.name,
-                protocol: mappingInput.protocol,
-              };
-            });
-          }),
-        };
-      }),
-    ),
-  );
+  const containerString = containerDefinitions.apply((d) => JSON.stringify(d));
   const defaultFamily = containerString.apply(
     (s) => name + "-" + utils.sha1hash(pulumi.getStack() + s),
   );


### PR DESCRIPTION
The [container
definition](https://www.pulumi.com/registry/packages/aws/api-docs/ecs/taskdefinition/#containerdefinitions_nodejs) property of a Task Definition is a JSON string. We do not provide types for the container definition which means it is possible to include things in that JSON string that shouldn't be there. In the case of this bug, we are including an additional `targetGroup` object in the container definition string.

To fix this, I am removing the `targetGroup` field. 

fix #1248