### PR TITLE
Change policyArns in RoleWithPolicyArgs to accept eventual types

### DIFF
--- a/awsx/role.ts
+++ b/awsx/role.ts
@@ -91,16 +91,18 @@ export function defaultRoleWithPolicies(
 
   const role = new aws.iam.Role(name, roleArgs, opts);
 
-  const policies = args.policyArns ?
-    pulumi.Output.create(args.policyArns).apply(unwrapped =>
-      unwrapped.map(policyArn =>
-        new aws.iam.RolePolicyAttachment(
-          `${name}-${utils.sha1hash(policyArn)}`,
-          { role: role.name, policyArn },
-          opts,
+  const policies = args.policyArns
+    ? pulumi.Output.create(args.policyArns).apply((unwrapped) =>
+        unwrapped.map(
+          (policyArn) =>
+            new aws.iam.RolePolicyAttachment(
+              `${name}-${utils.sha1hash(policyArn)}`,
+              { role: role.name, policyArn },
+              opts,
+            ),
         ),
-      ),
-    ) : undefined;
+      )
+    : undefined;
 
   return { role, policies, roleArn: role.arn };
 }

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -525,7 +525,7 @@ export interface RoleWithPolicyInputs {
     readonly namePrefix?: pulumi.Input<string>;
     readonly path?: pulumi.Input<string>;
     readonly permissionsBoundary?: pulumi.Input<string>;
-    readonly policyArns?: string[];
+    readonly policyArns?: pulumi.Input<pulumi.Input<string>[]>;
     readonly tags?: pulumi.Input<Record<string, pulumi.Input<string>>>;
 }
 export interface RoleWithPolicyOutputs {
@@ -538,7 +538,7 @@ export interface RoleWithPolicyOutputs {
     readonly namePrefix?: pulumi.Output<string>;
     readonly path?: pulumi.Output<string>;
     readonly permissionsBoundary?: pulumi.Output<string>;
-    readonly policyArns?: string[];
+    readonly policyArns?: pulumi.Output<string[]>;
     readonly tags?: pulumi.Output<Record<string, string>>;
 }
 export interface SecurityGroupInputs {

--- a/schema.json
+++ b/schema.json
@@ -438,10 +438,8 @@
                 "policyArns": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "plain": true
+                        "type": "string"
                     },
-                    "plain": true,
                     "description": "ARNs of the policies to attach to the created role."
                 },
                 "tags": {

--- a/schemagen/pkg/gen/iam.go
+++ b/schemagen/pkg/gen/iam.go
@@ -75,9 +75,7 @@ func roleWithPolicyArgs(awsSpec schema.PackageSpec) schema.ComplexTypeSpec {
 			Type: "array",
 			Items: &schema.TypeSpec{
 				Type:  "string",
-				Plain: true,
 			},
-			Plain: true,
 		},
 	}
 

--- a/sdk/dotnet/Awsx/Inputs/RoleWithPolicyArgs.cs
+++ b/sdk/dotnet/Awsx/Inputs/RoleWithPolicyArgs.cs
@@ -78,14 +78,14 @@ namespace Pulumi.Awsx.Awsx.Inputs
         public Input<string>? PermissionsBoundary { get; set; }
 
         [Input("policyArns")]
-        private List<string>? _policyArns;
+        private InputList<string>? _policyArns;
 
         /// <summary>
         /// ARNs of the policies to attach to the created role.
         /// </summary>
-        public List<string> PolicyArns
+        public InputList<string> PolicyArns
         {
-            get => _policyArns ?? (_policyArns = new List<string>());
+            get => _policyArns ?? (_policyArns = new InputList<string>());
             set => _policyArns = value;
         }
 

--- a/sdk/go/awsx/awsx/pulumiTypes.go
+++ b/sdk/go/awsx/awsx/pulumiTypes.go
@@ -2129,7 +2129,7 @@ type RoleWithPolicyArgs struct {
 	// ARN of the policy that is used to set the permissions boundary for the role.
 	PermissionsBoundary pulumi.StringPtrInput `pulumi:"permissionsBoundary"`
 	// ARNs of the policies to attach to the created role.
-	PolicyArns []string `pulumi:"policyArns"`
+	PolicyArns pulumi.StringArrayInput `pulumi:"policyArns"`
 	// Key-value mapping of tags for the IAM role. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
 	Tags pulumi.StringMapInput `pulumi:"tags"`
 }

--- a/sdk/java/src/main/java/com/pulumi/awsx/awsx/inputs/RoleWithPolicyArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/awsx/inputs/RoleWithPolicyArgs.java
@@ -156,13 +156,13 @@ public final class RoleWithPolicyArgs extends com.pulumi.resources.ResourceArgs 
      * 
      */
     @Import(name="policyArns")
-    private @Nullable List<String> policyArns;
+    private @Nullable Output<List<String>> policyArns;
 
     /**
      * @return ARNs of the policies to attach to the created role.
      * 
      */
-    public Optional<List<String>> policyArns() {
+    public Optional<Output<List<String>>> policyArns() {
         return Optional.ofNullable(this.policyArns);
     }
 
@@ -412,9 +412,19 @@ public final class RoleWithPolicyArgs extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder policyArns(@Nullable List<String> policyArns) {
+        public Builder policyArns(@Nullable Output<List<String>> policyArns) {
             $.policyArns = policyArns;
             return this;
+        }
+
+        /**
+         * @param policyArns ARNs of the policies to attach to the created role.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder policyArns(List<String> policyArns) {
+            return policyArns(Output.of(policyArns));
         }
 
         /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -310,7 +310,7 @@ export namespace awsx {
         /**
          * ARNs of the policies to attach to the created role.
          */
-        policyArns?: string[];
+        policyArns?: pulumi.Input<pulumi.Input<string>[]>;
         /**
          * Key-value mapping of tags for the IAM role. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
          */

--- a/sdk/python/pulumi_awsx/awsx/_inputs.py
+++ b/sdk/python/pulumi_awsx/awsx/_inputs.py
@@ -878,7 +878,7 @@ class RoleWithPolicyArgs:
                  name_prefix: Optional[pulumi.Input[str]] = None,
                  path: Optional[pulumi.Input[str]] = None,
                  permissions_boundary: Optional[pulumi.Input[str]] = None,
-                 policy_arns: Optional[Sequence[str]] = None,
+                 policy_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Role resource and Policy attachments.
@@ -890,7 +890,7 @@ class RoleWithPolicyArgs:
         :param pulumi.Input[str] name_prefix: Creates a unique friendly name beginning with the specified prefix. Conflicts with `name`.
         :param pulumi.Input[str] path: Path to the role. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
         :param pulumi.Input[str] permissions_boundary: ARN of the policy that is used to set the permissions boundary for the role.
-        :param Sequence[str] policy_arns: ARNs of the policies to attach to the created role.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] policy_arns: ARNs of the policies to attach to the created role.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: Key-value mapping of tags for the IAM role. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
         """
         if description is not None:
@@ -1023,14 +1023,14 @@ class RoleWithPolicyArgs:
 
     @property
     @pulumi.getter(name="policyArns")
-    def policy_arns(self) -> Optional[Sequence[str]]:
+    def policy_arns(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
         ARNs of the policies to attach to the created role.
         """
         return pulumi.get(self, "policy_arns")
 
     @policy_arns.setter
-    def policy_arns(self, value: Optional[Sequence[str]]):
+    def policy_arns(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "policy_arns", value)
 
     @property


### PR DESCRIPTION
Previously the `policyArns` attribute in RoleWithPolicyArgs only accepted plain types as inputs. This forced users to use workarounds like using `apply` in order to configure policies created in the same pulumi program.
This PR changes the `policyArns` attribute from a plain string array to an nested Input array (`Input<Input<string>[]>`) to allow users to pass the whole list as well as individual elements as eventual types.

Fixes https://github.com/pulumi/pulumi-awsx/issues/1197