### PR TITLE
Ensure requested ECS container resources are within Fargate limits

### DIFF
--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -74,14 +74,6 @@ export function calculateFargateMemoryAndCPU(containers: FargateContainerMemoryA
     );
   }
 
-  // Don't exceed the max CPU that can be requested. No need to worry about a
-  // min as we're finding the first config that provides *at least* this amount.
-  requestedVCPU = Math.min(requestedVCPU, maxVCPU);
-
-  // Don't exceed the max memory that can be requested. No need to worry about
-  // a min as we're finding the first config that provides *at least* this amount.
-  requestedGB = Math.min(requestedGB, maxMemGB);
-
   // Get all configs that can at least satisfy this pair of cpu/memory needs.
   const config = fargateConfigsByPriceAscending().find(
     (c) => c.vcpu >= requestedVCPU && c.memGB >= requestedGB,

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -66,6 +66,14 @@ export function calculateFargateMemoryAndCPU(containers: FargateContainerMemoryA
   // First, determine how much VCPU/GB that the user is asking for in their containers.
   let { requestedVCPU, requestedGB } = getRequestedVCPUandMemory(containers);
 
+  // Ensure that the requested resources are within the bounds of what Fargate can support.
+  // Task creation will fail if we allocate a smaller amount of CPU or memory than what the containers request
+  if (requestedVCPU > maxVCPU || requestedGB > maxMemGB) {
+    throw new Error(
+      `Requested resources exceed the maximum allowed for Fargate. Requested: ${requestedVCPU} vCPU and ${requestedGB}GB. Max: ${maxVCPU} vCPU and ${maxMemGB}GB.`,
+    );
+  }
+
   // Don't exceed the max CPU that can be requested. No need to worry about a
   // min as we're finding the first config that provides *at least* this amount.
   requestedVCPU = Math.min(requestedVCPU, maxVCPU);

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -64,7 +64,7 @@ type FargateContainerMemoryAndCpu = {
 
 export function calculateFargateMemoryAndCPU(containers: FargateContainerMemoryAndCpu[]) {
   // First, determine how much VCPU/GB that the user is asking for in their containers.
-  let { requestedVCPU, requestedGB } = getRequestedVCPUandMemory(containers);
+  const { requestedVCPU, requestedGB } = getRequestedVCPUandMemory(containers);
 
   // Ensure that the requested resources are within the bounds of what Fargate can support.
   // Task creation will fail if we allocate a smaller amount of CPU or memory than what the containers request


### PR DESCRIPTION
In the prior implementation, if an ECS task's requested resources surpassed the Fargate limits, the system defaulted to the maximum resources permitted by Fargate.
This led to obscure AWS API errors indicating that the containers were requesting more resources than the task could provide.

Fixes #1220 