### PR TITLE
Add Security Group to NLBs

### DIFF
--- a/awsx/lb/applicationLoadBalancer.ts
+++ b/awsx/lb/applicationLoadBalancer.ts
@@ -117,50 +117,6 @@ export class ApplicationLoadBalancer extends schema.ApplicationLoadBalancer {
       }
     }
 
-    if (listener && listeners) {
-      throw new Error("Only one of [listener] and [listeners] can be specified");
-    }
-
-    if (!lbArgs.securityGroups && !defaultSecurityGroup?.skip) {
-      if (defaultSecurityGroup?.args && defaultSecurityGroup.securityGroupId) {
-        throw new Error(
-          "Only one of [defaultSecurityGroup] [args] or [securityGroupId] can be specified",
-        );
-      }
-      const securityGroupId = defaultSecurityGroup?.securityGroupId;
-      if (securityGroupId) {
-        lbArgs.securityGroups = [securityGroupId];
-      } else {
-        const securityGroup = new aws.ec2.SecurityGroup(
-          name,
-          defaultSecurityGroup?.args ?? {
-            // TO-DO: we default to open SG rules at this point - we should review this!
-            ingress: [
-              {
-                fromPort: 0,
-                toPort: 0,
-                protocol: "-1",
-                cidrBlocks: ["0.0.0.0/0"],
-                ipv6CidrBlocks: ["::/0"],
-              },
-            ],
-            egress: [
-              {
-                fromPort: 0,
-                toPort: 65535,
-                protocol: "tcp",
-                cidrBlocks: ["0.0.0.0/0"],
-                ipv6CidrBlocks: ["::/0"],
-              },
-            ],
-          },
-          { parent: this },
-        );
-        this.defaultSecurityGroup = securityGroup;
-        lbArgs.securityGroups = [securityGroup.id];
-      }
-    }
-
     // this is an application loadbalancer so we set this explicitly
     // we have removed this from the input properties in the schema
     lbArgs.loadBalancerType = "application";

--- a/awsx/lb/networkLoadBalancer.ts
+++ b/awsx/lb/networkLoadBalancer.ts
@@ -39,6 +39,7 @@ export class NetworkLoadBalancer extends schema.NetworkLoadBalancer {
     const {
       subnetIds,
       subnets,
+      defaultSecurityGroup,
       defaultTargetGroup,
       defaultTargetGroupPort,
       listener,
@@ -82,6 +83,26 @@ export class NetworkLoadBalancer extends schema.NetworkLoadBalancer {
     lbArgs.enableHttp2 = false;
     // idleTimeout is not valid in NLB
     lbArgs.idleTimeout = 0;
+
+    if (!lbArgs.securityGroups && !defaultSecurityGroup?.skip) {
+      if (defaultSecurityGroup?.args && defaultSecurityGroup.securityGroupId) {
+        throw new Error(
+          "Only one of [defaultSecurityGroup] [args] or [securityGroupId] can be specified",
+        );
+      }
+      const securityGroupId = defaultSecurityGroup?.securityGroupId;
+      if (securityGroupId) {
+        lbArgs.securityGroups = [securityGroupId];
+      } else {
+        const securityGroup = new aws.ec2.SecurityGroup(
+          name,
+          defaultSecurityGroup?.args ?? { vpcId: this.vpcId },
+          { parent: this },
+        );
+        this.defaultSecurityGroup = securityGroup;
+        lbArgs.securityGroups = [securityGroup.id];
+      }
+    }
 
     this.loadBalancer = new aws.lb.LoadBalancer(name, lbArgs, {
       parent: this,

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -314,12 +314,13 @@ export interface ApplicationLoadBalancerArgs {
     readonly xffHeaderProcessingMode?: pulumi.Input<string>;
 }
 export abstract class NetworkLoadBalancer<TData = any> extends (pulumi.ComponentResource)<TData> {
+    public defaultSecurityGroup?: aws.ec2.SecurityGroup | pulumi.Output<aws.ec2.SecurityGroup>;
     public defaultTargetGroup!: aws.lb.TargetGroup | pulumi.Output<aws.lb.TargetGroup>;
     public listeners?: aws.lb.Listener[] | pulumi.Output<aws.lb.Listener[]>;
     public loadBalancer!: aws.lb.LoadBalancer | pulumi.Output<aws.lb.LoadBalancer>;
     public vpcId?: string | pulumi.Output<string>;
     constructor(name: string, args: pulumi.Inputs, opts: pulumi.ComponentResourceOptions = {}) {
-        super("awsx:lb:NetworkLoadBalancer", name, opts.urn ? { defaultTargetGroup: undefined, listeners: undefined, loadBalancer: undefined, vpcId: undefined } : { name, args, opts }, opts);
+        super("awsx:lb:NetworkLoadBalancer", name, opts.urn ? { defaultSecurityGroup: undefined, defaultTargetGroup: undefined, listeners: undefined, loadBalancer: undefined, vpcId: undefined } : { name, args, opts }, opts);
     }
 }
 export interface NetworkLoadBalancerArgs {
@@ -327,6 +328,7 @@ export interface NetworkLoadBalancerArgs {
     readonly clientKeepAlive?: pulumi.Input<number>;
     readonly connectionLogs?: pulumi.Input<aws.types.input.lb.LoadBalancerConnectionLogs>;
     readonly customerOwnedIpv4Pool?: pulumi.Input<string>;
+    readonly defaultSecurityGroup?: DefaultSecurityGroupInputs;
     readonly defaultTargetGroup?: TargetGroupInputs;
     readonly defaultTargetGroupPort?: pulumi.Input<number>;
     readonly desyncMitigationMode?: pulumi.Input<string>;
@@ -346,6 +348,7 @@ export interface NetworkLoadBalancerArgs {
     readonly name?: pulumi.Input<string>;
     readonly namePrefix?: pulumi.Input<string>;
     readonly preserveHostHeader?: pulumi.Input<boolean>;
+    readonly securityGroups?: pulumi.Input<pulumi.Input<string>[]>;
     readonly subnetIds?: pulumi.Input<pulumi.Input<string>[]>;
     readonly subnetMappings?: pulumi.Input<pulumi.Input<aws.types.input.lb.LoadBalancerSubnetMapping>[]>;
     readonly subnets?: pulumi.Input<pulumi.Input<aws.ec2.Subnet>[]>;

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -90,6 +90,25 @@ func TestNlbSimple(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			RunUpdateTest: false,
 			Dir:           filepath.Join(getCwd(t), "ts-nlb-simple"),
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Verify that the NLB has a default security group
+				assert.Contains(t, stackInfo.Outputs, "securityGroupId")
+				assert.NotEmpty(t, stackInfo.Outputs["securityGroupId"])
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestNlbWithSecurityGroup(t *testing.T) {
+	test := getNodeJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			RunUpdateTest: false,
+			Dir:           filepath.Join(getCwd(t), "ts-nlb-with-security-group"),
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Verify that the NLB does not have a default security group
+				assert.NotContains(t, stackInfo.Outputs, "defaultSecurityGroupId")
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/ts-nlb-simple/index.ts
+++ b/examples/ts-nlb-simple/index.ts
@@ -2,3 +2,5 @@ import * as awsx from "@pulumi/awsx";
 
 // // Create a network load balancer.
 const lb = new awsx.lb.NetworkLoadBalancer("nginx-lb");
+
+export const securityGroupId = lb.defaultSecurityGroup;

--- a/examples/ts-nlb-with-security-group/Pulumi.yaml
+++ b/examples/ts-nlb-with-security-group/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: ts-nlb-with-security-group
+runtime: nodejs
+description: Minimal Network LoadBalancer Typescript component test

--- a/examples/ts-nlb-with-security-group/index.ts
+++ b/examples/ts-nlb-with-security-group/index.ts
@@ -1,0 +1,13 @@
+import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+
+const securityGroup = new aws.ec2.SecurityGroup(
+  "nlb-security-group",
+);
+
+// // Create a network load balancer with the security group created above
+const lb = new awsx.lb.NetworkLoadBalancer("nlb", {
+  securityGroups: [securityGroup.id]
+});
+
+export const defaultSecurityGroupId = lb.defaultSecurityGroup;

--- a/examples/ts-nlb-with-security-group/package.json
+++ b/examples/ts-nlb-with-security-group/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ts-lb-simple",
+  "devDependencies": {
+    "@types/node": "^18.0.0"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^6.0.0",
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/awsx": "latest"
+  }
+}

--- a/examples/ts-nlb-with-security-group/tsconfig.json
+++ b/examples/ts-nlb-with-security-group/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -3036,8 +3036,12 @@
             "isComponent": true
         },
         "awsx:lb:NetworkLoadBalancer": {
-            "description": "Provides a Network Load Balancer resource with listeners and default target group.",
+            "description": "Provides a Network Load Balancer resource with listeners, default target group and default security group.",
             "properties": {
+                "defaultSecurityGroup": {
+                    "$ref": "/aws/v6.32.0/schema.json#/resources/aws:ec2%2fsecurityGroup:SecurityGroup",
+                    "description": "Default security group, if auto-created"
+                },
                 "defaultTargetGroup": {
                     "$ref": "/aws/v6.32.0/schema.json#/resources/aws:lb%2ftargetGroup:TargetGroup",
                     "description": "Default target group, if auto-created"
@@ -3080,6 +3084,11 @@
                     "type": "string",
                     "description": "ID of the customer owned ipv4 pool to use for this load balancer.\n",
                     "willReplaceOnChanges": true
+                },
+                "defaultSecurityGroup": {
+                    "$ref": "#/types/awsx:awsx:DefaultSecurityGroup",
+                    "plain": true,
+                    "description": "Options for creating a default security group if [securityGroups] not specified."
                 },
                 "defaultTargetGroup": {
                     "$ref": "#/types/awsx:lb:TargetGroup",
@@ -3166,6 +3175,13 @@
                 "preserveHostHeader": {
                     "type": "boolean",
                     "description": "Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.\n"
+                },
+                "securityGroups": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.\n"
                 },
                 "subnetIds": {
                     "type": "array",

--- a/schemagen/pkg/gen/lb.go
+++ b/schemagen/pkg/gen/lb.go
@@ -45,8 +45,6 @@ func loadBalancer(awsSpec schema.PackageSpec, isNetworkLoadBalancer bool) schema
 	if isNetworkLoadBalancer {
 		// "enableHttp2" is only for ApplicationLoadBalancers
 		delete(inputProperties, "enableHttp2")
-		// NLBs don't allow security groups
-		delete(inputProperties, "securityGroups")
 	}
 	delete(inputProperties, "loadBalancerType")
 
@@ -61,15 +59,12 @@ func loadBalancer(awsSpec schema.PackageSpec, isNetworkLoadBalancer bool) schema
 			},
 		},
 	}
-	if !isNetworkLoadBalancer {
-		// NLBs don't allow security groups
-		inputProperties["defaultSecurityGroup"] = schema.PropertySpec{
-			Description: "Options for creating a default security group if [securityGroups] not specified.",
-			TypeSpec: schema.TypeSpec{
-				Ref:   "#/types/awsx:awsx:DefaultSecurityGroup",
-				Plain: true,
-			},
-		}
+	inputProperties["defaultSecurityGroup"] = schema.PropertySpec{
+		Description: "Options for creating a default security group if [securityGroups] not specified.",
+		TypeSpec: schema.TypeSpec{
+			Ref:   "#/types/awsx:awsx:DefaultSecurityGroup",
+			Plain: true,
+		},
 	}
 	inputProperties["defaultTargetGroup"] = schema.PropertySpec{
 		Description: "Options creating a default target group.",
@@ -139,14 +134,9 @@ func loadBalancer(awsSpec schema.PackageSpec, isNetworkLoadBalancer bool) schema
 		},
 	}
 
-	if isNetworkLoadBalancer {
-		// NLB don't have Security Groups
-		delete(outputs, "defaultSecurityGroup")
-	}
-
 	var description string
 	if isNetworkLoadBalancer {
-		description = "Provides a Network Load Balancer resource with listeners and default target group."
+		description = "Provides a Network Load Balancer resource with listeners, default target group and default security group."
 	} else {
 		description = "Provides an Application Load Balancer resource with listeners, default target group and default security group."
 	}

--- a/sdk/dotnet/Lb/NetworkLoadBalancer.cs
+++ b/sdk/dotnet/Lb/NetworkLoadBalancer.cs
@@ -10,11 +10,17 @@ using Pulumi.Serialization;
 namespace Pulumi.Awsx.Lb
 {
     /// <summary>
-    /// Provides a Network Load Balancer resource with listeners and default target group.
+    /// Provides a Network Load Balancer resource with listeners, default target group and default security group.
     /// </summary>
     [AwsxResourceType("awsx:lb:NetworkLoadBalancer")]
     public partial class NetworkLoadBalancer : global::Pulumi.ComponentResource
     {
+        /// <summary>
+        /// Default security group, if auto-created
+        /// </summary>
+        [Output("defaultSecurityGroup")]
+        public Output<Pulumi.Aws.Ec2.SecurityGroup?> DefaultSecurityGroup { get; private set; } = null!;
+
         /// <summary>
         /// Default target group, if auto-created
         /// </summary>
@@ -90,6 +96,12 @@ namespace Pulumi.Awsx.Lb
         /// </summary>
         [Input("customerOwnedIpv4Pool")]
         public Input<string>? CustomerOwnedIpv4Pool { get; set; }
+
+        /// <summary>
+        /// Options for creating a default security group if [securityGroups] not specified.
+        /// </summary>
+        [Input("defaultSecurityGroup")]
+        public Pulumi.Awsx.Awsx.Inputs.DefaultSecurityGroupArgs? DefaultSecurityGroup { get; set; }
 
         /// <summary>
         /// Options creating a default target group.
@@ -210,6 +222,18 @@ namespace Pulumi.Awsx.Lb
         /// </summary>
         [Input("preserveHostHeader")]
         public Input<bool>? PreserveHostHeader { get; set; }
+
+        [Input("securityGroups")]
+        private InputList<string>? _securityGroups;
+
+        /// <summary>
+        /// List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+        /// </summary>
+        public InputList<string> SecurityGroups
+        {
+            get => _securityGroups ?? (_securityGroups = new InputList<string>());
+            set => _securityGroups = value;
+        }
 
         [Input("subnetIds")]
         private InputList<string>? _subnetIds;

--- a/sdk/java/src/main/java/com/pulumi/awsx/lb/NetworkLoadBalancer.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/lb/NetworkLoadBalancer.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.awsx.lb;
 
+import com.pulumi.aws.ec2.SecurityGroup;
 import com.pulumi.aws.lb.Listener;
 import com.pulumi.aws.lb.LoadBalancer;
 import com.pulumi.aws.lb.TargetGroup;
@@ -18,11 +19,25 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
- * Provides a Network Load Balancer resource with listeners and default target group.
+ * Provides a Network Load Balancer resource with listeners, default target group and default security group.
  * 
  */
 @ResourceType(type="awsx:lb:NetworkLoadBalancer")
 public class NetworkLoadBalancer extends com.pulumi.resources.ComponentResource {
+    /**
+     * Default security group, if auto-created
+     * 
+     */
+    @Export(name="defaultSecurityGroup", refs={SecurityGroup.class}, tree="[0]")
+    private Output</* @Nullable */ SecurityGroup> defaultSecurityGroup;
+
+    /**
+     * @return Default security group, if auto-created
+     * 
+     */
+    public Output<Optional<SecurityGroup>> defaultSecurityGroup() {
+        return Codegen.optional(this.defaultSecurityGroup);
+    }
     /**
      * Default target group, if auto-created
      * 

--- a/sdk/java/src/main/java/com/pulumi/awsx/lb/NetworkLoadBalancerArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/lb/NetworkLoadBalancerArgs.java
@@ -7,6 +7,7 @@ import com.pulumi.aws.ec2.Subnet;
 import com.pulumi.aws.lb.inputs.LoadBalancerAccessLogsArgs;
 import com.pulumi.aws.lb.inputs.LoadBalancerConnectionLogsArgs;
 import com.pulumi.aws.lb.inputs.LoadBalancerSubnetMappingArgs;
+import com.pulumi.awsx.awsx.inputs.DefaultSecurityGroupArgs;
 import com.pulumi.awsx.lb.inputs.ListenerArgs;
 import com.pulumi.awsx.lb.inputs.TargetGroupArgs;
 import com.pulumi.core.Output;
@@ -83,6 +84,21 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
      */
     public Optional<Output<String>> customerOwnedIpv4Pool() {
         return Optional.ofNullable(this.customerOwnedIpv4Pool);
+    }
+
+    /**
+     * Options for creating a default security group if [securityGroups] not specified.
+     * 
+     */
+    @Import(name="defaultSecurityGroup")
+    private @Nullable DefaultSecurityGroupArgs defaultSecurityGroup;
+
+    /**
+     * @return Options for creating a default security group if [securityGroups] not specified.
+     * 
+     */
+    public Optional<DefaultSecurityGroupArgs> defaultSecurityGroup() {
+        return Optional.ofNullable(this.defaultSecurityGroup);
     }
 
     /**
@@ -371,6 +387,21 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
     }
 
     /**
+     * List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+     * 
+     */
+    @Import(name="securityGroups")
+    private @Nullable Output<List<String>> securityGroups;
+
+    /**
+     * @return List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+     * 
+     */
+    public Optional<Output<List<String>>> securityGroups() {
+        return Optional.ofNullable(this.securityGroups);
+    }
+
+    /**
      * List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
      * 
      */
@@ -452,6 +483,7 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
         this.clientKeepAlive = $.clientKeepAlive;
         this.connectionLogs = $.connectionLogs;
         this.customerOwnedIpv4Pool = $.customerOwnedIpv4Pool;
+        this.defaultSecurityGroup = $.defaultSecurityGroup;
         this.defaultTargetGroup = $.defaultTargetGroup;
         this.defaultTargetGroupPort = $.defaultTargetGroupPort;
         this.desyncMitigationMode = $.desyncMitigationMode;
@@ -471,6 +503,7 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
         this.name = $.name;
         this.namePrefix = $.namePrefix;
         this.preserveHostHeader = $.preserveHostHeader;
+        this.securityGroups = $.securityGroups;
         this.subnetIds = $.subnetIds;
         this.subnetMappings = $.subnetMappings;
         this.subnets = $.subnets;
@@ -578,6 +611,17 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
          */
         public Builder customerOwnedIpv4Pool(String customerOwnedIpv4Pool) {
             return customerOwnedIpv4Pool(Output.of(customerOwnedIpv4Pool));
+        }
+
+        /**
+         * @param defaultSecurityGroup Options for creating a default security group if [securityGroups] not specified.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder defaultSecurityGroup(@Nullable DefaultSecurityGroupArgs defaultSecurityGroup) {
+            $.defaultSecurityGroup = defaultSecurityGroup;
+            return this;
         }
 
         /**
@@ -957,6 +1001,37 @@ public final class NetworkLoadBalancerArgs extends com.pulumi.resources.Resource
          */
         public Builder preserveHostHeader(Boolean preserveHostHeader) {
             return preserveHostHeader(Output.of(preserveHostHeader));
+        }
+
+        /**
+         * @param securityGroups List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder securityGroups(@Nullable Output<List<String>> securityGroups) {
+            $.securityGroups = securityGroups;
+            return this;
+        }
+
+        /**
+         * @param securityGroups List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder securityGroups(List<String> securityGroups) {
+            return securityGroups(Output.of(securityGroups));
+        }
+
+        /**
+         * @param securityGroups List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder securityGroups(String... securityGroups) {
+            return securityGroups(List.of(securityGroups));
         }
 
         /**

--- a/sdk/nodejs/lb/networkLoadBalancer.ts
+++ b/sdk/nodejs/lb/networkLoadBalancer.ts
@@ -10,7 +10,7 @@ import * as utilities from "../utilities";
 import * as pulumiAws from "@pulumi/aws";
 
 /**
- * Provides a Network Load Balancer resource with listeners and default target group.
+ * Provides a Network Load Balancer resource with listeners, default target group and default security group.
  */
 export class NetworkLoadBalancer extends pulumi.ComponentResource {
     /** @internal */
@@ -27,6 +27,10 @@ export class NetworkLoadBalancer extends pulumi.ComponentResource {
         return obj['__pulumiType'] === NetworkLoadBalancer.__pulumiType;
     }
 
+    /**
+     * Default security group, if auto-created
+     */
+    public readonly defaultSecurityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup | undefined>;
     /**
      * Default target group, if auto-created
      */
@@ -59,6 +63,7 @@ export class NetworkLoadBalancer extends pulumi.ComponentResource {
             resourceInputs["clientKeepAlive"] = args ? args.clientKeepAlive : undefined;
             resourceInputs["connectionLogs"] = args ? args.connectionLogs : undefined;
             resourceInputs["customerOwnedIpv4Pool"] = args ? args.customerOwnedIpv4Pool : undefined;
+            resourceInputs["defaultSecurityGroup"] = args ? (args.defaultSecurityGroup ? inputs.awsx.defaultSecurityGroupArgsProvideDefaults(args.defaultSecurityGroup) : undefined) : undefined;
             resourceInputs["defaultTargetGroup"] = args ? args.defaultTargetGroup : undefined;
             resourceInputs["defaultTargetGroupPort"] = args ? args.defaultTargetGroupPort : undefined;
             resourceInputs["desyncMitigationMode"] = args ? args.desyncMitigationMode : undefined;
@@ -78,6 +83,7 @@ export class NetworkLoadBalancer extends pulumi.ComponentResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["namePrefix"] = args ? args.namePrefix : undefined;
             resourceInputs["preserveHostHeader"] = args ? args.preserveHostHeader : undefined;
+            resourceInputs["securityGroups"] = args ? args.securityGroups : undefined;
             resourceInputs["subnetIds"] = args ? args.subnetIds : undefined;
             resourceInputs["subnetMappings"] = args ? args.subnetMappings : undefined;
             resourceInputs["subnets"] = args ? args.subnets : undefined;
@@ -86,6 +92,7 @@ export class NetworkLoadBalancer extends pulumi.ComponentResource {
             resourceInputs["loadBalancer"] = undefined /*out*/;
             resourceInputs["vpcId"] = undefined /*out*/;
         } else {
+            resourceInputs["defaultSecurityGroup"] = undefined /*out*/;
             resourceInputs["defaultTargetGroup"] = undefined /*out*/;
             resourceInputs["listeners"] = undefined /*out*/;
             resourceInputs["loadBalancer"] = undefined /*out*/;
@@ -116,6 +123,10 @@ export interface NetworkLoadBalancerArgs {
      * ID of the customer owned ipv4 pool to use for this load balancer.
      */
     customerOwnedIpv4Pool?: pulumi.Input<string>;
+    /**
+     * Options for creating a default security group if [securityGroups] not specified.
+     */
+    defaultSecurityGroup?: inputs.awsx.DefaultSecurityGroupArgs;
     /**
      * Options creating a default target group.
      */
@@ -192,6 +203,10 @@ export interface NetworkLoadBalancerArgs {
      * Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
      */
     preserveHostHeader?: pulumi.Input<boolean>;
+    /**
+     * List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+     */
+    securityGroups?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
      */

--- a/sdk/python/pulumi_awsx/lb/network_load_balancer.py
+++ b/sdk/python/pulumi_awsx/lb/network_load_balancer.py
@@ -8,6 +8,7 @@ import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
 from .. import _utilities
+from .. import awsx as _awsx
 from ._inputs import *
 import pulumi_aws
 
@@ -20,6 +21,7 @@ class NetworkLoadBalancerArgs:
                  client_keep_alive: Optional[pulumi.Input[int]] = None,
                  connection_logs: Optional[pulumi.Input['pulumi_aws.lb.LoadBalancerConnectionLogsArgs']] = None,
                  customer_owned_ipv4_pool: Optional[pulumi.Input[str]] = None,
+                 default_security_group: Optional['_awsx.DefaultSecurityGroupArgs'] = None,
                  default_target_group: Optional['TargetGroupArgs'] = None,
                  default_target_group_port: Optional[pulumi.Input[int]] = None,
                  desync_mitigation_mode: Optional[pulumi.Input[str]] = None,
@@ -39,6 +41,7 @@ class NetworkLoadBalancerArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  name_prefix: Optional[pulumi.Input[str]] = None,
                  preserve_host_header: Optional[pulumi.Input[bool]] = None,
+                 security_groups: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_mappings: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.lb.LoadBalancerSubnetMappingArgs']]]] = None,
                  subnets: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.Subnet']]]] = None,
@@ -50,6 +53,7 @@ class NetworkLoadBalancerArgs:
         :param pulumi.Input[int] client_keep_alive: Client keep alive value in seconds. The valid range is 60-604800 seconds. The default is 3600 seconds.
         :param pulumi.Input['pulumi_aws.lb.LoadBalancerConnectionLogsArgs'] connection_logs: Connection Logs block. See below. Only valid for Load Balancers of type `application`.
         :param pulumi.Input[str] customer_owned_ipv4_pool: ID of the customer owned ipv4 pool to use for this load balancer.
+        :param '_awsx.DefaultSecurityGroupArgs' default_security_group: Options for creating a default security group if [securityGroups] not specified.
         :param 'TargetGroupArgs' default_target_group: Options creating a default target group.
         :param pulumi.Input[int] default_target_group_port: Port to use to connect with the target. Valid values are ports 1-65535. Defaults to 80.
         :param pulumi.Input[str] desync_mitigation_mode: How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
@@ -69,6 +73,7 @@ class NetworkLoadBalancerArgs:
         :param pulumi.Input[str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
         :param pulumi.Input[str] name_prefix: Creates a unique name beginning with the specified prefix. Conflicts with `name`.
         :param pulumi.Input[bool] preserve_host_header: Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] security_groups: List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.lb.LoadBalancerSubnetMappingArgs']]] subnet_mappings: Subnet mapping block. See below. For Load Balancers of type `network` subnet mappings can only be added.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.Subnet']]] subnets: A list of subnets to attach to the LB. Only one of [subnets], [subnetIds] or [subnetMappings] can be specified
@@ -83,6 +88,8 @@ class NetworkLoadBalancerArgs:
             pulumi.set(__self__, "connection_logs", connection_logs)
         if customer_owned_ipv4_pool is not None:
             pulumi.set(__self__, "customer_owned_ipv4_pool", customer_owned_ipv4_pool)
+        if default_security_group is not None:
+            pulumi.set(__self__, "default_security_group", default_security_group)
         if default_target_group is not None:
             pulumi.set(__self__, "default_target_group", default_target_group)
         if default_target_group_port is not None:
@@ -121,6 +128,8 @@ class NetworkLoadBalancerArgs:
             pulumi.set(__self__, "name_prefix", name_prefix)
         if preserve_host_header is not None:
             pulumi.set(__self__, "preserve_host_header", preserve_host_header)
+        if security_groups is not None:
+            pulumi.set(__self__, "security_groups", security_groups)
         if subnet_ids is not None:
             pulumi.set(__self__, "subnet_ids", subnet_ids)
         if subnet_mappings is not None:
@@ -179,6 +188,18 @@ class NetworkLoadBalancerArgs:
     @customer_owned_ipv4_pool.setter
     def customer_owned_ipv4_pool(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "customer_owned_ipv4_pool", value)
+
+    @property
+    @pulumi.getter(name="defaultSecurityGroup")
+    def default_security_group(self) -> Optional['_awsx.DefaultSecurityGroupArgs']:
+        """
+        Options for creating a default security group if [securityGroups] not specified.
+        """
+        return pulumi.get(self, "default_security_group")
+
+    @default_security_group.setter
+    def default_security_group(self, value: Optional['_awsx.DefaultSecurityGroupArgs']):
+        pulumi.set(self, "default_security_group", value)
 
     @property
     @pulumi.getter(name="defaultTargetGroup")
@@ -409,6 +430,18 @@ class NetworkLoadBalancerArgs:
         pulumi.set(self, "preserve_host_header", value)
 
     @property
+    @pulumi.getter(name="securityGroups")
+    def security_groups(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
+        """
+        return pulumi.get(self, "security_groups")
+
+    @security_groups.setter
+    def security_groups(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "security_groups", value)
+
+    @property
     @pulumi.getter(name="subnetIds")
     def subnet_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
@@ -478,6 +511,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  client_keep_alive: Optional[pulumi.Input[int]] = None,
                  connection_logs: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerConnectionLogsArgs']]] = None,
                  customer_owned_ipv4_pool: Optional[pulumi.Input[str]] = None,
+                 default_security_group: Optional[pulumi.InputType['_awsx.DefaultSecurityGroupArgs']] = None,
                  default_target_group: Optional[pulumi.InputType['TargetGroupArgs']] = None,
                  default_target_group_port: Optional[pulumi.Input[int]] = None,
                  desync_mitigation_mode: Optional[pulumi.Input[str]] = None,
@@ -497,6 +531,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  name: Optional[pulumi.Input[str]] = None,
                  name_prefix: Optional[pulumi.Input[str]] = None,
                  preserve_host_header: Optional[pulumi.Input[bool]] = None,
+                 security_groups: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerSubnetMappingArgs']]]]] = None,
                  subnets: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.Subnet']]]] = None,
@@ -504,7 +539,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  xff_header_processing_mode: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
-        Provides a Network Load Balancer resource with listeners and default target group.
+        Provides a Network Load Balancer resource with listeners, default target group and default security group.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -512,6 +547,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
         :param pulumi.Input[int] client_keep_alive: Client keep alive value in seconds. The valid range is 60-604800 seconds. The default is 3600 seconds.
         :param pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerConnectionLogsArgs']] connection_logs: Connection Logs block. See below. Only valid for Load Balancers of type `application`.
         :param pulumi.Input[str] customer_owned_ipv4_pool: ID of the customer owned ipv4 pool to use for this load balancer.
+        :param pulumi.InputType['_awsx.DefaultSecurityGroupArgs'] default_security_group: Options for creating a default security group if [securityGroups] not specified.
         :param pulumi.InputType['TargetGroupArgs'] default_target_group: Options creating a default target group.
         :param pulumi.Input[int] default_target_group_port: Port to use to connect with the target. Valid values are ports 1-65535. Defaults to 80.
         :param pulumi.Input[str] desync_mitigation_mode: How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`.
@@ -531,6 +567,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
         :param pulumi.Input[str] name: Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, this provider will autogenerate a name beginning with `tf-lb`.
         :param pulumi.Input[str] name_prefix: Creates a unique name beginning with the specified prefix. Conflicts with `name`.
         :param pulumi.Input[bool] preserve_host_header: Whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] security_groups: List of security group IDs to assign to the LB. Only valid for Load Balancers of type `application` or `network`. For load balancers of type `network` security groups cannot be added if none are currently present, and cannot all be removed once added. If either of these conditions are met, this will force a recreation of the resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] subnet_ids: List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerSubnetMappingArgs']]]] subnet_mappings: Subnet mapping block. See below. For Load Balancers of type `network` subnet mappings can only be added.
         :param pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.Subnet']]] subnets: A list of subnets to attach to the LB. Only one of [subnets], [subnetIds] or [subnetMappings] can be specified
@@ -544,7 +581,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  args: Optional[NetworkLoadBalancerArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Provides a Network Load Balancer resource with listeners and default target group.
+        Provides a Network Load Balancer resource with listeners, default target group and default security group.
 
         :param str resource_name: The name of the resource.
         :param NetworkLoadBalancerArgs args: The arguments to use to populate this resource's properties.
@@ -565,6 +602,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  client_keep_alive: Optional[pulumi.Input[int]] = None,
                  connection_logs: Optional[pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerConnectionLogsArgs']]] = None,
                  customer_owned_ipv4_pool: Optional[pulumi.Input[str]] = None,
+                 default_security_group: Optional[pulumi.InputType['_awsx.DefaultSecurityGroupArgs']] = None,
                  default_target_group: Optional[pulumi.InputType['TargetGroupArgs']] = None,
                  default_target_group_port: Optional[pulumi.Input[int]] = None,
                  desync_mitigation_mode: Optional[pulumi.Input[str]] = None,
@@ -584,6 +622,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
                  name: Optional[pulumi.Input[str]] = None,
                  name_prefix: Optional[pulumi.Input[str]] = None,
                  preserve_host_header: Optional[pulumi.Input[bool]] = None,
+                 security_groups: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  subnet_mappings: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_aws.lb.LoadBalancerSubnetMappingArgs']]]]] = None,
                  subnets: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_aws.ec2.Subnet']]]] = None,
@@ -604,6 +643,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
             __props__.__dict__["client_keep_alive"] = client_keep_alive
             __props__.__dict__["connection_logs"] = connection_logs
             __props__.__dict__["customer_owned_ipv4_pool"] = customer_owned_ipv4_pool
+            __props__.__dict__["default_security_group"] = default_security_group
             __props__.__dict__["default_target_group"] = default_target_group
             __props__.__dict__["default_target_group_port"] = default_target_group_port
             __props__.__dict__["desync_mitigation_mode"] = desync_mitigation_mode
@@ -623,6 +663,7 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
             __props__.__dict__["name"] = name
             __props__.__dict__["name_prefix"] = name_prefix
             __props__.__dict__["preserve_host_header"] = preserve_host_header
+            __props__.__dict__["security_groups"] = security_groups
             __props__.__dict__["subnet_ids"] = subnet_ids
             __props__.__dict__["subnet_mappings"] = subnet_mappings
             __props__.__dict__["subnets"] = subnets
@@ -636,6 +677,14 @@ class NetworkLoadBalancer(pulumi.ComponentResource):
             __props__,
             opts,
             remote=True)
+
+    @property
+    @pulumi.getter(name="defaultSecurityGroup")
+    def default_security_group(self) -> pulumi.Output[Optional['pulumi_aws.ec2.SecurityGroup']]:
+        """
+        Default security group, if auto-created
+        """
+        return pulumi.get(self, "default_security_group")
 
     @property
     @pulumi.getter(name="defaultTargetGroup")


### PR DESCRIPTION
Since August 23 NLBs support Security Groups as well now (see [AWS blog post](https://aws.amazon.com/blogs/containers/network-load-balancers-now-support-security-groups/)).

This change adds the parameters for configuring security groups to the NLB component as well. The one notable difference to the ALB security group is that I refrained from opening up the whole security group by default.

Components should be secure by default, but right now a fully open security group (ingress&egress) is created when users create an ALB without specifying a security group. What makes this issue worse is that the load balancer is placed into a public subnet by default, ergo automatically exposing what's behind the LB to the whole world.

Fixes https://github.com/pulumi/pulumi-awsx/issues/1282