### PR TITLE
Embed SDK version

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,11 +32,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -59,17 +54,19 @@ jobs:
       - name: Lint classic AWSX Code
         run: make lint_classic
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -107,7 +104,14 @@ jobs:
       - name: Test provider
         run: make test_provider
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Upload bin
         uses: actions/upload-artifact@v3
         with:
@@ -138,11 +142,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -167,7 +166,14 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,10 +25,16 @@ env:
   NODEVERSION: "18.x"
   JAVAVERSION: "11"
 jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -64,6 +70,9 @@ jobs:
             sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -132,8 +141,12 @@ jobs:
           fields: repo,commit,author,action
           status: ${{ job.status }}
   acceptance-test:
-    needs: build-provider
     runs-on: ubuntu-latest
+    needs:
+      - build-provider
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -85,8 +83,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -155,8 +151,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -85,8 +83,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -155,8 +151,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -231,8 +225,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -280,8 +272,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,11 +32,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -59,7 +54,14 @@ jobs:
       - name: Lint classic AWSX Code
         run: make lint_classic
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
     steps:
@@ -74,11 +76,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
@@ -107,7 +104,14 @@ jobs:
       - name: Test provider
         run: make test_provider
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Upload bin
         uses: actions/upload-artifact@v3
         with:
@@ -138,11 +142,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -171,7 +170,14 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
@@ -253,11 +259,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,10 +25,16 @@ env:
   NODEVERSION: "18.x"
   JAVAVERSION: "11"
 jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -64,6 +70,9 @@ jobs:
             sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -132,8 +141,12 @@ jobs:
           fields: repo,commit,author,action
           status: ${{ job.status }}
   acceptance-test:
-    needs: build-provider
     runs-on: ubuntu-latest
+    needs:
+      - build-provider
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -209,8 +222,12 @@ jobs:
           - java
   publish:
     name: publish
-    needs: acceptance-test
     runs-on: ubuntu-latest
+    needs:
+      - acceptance-test
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -254,8 +271,12 @@ jobs:
         run: aws s3 cp dist s3://get.pulumi.com/releases/plugins/ --recursive
   publish_sdk:
     name: publish_sdk
-    needs: publish
     runs-on: ubuntu-latest
+    needs:
+      - publish
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -85,8 +83,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -155,8 +151,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -231,8 +225,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -288,8 +280,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -32,11 +32,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -59,7 +54,14 @@ jobs:
       - name: Lint classic AWSX Code
         run: make lint_classic
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
     steps:
@@ -74,11 +76,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
@@ -107,7 +104,14 @@ jobs:
       - name: Test provider
         run: make test_provider
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Upload bin
         uses: actions/upload-artifact@v3
         with:
@@ -138,11 +142,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -171,7 +170,14 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
@@ -261,11 +267,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,10 +25,16 @@ env:
   NODEVERSION: "18.x"
   JAVAVERSION: "11"
 jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -64,6 +70,9 @@ jobs:
             sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -132,8 +141,12 @@ jobs:
           fields: repo,commit,author,action
           status: ${{ job.status }}
   acceptance-test:
-    needs: build-provider
     runs-on: ubuntu-latest
+    needs:
+      - build-provider
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -209,8 +222,12 @@ jobs:
           - java
   publish:
     name: publish
-    needs: acceptance-test
     runs-on: ubuntu-latest
+    needs:
+      - acceptance-test
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -262,8 +279,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
     runs-on: ubuntu-latest
+    needs:
+      - publish
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -323,8 +344,12 @@ jobs:
           gradle-version: 7.4.1
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
     runs-on: ubuntu-latest
+    needs:
+      - publish_sdk
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -84,8 +82,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -154,8 +150,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -230,8 +224,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -286,8 +278,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,16 @@ env:
   NODEVERSION: "18.x"
   JAVAVERSION: "11"
 jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -63,6 +69,9 @@ jobs:
             sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -131,8 +140,12 @@ jobs:
           fields: repo,commit,author,action
           status: ${{ job.status }}
   acceptance-test:
-    needs: build-provider
     runs-on: ubuntu-latest
+    needs:
+      - build-provider
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -208,8 +221,12 @@ jobs:
           - java
   publish:
     name: publish
-    needs: acceptance-test
     runs-on: ubuntu-latest
+    needs:
+      - acceptance-test
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -260,8 +277,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   publish_sdk:
     name: publish_sdk
-    needs: publish
     runs-on: ubuntu-latest
+    needs:
+      - publish
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -321,8 +342,12 @@ jobs:
           gradle-version: 7.4.1
   tag_sdk:
     name: tag_sdk
-    needs: publish_sdk
     runs-on: ubuntu-latest
+    needs:
+      - publish_sdk
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -335,8 +360,12 @@ jobs:
           sdk/v$(pulumictl get version --language generic)
   create_docs_build:
     name: Create docs build
-    needs: tag_sdk
     runs-on: ubuntu-latest
+    needs:
+      - tag_sdk
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -58,7 +53,14 @@ jobs:
       - name: Lint classic AWSX Code
         run: make lint_classic
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
     steps:
@@ -73,11 +75,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
@@ -106,7 +103,14 @@ jobs:
       - name: Test provider
         run: make test_provider
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Upload bin
         uses: actions/upload-artifact@v3
         with:
@@ -137,11 +141,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -170,7 +169,14 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .
@@ -259,11 +265,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -52,8 +52,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -109,8 +107,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -180,8 +176,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -39,10 +39,16 @@ jobs:
           issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
           body: |
             Please view the PR build - ${{ steps.vars.outputs.run-url }}
+  version:
+    uses: ./.github/workflows/version.yml
+    secrets: inherit
   lint:
     name: lint
     runs-on: ubuntu-latest
     continue-on-error: true
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -88,6 +94,9 @@ jobs:
             sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
+    needs: version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -156,9 +165,13 @@ jobs:
           fields: repo,commit,author,action
           status: ${{ job.status }}
   acceptance-test:
-    needs: build-provider
     runs-on: ubuntu-latest
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - build-provider
+      - version
+    env:
+      PROVIDER_VERSION: ${{ needs.version.outputs.version }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -1,4 +1,3 @@
-
 env:
   AWS_REGION: us-west-2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,11 +46,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -84,7 +78,14 @@ jobs:
           name: dist
           path: dist
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
   build-provider:
     runs-on: ubuntu-latest
     steps:
@@ -99,11 +100,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install Go
@@ -132,7 +128,14 @@ jobs:
       - name: Test provider
         run: make test_provider
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Upload bin
         uses: actions/upload-artifact@v3
         with:
@@ -164,11 +167,6 @@ jobs:
           swap-storage: false
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v4
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
@@ -193,7 +191,14 @@ jobs:
       - name: Build SDK
         run: make build_${{ matrix.language }}
       - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
+        uses: pulumi/git-status-check-action@v1
+        with:
+          allowed-changes: |
+            sdk/**/pulumi-plugin.json
+            sdk/dotnet/Pulumi.*.csproj
+            sdk/go/**/pulumiUtilities.go
+            sdk/nodejs/package.json
+            sdk/python/pyproject.toml
       - name: Compress SDK folder
         run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
           .

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,22 @@
+name: version
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: Calculated version
+        value: ${{ jobs.version.outputs.version }}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    name: Calculate Dev Version
+    steps:
+      - id: version
+        name: Calculate build version
+        uses: pulumi/provider-version-action@v1
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -42,9 +42,11 @@ jobs:
         if ! git diff-files --quiet; then
           echo changes=1 >> "$GITHUB_OUTPUT"
         fi
-    - name: Unshallow clone for tags
+    - name: Calculate build version
       if: steps.gomod.outputs.changes != 0
-      run: git fetch --prune --unshallow --tags
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Setup Node
       if: steps.gomod.outputs.changes != 0
       uses: actions/setup-node@v4

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ dist/${GZIP_PREFIX}-%.tar.gz::
 		yarn install --no-progress && \
 		yarn run tsc --version && \
 		yarn run tsc && \
-		cp ../../README.md ../../LICENSE bin/
+		cp package.json ../../README.md ../../LICENSE bin/
 	@touch $@
 
 .make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ dist/${GZIP_PREFIX}-%.tar.gz::
 		yarn install --no-progress && \
 		yarn run tsc --version && \
 		yarn run tsc && \
-		sed -e 's/\$${VERSION}/$(VERSION_GENERIC)/g' < package.json > bin/package.json && \
 		cp ../../README.md ../../LICENSE bin/
 	@touch $@
 
@@ -110,15 +109,12 @@ dist/${GZIP_PREFIX}-%.tar.gz::
 bin/pulumi-java-gen::
 	$(shell pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java)
 
-.make/build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 .make/build_python: bin/${CODEGEN} .make/schema README.md
 	rm -rf sdk/python
 	bin/${CODEGEN} python sdk/python schema.json $(VERSION_GENERIC)
 	cd sdk/python/ && \
 		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^  version = .*/  version = "$(PYPI_VERSION)"/g' ./bin/pyproject.toml && \
-		rm ./bin/pyproject.toml.bak && \
 		python3 -m venv venv && \
 		./venv/bin/python -m pip install build && \
 		cd ./bin && \
@@ -134,13 +130,11 @@ bin/pulumi-java-gen::
 		go test -v ./... -check.vv
 	@touch $@
 
-.make/build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 .make/build_dotnet: bin/${CODEGEN} .make/schema
 	rm -rf sdk/dotnet
 	bin/${CODEGEN} dotnet sdk/dotnet schema.json $(VERSION_GENERIC)
 	cd sdk/dotnet/ && \
-		echo "${DOTNET_VERSION}" >version.txt && \
-		dotnet build /p:Version=${DOTNET_VERSION}
+		dotnet build
 	@touch $@
 
 # Phony targets

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 MAKEFLAGS 		:= --jobs=$(shell nproc) --warn-undefined-variables
 PROJECT_NAME 	:= Pulumi Infrastructure Components for AWS
 
-VERSION         := $(shell pulumictl get version)
 TESTPARALLELISM := 10
 
 PACK            := awsx
 PROVIDER        := pulumi-resource-${PACK}
 CODEGEN         := pulumi-gen-${PACK}
-GZIP_PREFIX		:= pulumi-resource-${PACK}-v${VERSION}
-BIN				:= ${PROVIDER}
+GZIP_PREFIX     := pulumi-resource-${PACK}-v${VERSION_GENERIC}
+BIN             := ${PROVIDER}
 
 JAVA_GEN 		 := pulumi-java-gen
 JAVA_GEN_VERSION := v0.9.7
@@ -25,6 +24,12 @@ LanguageTags 	?= "all"
 LOCAL_PLAT		?= ""
 
 PKG_ARGS 		:= --no-bytecode --public-packages "*" --public
+
+# Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
+# Local & branch builds will just used this fixed default version unless specified
+PROVIDER_VERSION ?= 1.0.0-alpha.0+dev
+# Use this normalised version everywhere rather than the raw input to ensure consistency.
+VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
 # Pre-requisites: ensure these folders exist
 _ := $(shell mkdir -p .make bin dist)
@@ -50,7 +55,7 @@ bin/${CODEGEN}: ${CODEGEN_SRC}
 	@cd awsx && \
 		yarn tsc && \
 		cp package.json ../schema.json ./bin/ && \
-		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
+		sed -i.bak -e "s/\$${VERSION}/$(VERSION_GENERIC)/g" ./bin/package.json
 	@touch $@
 
 # Re-use the local platform if provided (e.g. `make provider LOCAL_PLAT=linux-amd64`)
@@ -83,19 +88,18 @@ dist/${GZIP_PREFIX}-%.tar.gz::
 	@# $< is the last dependency (the binary path from above)
 	tar --gzip -cf $@ README.md LICENSE -C $$(dirname $<) .
 
-.make/build_nodejs: VERSION := $(shell pulumictl get version --language javascript)
 .make/build_nodejs: bin/${CODEGEN} .make/schema ${AWSX_CLASSIC_SRC}
 	rm -rf sdk/nodejs
-	bin/${CODEGEN} nodejs sdk/nodejs schema.json $(VERSION)
+	bin/${CODEGEN} nodejs sdk/nodejs schema.json $(VERSION_GENERIC)
 	cd sdk/nodejs && \
 		yarn install --no-progress && \
 		yarn run tsc --version && \
 		yarn run tsc && \
-		sed -e 's/\$${VERSION}/$(VERSION)/g' < package.json > bin/package.json && \
+		sed -e 's/\$${VERSION}/$(VERSION_GENERIC)/g' < package.json > bin/package.json && \
 		cp ../../README.md ../../LICENSE bin/
 	@touch $@
 
-.make/build_java: VERSION := $(shell pulumictl get version --language javascript)
+.make/build_java: PACKAGE_VERSION := $(VERSION_GENERIC)
 .make/build_java: bin/pulumi-java-gen .make/schema ${AWSX_CLASSIC_SRC}
 	rm -rf sdk/java
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema schema.json --out sdk/java --build gradle-nexus
@@ -109,7 +113,7 @@ bin/pulumi-java-gen::
 .make/build_python: PYPI_VERSION := $(shell pulumictl get version --language python)
 .make/build_python: bin/${CODEGEN} .make/schema README.md
 	rm -rf sdk/python
-	bin/${CODEGEN} python sdk/python schema.json $(VERSION)
+	bin/${CODEGEN} python sdk/python schema.json $(VERSION_GENERIC)
 	cd sdk/python/ && \
 		cp ../../README.md . && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
@@ -120,11 +124,10 @@ bin/pulumi-java-gen::
 		cd ./bin && \
 		../venv/bin/python -m build .
 
-.make/build_go: VERSION := $(shell pulumictl get version --language generic)
 .make/build_go: AWS_VERSION := $(shell node -e 'console.log(require("./awsx/package.json").dependencies["@pulumi/aws"])')
 .make/build_go: bin/${CODEGEN} .make/schema
 	rm -rf sdk/go
-	bin/${CODEGEN} go sdk/go schema.json $(VERSION)
+	bin/${CODEGEN} go sdk/go schema.json $(VERSION_GENERIC)
 	cd sdk && \
 		go get github.com/pulumi/pulumi-aws/sdk/v6@v$(AWS_VERSION) && \
 		go mod tidy && \
@@ -134,7 +137,7 @@ bin/pulumi-java-gen::
 .make/build_dotnet: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 .make/build_dotnet: bin/${CODEGEN} .make/schema
 	rm -rf sdk/dotnet
-	bin/${CODEGEN} dotnet sdk/dotnet schema.json $(VERSION)
+	bin/${CODEGEN} dotnet sdk/dotnet schema.json $(VERSION_GENERIC)
 	cd sdk/dotnet/ && \
 		echo "${DOTNET_VERSION}" >version.txt && \
 		dotnet build /p:Version=${DOTNET_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PKG_ARGS 		:= --no-bytecode --public-packages "*" --public
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified
-PROVIDER_VERSION ?= 1.0.0-alpha.0+dev
+PROVIDER_VERSION ?= 2.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 

--- a/schema.json
+++ b/schema.json
@@ -20,7 +20,8 @@
                 "Pulumi": "3.*",
                 "Pulumi.Aws": "6.*",
                 "Pulumi.Docker": "4.*"
-            }
+            },
+            "respectSchemaVersion": true
         },
         "go": {
             "generateResourceContainerTypes": true,
@@ -28,7 +29,8 @@
             "internalDependencies": [
                 "github.com/pulumi/pulumi-docker/sdk/v4/go/docker"
             ],
-            "liftSingleValueMethodReturns": true
+            "liftSingleValueMethodReturns": true,
+            "respectSchemaVersion": true
         },
         "java": {
             "dependencies": {
@@ -51,7 +53,8 @@
                 "@types/mime": "^2.0.0",
                 "@types/node": "^18",
                 "typescript": "^4.6.2"
-            }
+            },
+            "respectSchemaVersion": true
         },
         "python": {
             "liftSingleValueMethodReturns": true,
@@ -64,6 +67,7 @@
                 "pulumi-aws": "\u003e=6.0.4,\u003c7.0.0",
                 "pulumi-docker": "\u003e=4.5.1,\u003c5.0.0"
             },
+            "respectSchemaVersion": true,
             "usesIOClasses": true
         }
     },

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -61,12 +61,14 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 					"Pulumi.Docker": "4.*",
 				},
 				"liftSingleValueMethodReturns": true,
+				"respectSchemaVersion":         true,
 			}),
 			"go": rawMessage(map[string]interface{}{
 				"generateResourceContainerTypes": true,
 				"importBasePath":                 "github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx",
 				"liftSingleValueMethodReturns":   true,
 				"internalDependencies":           []string{"github.com/pulumi/pulumi-docker/sdk/v4/go/docker"},
+				"respectSchemaVersion":           true,
 			}),
 			"java": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
@@ -90,6 +92,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 					"@types/mime": "^2.0.0",
 					"typescript":  "^4.6.2",
 				},
+				"respectSchemaVersion": true,
 			}),
 			"python": rawMessage(map[string]interface{}{
 				"requires": map[string]string{
@@ -103,6 +106,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 				"pyproject": map[string]bool{
 					"enabled": true,
 				},
+				"respectSchemaVersion": true,
 			}),
 		},
 	}

--- a/sdk/dotnet/Pulumi.Awsx.csproj
+++ b/sdk/dotnet/Pulumi.Awsx.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-awsx</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>1.0.0-alpha.0+dev</Version>
+    <Version>2.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/Pulumi.Awsx.csproj
+++ b/sdk/dotnet/Pulumi.Awsx.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-awsx</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>1.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "awsx",
-  "version": "1.0.0-alpha.0+dev"
+  "version": "2.0.0-alpha.0+dev"
 }

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "awsx"
+  "name": "awsx",
+  "version": "1.0.0-alpha.0+dev"
 }

--- a/sdk/go/awsx/internal/pulumiUtilities.go
+++ b/sdk/go/awsx/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("1.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("1.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/awsx/internal/pulumiUtilities.go
+++ b/sdk/go/awsx/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := semver.MustParse("1.0.0-alpha.0+dev")
+	version := semver.MustParse("2.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := semver.MustParse("1.0.0-alpha.0+dev")
+	version := semver.MustParse("2.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/awsx/pulumi-plugin.json
+++ b/sdk/go/awsx/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "awsx",
-  "version": "1.0.0-alpha.0+dev"
+  "version": "2.0.0-alpha.0+dev"
 }

--- a/sdk/go/awsx/pulumi-plugin.json
+++ b/sdk/go/awsx/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "awsx"
+  "name": "awsx",
+  "version": "1.0.0-alpha.0+dev"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/awsx",
-    "version": "1.0.0-alpha.0+dev",
+    "version": "2.0.0-alpha.0+dev",
     "keywords": [
         "pulumi",
         "aws",
@@ -32,6 +32,6 @@
     "pulumi": {
         "resource": true,
         "name": "awsx",
-        "version": "1.0.0-alpha.0+dev"
+        "version": "2.0.0-alpha.0+dev"
     }
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/awsx",
-    "version": "${VERSION}",
+    "version": "1.0.0-alpha.0+dev",
     "keywords": [
         "pulumi",
         "aws",
@@ -31,6 +31,7 @@
     },
     "pulumi": {
         "resource": true,
-        "name": "awsx"
+        "name": "awsx",
+        "version": "1.0.0-alpha.0+dev"
     }
 }

--- a/sdk/python/pulumi_awsx/pulumi-plugin.json
+++ b/sdk/python/pulumi_awsx/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "awsx",
-  "version": "1.0.0-alpha.0+dev"
+  "version": "2.0.0-alpha.0+dev"
 }

--- a/sdk/python/pulumi_awsx/pulumi-plugin.json
+++ b/sdk/python/pulumi_awsx/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "awsx"
+  "name": "awsx",
+  "version": "1.0.0-alpha.0+dev"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["pulumi", "aws", "awsx", "kind/component", "category/cloud"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "0.0.0"
+  version = "1.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["pulumi", "aws", "awsx", "kind/component", "category/cloud"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "1.0.0a0+dev"
+  version = "2.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
Part of https://github.com/pulumi/ci-mgmt/issues/915

Bring workflows in line with the approach used in other providers.

1. Use action for checking for unexpected changes - and allow files with the version embedded to change once we've enabled `respectSchemaVersion`.
2. Fix how we calculate the version we're building. Stop relying on the local git checkout to contain all tags. Use a placeholder locally and override the placeholder in CI with the version calculated from our action.
    - Remove fetching all tags.
3. (Pending) enable `respectSchemaVersion`.