### PR TITLE
Modify weekly pulumi upgrade action to run acceptance tests in PR

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,5 +1,8 @@
 name: weekly-pulumi-update
 on:
+  pull_request:
+    branches:
+      - master
   schedule:
   # Every Monday at 11AM UTC
   - cron: 0 11 * * 1
@@ -85,8 +88,9 @@ jobs:
     - name: pull-request
       if: steps.gomod.outputs.changes != 0
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       run: |
         gh pr create --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
-        gh pr merge --auto
+        # Disable for testing
+        # gh pr merge --auto
     name: weekly-pulumi-update


### PR DESCRIPTION
Previously the weekly pulumi upgrade couldn't auto-merge because it used the built-in action access token for creating the PR. That default GH action user doesn't have the necessary access rights (i.e. is not a member of pulumi) to run acceptance tests.

This change makes the gh cli use the pulumi bot token.