### PR TITLE
Change DotNet tests to auto configure PULUMI_LOCAL_NUGET

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,7 @@ For building the SDKs:
 - `make dev` tests and build the provider and builds only the nodejs SDK
 - `make build` tests and build the provider and all SDKS
 - `make clean` removes all build artifacts ready for a clean build
+- `make install_sdks` installs all SDKs
 - `make test` runs all acceptance tests
 - `make test Test=TEST_NAME` runs a single test
 
@@ -61,3 +62,7 @@ For running Typescript examples locally:
 1. `cd examples/YOUR_EXAMPLE`
 1. `yarn && yarn link @pulumi/awsx` - install dependencies, but use local version of
 1. `PATH=~/YOUR_DEV_FOLDER/pulumi-awsx/bin/:$PATH pulumi up`
+
+### Testing DotNet locally
+When running dotnet tests locally you need to set the environment variable `PULUMI_LOCAL_NUGET` to point to the directory containing the awsx nuget package.
+For example: `PULUMI_LOCAL_NUGET=../nuget make test`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,3 @@ For running Typescript examples locally:
 1. `cd examples/YOUR_EXAMPLE`
 1. `yarn && yarn link @pulumi/awsx` - install dependencies, but use local version of
 1. `PATH=~/YOUR_DEV_FOLDER/pulumi-awsx/bin/:$PATH pulumi up`
-
-### Testing DotNet locally
-When running dotnet tests locally you need to set the environment variable `PULUMI_LOCAL_NUGET` to point to the directory containing the awsx nuget package.
-For example: `PULUMI_LOCAL_NUGET=../nuget make test`

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,8 @@ install_provider: bin/${PROVIDER}
 	rm -f ${GOBIN}/${PROVIDER}
 	cp bin/${PROVIDER} ${GOBIN}/${PROVIDER}
 
+install_sdks: install_nodejs_sdk install_python_sdk install_go_sdk install_dotnet_sdk
+
 install_nodejs_sdk: .make/build_nodejs
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 


### PR DESCRIPTION
The DotNet tests require the path to the directory containing the awsx nuget package to be set using `PULUMI_LOCAL_NUGET`. This adds functionality for automatically setting this env variable with the path to the dotnet sdk

Also added a convenience make target to install all SDKs