### PR TITLE
Add repository dispatch command for testing weekly pulumi upgrade in PRs

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: run-acceptance-tests
+          commands: |
+            run-acceptance-tests
+            run-pulumi-update
           permission: write
           issue-type: pull-request
           repository: pulumi/pulumi-awsx

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -95,5 +95,5 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh pr merge --merge --auto "1"
+        gh pr merge --squash --auto "1"
     name: weekly-pulumi-update

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,5 +1,7 @@
 name: weekly-pulumi-update
 on:
+  repository_dispatch:
+    types: [run-pulumi-update-command]
   schedule:
   # Every Monday at 11AM UTC
   - cron: 0 11 * * 1
@@ -88,5 +90,10 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create --title "Update pulumi/pulumi version to $PULUMI_VERSION" --body "Upgrading pulumi/pkg and pulumi/sdk to version $PULUMI_VERSION."
-        gh pr merge --auto
+    - name: Enable auto-merge
+      if: steps.gomod.outputs.changes != 0 && github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh pr merge --merge --auto "1"
     name: weekly-pulumi-update


### PR DESCRIPTION
This change makes it easier to debug the weekly pulumi update by allowing it to be dispatched
via the command run-pulumi-update.

The auto merge will be disabled for the automated upgrades. Otherwise those commits will get merged into the PR branch
