### PR TITLE
Automate updating pu/pu node dependency

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -50,10 +50,11 @@ jobs:
         # Strips the v from the version to get the correct npm version
         yarn upgrade @pulumi/pulumi@${PULUMI_VERSION#v}
         yarn run dedupe-deps
+
+        echo "Ensure that we don't have any duplicate dependencies"
+        yarn run check-duplicate-deps
         popd
 
-        # Ensure that we don't have any duplicate dependencies
-        yarn run check-duplicate-deps
 
         git update-index -q --refresh
 

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -46,9 +46,11 @@ jobs:
         ./scripts/bump-pulumi-deps.sh --version "$PULUMI_VERSION"
 
         echo "Updating node @pulumi/pulumi to $PULUMI_VERSION"
+        pushd awsx
         # Strips the v from the version to get the correct npm version
         yarn upgrade @pulumi/pulumi@${PULUMI_VERSION#v}
         yarn run dedupe-deps
+        popd
 
         # Ensure that we don't have any duplicate dependencies
         yarn run check-duplicate-deps

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -74,6 +74,13 @@ jobs:
     - name: Build Provider
       if: steps.gomod.outputs.changes != 0
       run: |
+        # Strips the v from the version to get the correct npm version
+        yarn upgrade @pulumi/pulumi@${PULUMI_VERSION#v}
+        yarn run dedupe-deps
+
+        # Ensure that we don't have any duplicate dependencies
+        yarn run check-duplicate-deps
+
         make build
         make lint
     - name: Commit changes

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -24,6 +24,12 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GOVERSION }}
+    - name: Install Yarn
+      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+    - name: Update PATH for Yarn
+      run: |
+        echo "$HOME/.yarn/bin" >> $GITHUB_PATH
+        echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
     - name: Update Pulumi/Pulumi
       id: gomod
       run: |
@@ -38,6 +44,14 @@ jobs:
 
         echo "Updating Pulumi dependencies to $PULUMI_VERSION"
         ./scripts/bump-pulumi-deps.sh --version "$PULUMI_VERSION"
+
+        echo "Updating node @pulumi/pulumi to $PULUMI_VERSION"
+        # Strips the v from the version to get the correct npm version
+        yarn upgrade @pulumi/pulumi@${PULUMI_VERSION#v}
+        yarn run dedupe-deps
+
+        # Ensure that we don't have any duplicate dependencies
+        yarn run check-duplicate-deps
 
         git update-index -q --refresh
 
@@ -55,14 +69,6 @@ jobs:
       with:
         node-version: ${{env.NODEVERSION}}
         registry-url: https://registry.npmjs.org
-    - name: Install Yarn
-      if: steps.gomod.outputs.changes != 0
-      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-    - name: Update PATH for Yarn
-      if: steps.gomod.outputs.changes != 0
-      run: |
-        echo "$HOME/.yarn/bin" >> $GITHUB_PATH
-        echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
     - name: Install pulumictl
       if: steps.gomod.outputs.changes != 0
       uses: jaxxstorm/action-install-gh-release@v1.10.0
@@ -74,13 +80,6 @@ jobs:
     - name: Build Provider
       if: steps.gomod.outputs.changes != 0
       run: |
-        # Strips the v from the version to get the correct npm version
-        yarn upgrade @pulumi/pulumi@${PULUMI_VERSION#v}
-        yarn run dedupe-deps
-
-        # Ensure that we don't have any duplicate dependencies
-        yarn run check-duplicate-deps
-
         make build
         make lint
     - name: Commit changes

--- a/awsx/package.json
+++ b/awsx/package.json
@@ -18,7 +18,9 @@
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "test": "jest",
     "tsc": "tsc --incremental",
-    "start": "ts-node index.ts"
+    "start": "ts-node index.ts",
+    "dedupe-deps": "yarn-deduplicate",
+    "check-duplicate-deps": "yarn-deduplicate --fail"
   },
   "//": "Pulumi sub-provider dependencies must be pinned at an exact version because we extract this value to generate the correct dependency in the schema",
   "dependencies": {
@@ -51,7 +53,8 @@
     "ts-node": "^10.7.0",
     "tslint": "^6.1.3",
     "typedoc": "^0.13.0",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.2",
+    "yarn-deduplicate": "^6.0.2"
   },
   "jest": {
     "modulePathIgnorePatterns": [

--- a/awsx/yarn.lock
+++ b/awsx/yarn.lock
@@ -1806,6 +1806,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
@@ -2256,6 +2261,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
@@ -4601,6 +4611,11 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.5.2, semver@^7.5.3, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.0:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
+
 set-function-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.0.tgz#e59e53e7fa23f9c2da1c0999fa202d5ed09c4756"
@@ -4966,6 +4981,11 @@ tslib@^1.13.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.5.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
 tslint@^6.1.3:
   version "6.1.3"
@@ -5360,6 +5380,16 @@ yargs@^17.3.1, yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yarn-deduplicate@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-6.0.2.tgz#63498d2d4c3a8567e992a994ce0ab51aa5681f2e"
+  integrity sha512-Efx4XEj82BgbRJe5gvQbZmEO7pU5DgHgxohYZp98/+GwPqdU90RXtzvHirb7hGlde0sQqk5G3J3Woyjai8hVqA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^10.0.1"
+    semver "^7.5.0"
+    tslib "^2.5.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Adds automation for updating the pu/pu node dependency.
This also adds tools for deduplicating entries in the yarn.lock file. Those sometimes happen when upgrading dependencies... :( https://github.com/yarnpkg/yarn/issues/3967