### PR TITLE
Automate weekly pulumi/pulumi upgrade

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -3,8 +3,10 @@ name: weekly-pulumi-update
 #   schedule:
 #   - cron: 35 12 * * 4
 #   workflow_dispatch: {}
-"on":
-  pull_request_target:
+on:
+  pull_request:
+    branches:
+      - master
 
 permissions:
   pull-requests: write
@@ -60,5 +62,6 @@ jobs:
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
-        gh pr merge --auto
+        Disable auto-merge for testing
+        # gh pr merge --auto
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -74,7 +74,8 @@ jobs:
     - name: Build Provider
       if: steps.gomod.outputs.changes != 0
       run: |
-        make build
+        # skipped for testing
+        # make build
         make lint
     - name: Commit changes
       if: steps.gomod.outputs.changes != 0

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -31,7 +31,7 @@ jobs:
             **/go.sum
     - name: Update Pulumi/Pulumi
       id: gomod
-      run: >-
+      run: |
         git config --local user.email 'bot@pulumi.com'
         git config --local user.name 'pulumi-bot'
 
@@ -51,7 +51,7 @@ jobs:
         fi
     - name: Bridge Pulumi Upgrade
       if: steps.gomod.outputs.changes != 0
-      run: >-
+      run: |
         make build && make lint
         git add .
 

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -88,6 +88,9 @@ jobs:
     - name: pull-request
       if: steps.gomod.outputs.changes != 0        
       run: |
-        gh_pr_up() { gh pr create $* || gh pr edit $* }
+        gh_pr_up() {
+          gh pr create $* || gh pr edit $*
+        }
+        
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -86,7 +86,9 @@ jobs:
 
         git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
     - name: pull-request
-      if: steps.gomod.outputs.changes != 0        
+      if: steps.gomod.outputs.changes != 0
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
         # Disable auto-merge for testing

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -85,6 +85,5 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
-        # Disable auto-merge for testing
-        # gh pr merge --auto
+        gh pr merge --auto
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,0 +1,64 @@
+name: weekly-pulumi-update
+# on:
+#   schedule:
+#   - cron: 35 12 * * 4
+#   workflow_dispatch: {}
+"on":
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+jobs:
+  weekly-pulumi-update:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        goversion:
+        - 1.21.x
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{matrix.goversion}}
+        cache-dependency-path: |
+            **/go.sum
+    - name: Update Pulumi/Pulumi
+      id: gomod
+      run: >-
+        git config --local user.email 'bot@pulumi.com'
+        git config --local user.name 'pulumi-bot'
+
+        PULUMI_VERSION=$(./scripts/get-latest-pulumi-version.sh)
+        echo "Latest Pulumi version is $PULUMI_VERSION"
+        echo "PULUMI_VERSION=$PULUMI_VERSION" >> "$GITHUB_ENV"
+
+        git checkout -b update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
+
+        echo "Update Pulumi dependencies to $PULUMI_VERSION"
+        ./scripts/bump-pulumi-deps.sh --version "$PULUMI_VERSION"
+
+        git update-index -q --refresh
+
+        if ! git diff-files --quiet; then
+          echo changes=1 >> "$GITHUB_OUTPUT"
+        fi
+    - name: Bridge Pulumi Upgrade
+      if: steps.gomod.outputs.changes != 0
+      run: >-
+        make build && make lint
+        git add .
+
+        git commit -m "Update pulumi/pulumi version to $PULUMI_VERSION"
+
+        git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
+    - name: pull-request
+      run: |
+        gh_pr_up() { gh pr create $* || gh pr edit $* }
+        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
+        gh pr merge --auto
+    name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -90,6 +90,6 @@ jobs:
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
-        Disable auto-merge for testing
+        # Disable auto-merge for testing
         # gh pr merge --auto
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -46,6 +46,9 @@ jobs:
         if ! git diff-files --quiet; then
           echo changes=1 >> "$GITHUB_OUTPUT"
         fi
+    - name: Unshallow clone for tags
+      if: steps.gomod.outputs.changes != 0
+      run: git fetch --prune --unshallow --tags
     - name: Setup Node
       if: steps.gomod.outputs.changes != 0
       uses: actions/setup-node@v4

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -10,8 +10,8 @@ on:
 
 permissions:
   pull-requests: write
-env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+# env:
+#   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
         if ! git diff-files --quiet; then
           echo changes=1 >> "$GITHUB_OUTPUT"
         fi
-    - name: Bridge Pulumi Upgrade
+    - name: Commit changes
       if: steps.gomod.outputs.changes != 0
       run: |
         make build && make lint

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -87,12 +87,7 @@ jobs:
         git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
     - name: pull-request
       if: steps.gomod.outputs.changes != 0        
-      uses: peter-evans/create-pull-request@v6
-      with:
-          author: Pulumi Bot <bot@pulumi.com>
-          body: "Upgrading pulumi/pkg and pulumi/sdk to version ${{ steps.gomod.outputs.pulumi_version }}."
-          branch: "update-pulumi/${{ steps.gomod.outputs.pulumi_version }}-${{ github.run_number }}"
-          committer: Pulumi Bot <bot@pulumi.com>
-          commit-message: "Update pulumi/pulumi version to ${{ steps.gomod.outputs.pulumi_version }}"
-          title: "Update pulumi/pulumi version to ${{ steps.gomod.outputs.pulumi_version }}"
+      run: |
+        gh_pr_up() { gh pr create $* || gh pr edit $* }
+        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
 
-# permissions:
-#   pull-requests: write
+permissions:
+  pull-requests: write
+  contents: write
 env:
   GOVERSION: "1.21.x"
 #   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -74,8 +75,6 @@ jobs:
         make lint
     - name: Commit changes
       if: steps.gomod.outputs.changes != 0
-      permissions:
-        contents: write
       run: |
         git add .
 
@@ -83,9 +82,7 @@ jobs:
 
         git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
     - name: pull-request
-      if: steps.gomod.outputs.changes != 0
-      permissions:
-        pull-requests: write
+      if: steps.gomod.outputs.changes != 0        
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,19 +1,14 @@
 name: weekly-pulumi-update
-# on:
-#   schedule:
-#   - cron: 35 12 * * 4
-#   workflow_dispatch: {}
 on:
-  pull_request:
-    branches:
-      - master
+  schedule:
+  - cron: 0 11 * * 1
+  workflow_dispatch: {}
 
 permissions:
   pull-requests: write
   contents: write
 env:
   GOVERSION: "1.21.x"
-#   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
@@ -38,7 +33,7 @@ jobs:
 
         git checkout -b update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
 
-        echo "Update Pulumi dependencies to $PULUMI_VERSION"
+        echo "Updating Pulumi dependencies to $PULUMI_VERSION"
         ./scripts/bump-pulumi-deps.sh --version "$PULUMI_VERSION"
 
         git update-index -q --refresh
@@ -74,8 +69,7 @@ jobs:
     - name: Build Provider
       if: steps.gomod.outputs.changes != 0
       run: |
-        # skipped for testing
-        # make build
+        make build
         make lint
     - name: Commit changes
       if: steps.gomod.outputs.changes != 0

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -89,5 +89,5 @@ jobs:
       if: steps.gomod.outputs.changes != 0        
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
-        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
+        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -90,6 +90,4 @@ jobs:
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
-        # Disable auto-merge for testing
-        # gh pr merge --auto
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,6 +1,7 @@
 name: weekly-pulumi-update
 on:
   schedule:
+  # Every Monday at 11AM UTC
   - cron: 0 11 * * 1
   workflow_dispatch: {}
 

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -88,9 +88,7 @@ jobs:
     - name: pull-request
       if: steps.gomod.outputs.changes != 0        
       run: |
-        gh_pr_up() {
-          gh pr create $* || gh pr edit $*
-        }
-        
-        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
+        gh pr create --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
+        # Disable auto-merge for testing
+        # gh pr merge --auto
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -8,27 +8,23 @@ on:
     branches:
       - master
 
-permissions:
-  pull-requests: write
-# env:
+# permissions:
+#   pull-requests: write
+env:
+  GOVERSION: "1.21.x"
 #   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        goversion:
-        - 1.21.x
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v4
       with:
-        go-version: ${{matrix.goversion}}
-        cache-dependency-path: |
-            **/go.sum
+        go-version: ${{ env.GOVERSION }}
     - name: Update Pulumi/Pulumi
       id: gomod
       run: |
@@ -49,16 +45,47 @@ jobs:
         if ! git diff-files --quiet; then
           echo changes=1 >> "$GITHUB_OUTPUT"
         fi
-    - name: Commit changes
+    - name: Setup Node
+      if: steps.gomod.outputs.changes != 0
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{env.NODEVERSION}}
+        registry-url: https://registry.npmjs.org
+    - name: Install Yarn
+      if: steps.gomod.outputs.changes != 0
+      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+    - name: Update PATH for Yarn
       if: steps.gomod.outputs.changes != 0
       run: |
-        make build && make lint
+        echo "$HOME/.yarn/bin" >> $GITHUB_PATH
+        echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
+    - name: Install pulumictl
+      if: steps.gomod.outputs.changes != 0
+      uses: jaxxstorm/action-install-gh-release@v1.10.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      if: steps.gomod.outputs.changes != 0
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Build Provider
+      if: steps.gomod.outputs.changes != 0
+      run: |
+        make build
+        make lint
+    - name: Commit changes
+      if: steps.gomod.outputs.changes != 0
+      permissions:
+        contents: write
+      run: |
         git add .
 
         git commit -m "Update pulumi/pulumi version to $PULUMI_VERSION"
 
         git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
     - name: pull-request
+      if: steps.gomod.outputs.changes != 0
+      permissions:
+        pull-requests: write
       run: |
         gh_pr_up() { gh pr create $* || gh pr edit $* }
         gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -87,7 +87,12 @@ jobs:
         git push origin update-pulumi/$PULUMI_VERSION-${{ github.run_id }}-${{ github.run_number }}
     - name: pull-request
       if: steps.gomod.outputs.changes != 0        
-      run: |
-        gh_pr_up() { gh pr create $* || gh pr edit $* }
-        gh_pr_up --title "Update pulumi/pulumi version to $PULUMI_VERSION"
+      uses: peter-evans/create-pull-request@v6
+      with:
+          author: Pulumi Bot <bot@pulumi.com>
+          body: "Upgrading pulumi/pkg and pulumi/sdk to version ${{ steps.gomod.outputs.pulumi_version }}."
+          branch: "update-pulumi/${{ steps.gomod.outputs.pulumi_version }}-${{ github.run_number }}"
+          committer: Pulumi Bot <bot@pulumi.com>
+          commit-message: "Update pulumi/pulumi version to ${{ steps.gomod.outputs.pulumi_version }}"
+          title: "Update pulumi/pulumi version to ${{ steps.gomod.outputs.pulumi_version }}"
     name: weekly-pulumi-update

--- a/scripts/bump-pulumi-deps.sh
+++ b/scripts/bump-pulumi-deps.sh
@@ -17,8 +17,7 @@ function upgrade_deps() {
             fi
 
             echo "Upgrading $dep to $DEPENDENCY_VERSION in $module"
-            go mod edit -droprequire="$dep"
-            go mod edit -require="$dep@$DEPENDENCY_VERSION"
+            go get "$dep@$DEPENDENCY_VERSION"
 
             made_changes=true
     done

--- a/scripts/bump-pulumi-deps.sh
+++ b/scripts/bump-pulumi-deps.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+PULUMI_DEPS=("github.com/pulumi/pulumi/pkg/v3" "github.com/pulumi/pulumi/sdk/v3")
+DEPENDENCY_VERSION=""
+MODULE_DIRS="$(git ls-files '**go.mod' | xargs dirname)"
+MODULE_EXCLUDES=("github.com/pulumi/pulumi-awsx/examples-legacy")
+
+function upgrade_deps() {
+    local module=$1
+    local made_changes=false
+
+    for dep in "${PULUMI_DEPS[@]}"; do
+            if ! go mod why -m "$dep" | grep -q "$module"; then
+                echo "Skipping $dep in $module because it doesn't have a direct dependency on it."
+                continue
+            fi
+
+            echo "Upgrading $dep to $DEPENDENCY_VERSION in $module"
+            go mod edit -droprequire="$dep"
+            go mod edit -require="$dep@$DEPENDENCY_VERSION"
+
+            made_changes=true
+    done
+
+    if [ "$made_changes" == false ]; then
+        echo "No changes made to $module"
+        return
+    fi
+
+    echo "Tidying up $module"
+    go mod tidy
+    printf "\n"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -v|--version)
+            DEPENDENCY_VERSION="$2"
+            shift
+            ;;
+        --help)
+            printf "Usage: bump-pulumi-deps.sh [--version <version>]
+\t--version <version>  The version of the Pulumi dependencies to upgrade to. Defaults to the latest version.\n"
+            exit 0
+            ;;
+        *)
+            echo "Invalid argument: $key"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Check if PULUMI_VERSION environment variable is set
+if [[ -n "${PULUMI_VERSION:-}" ]]; then
+    DEPENDENCY_VERSION="${PULUMI_VERSION}"
+fi
+
+# Check if DEPENDENCY_VERSION is set
+if [[ -z "${DEPENDENCY_VERSION}" ]]; then
+    echo "No version specified. Either set the PULUMI_VERSION environment variable or use the --version flag."
+    exit 1
+fi
+
+for dir in $MODULE_DIRS; do
+    pushd "$dir" > /dev/null
+    module="$(go list -m)"
+
+    if [[ " ${MODULE_EXCLUDES[@]} " =~ " $module " ]]; then
+        echo "Module is excluded: $module"
+    else
+        echo "Processing module: $module"
+        upgrade_deps "$module"
+    fi
+
+    popd > /dev/null
+done

--- a/scripts/bump-pulumi-deps.sh
+++ b/scripts/bump-pulumi-deps.sh
@@ -8,28 +8,12 @@ MODULE_EXCLUDES=("github.com/pulumi/pulumi-awsx/examples-legacy")
 
 function upgrade_deps() {
     local module=$1
-    local made_changes=false
 
     for dep in "${PULUMI_DEPS[@]}"; do
-            if ! go mod why -m "$dep" | grep -q "$module"; then
-                echo "Skipping $dep in $module because it doesn't have a direct dependency on it."
-                continue
-            fi
-
-            echo "Upgrading $dep to $DEPENDENCY_VERSION in $module"
-            go get "$dep@$DEPENDENCY_VERSION"
-
-            made_changes=true
+        go get "$dep@$DEPENDENCY_VERSION"
     done
 
-    if [ "$made_changes" == false ]; then
-        echo "No changes made to $module"
-        return
-    fi
-
-    echo "Tidying up $module"
     go mod tidy
-    printf "\n"
 }
 
 # Parse command line arguments
@@ -71,9 +55,10 @@ for dir in $MODULE_DIRS; do
     if [[ " ${MODULE_EXCLUDES[@]} " =~ " $module " ]]; then
         echo "Module is excluded: $module"
     else
-        echo "Processing module: $module"
+        echo "Upgrading Pulumi dependencies to $DEPENDENCY_VERSION in $module"
         upgrade_deps "$module"
     fi
+    printf "\n"
 
     popd > /dev/null
 done

--- a/scripts/get-latest-pulumi-version.sh
+++ b/scripts/get-latest-pulumi-version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+pushd "$TEMP_DIR" > /dev/null
+go mod init github.com/pulumi/version-extractor &> /dev/null
+go get -u github.com/pulumi/pulumi/pkg/v3 &> /dev/null
+go list -f "{{.Version}}" -m github.com/pulumi/pulumi/pkg/v3
+popd > /dev/null


### PR DESCRIPTION
This sets up a cron job to bump pulumi/pulumi versions every week. The cron job updates the dependencies, rebuilds the provider and then opens a PR. The PR is set to auto merge.

Closes #1264 