### PR TITLE
Skip flaky TestLbWithSubnets

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -55,6 +55,7 @@ func TestLbSimple(t *testing.T) {
 }
 
 func TestLbWithSubnets(t *testing.T) {
+	t.Skip("TODO[pulumi/pulumi-awsx#1246] flaky test but no way to increase custom timeout yet")
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			RunUpdateTest: false,


### PR DESCRIPTION
This test has been creating P1s and blocking PR verification; we are waiting on a feature fix from platform to enable increasing custom timeout. IN the meanwhile skipping it is reasonable.