### PR TITLE
Fix lookup of provider version to use versioning action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -315,11 +315,10 @@ jobs:
           path: ${{ github.workspace}}/sdk/
       - name: Uncompress java SDK
         run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
       - name: Publish Java SDK
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa
+        env:
+          PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
           build-root-directory: ./sdk/java

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -323,11 +323,10 @@ jobs:
           path: ${{ github.workspace}}/sdk/
       - name: Uncompress java SDK
         run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
       - name: Publish Java SDK
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa
+        env:
+          PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
           build-root-directory: ./sdk/java
@@ -348,8 +347,8 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Add SDK version tag
-        run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-          sdk/v$(pulumictl get version --language generic)
+        run: git tag "sdk/v$PROVIDER_VERSION" && git push origin
+          "sdk/v$PROVIDER_VERSION"
 name: prerelease
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,11 +321,10 @@ jobs:
           path: ${{ github.workspace}}/sdk/
       - name: Uncompress java SDK
         run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
       - name: Publish Java SDK
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa
+        env:
+          PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
           build-root-directory: ./sdk/java
@@ -346,8 +345,8 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Add SDK version tag
-        run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-          sdk/v$(pulumictl get version --language generic)
+        run: git tag "sdk/v$PROVIDER_VERSION" && git push origin
+          "sdk/v$PROVIDER_VERSION"
   create_docs_build:
     name: Create docs build
     runs-on: ubuntu-latest


### PR DESCRIPTION
There were some leftovers of the `pulumictl` based version lookup that started failing master builds and releases after the unshallow clone was removed (because it couldn't resolve the correct version without having access to all tags).
This change switches them over to use the output of the provider-version-action.

Fixes #1305 
