### PR TITLE
Standardize CI on Node 18

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
@@ -86,7 +86,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODEVERSION}}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -86,7 +86,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODEVERSION}}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
@@ -86,7 +86,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODEVERSION}}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -85,7 +85,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODEVERSION}}
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
@@ -111,7 +111,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{env.NODEVERSION}}
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Fixes recent failure of AWS Classic lint on master. Latest dependencies of pulumi/pulumi no longer work with 16.

https://github.com/pulumi/pulumi-awsx/issues/1268