### PR TITLE
ci: fix go sdk publish to embed version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,9 +344,28 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: pulumi/pulumictl
-      - name: Add SDK version tag
-        run: git tag "sdk/v$PROVIDER_VERSION" && git push origin
-          "sdk/v$PROVIDER_VERSION"
+      - name: Download Go SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: go-sdk.tar.gz
+          path: $${{ github.workspace }}/sdk/
+      - name: Uncompress Go SDK
+        run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
+          ${{ github.workspace }}/sdk/go
+        shell: bash
+      - uses: pulumi/publish-go-sdk-action@v1
+        with:
+          repository: ${{ github.repository }}
+          base-ref: ${{ github.sha }}
+          source: sdk
+          path: sdk
+          version: ${{ needs.version.outputs.version }}
+          additive: false
+          # Avoid including other language SDKs & artifacts in the commit
+          files: |
+            go.*
+            go/**
+            !*.tar.gz
   create_docs_build:
     name: Create docs build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follows the workflow defined in ci-mgmt (https://github.com/pulumi/ci-mgmt/blob/7c1f0521b8f04aff46732c6656659c85d60fd9c4/provider-ci/test-workflows/aws/.github/workflows/release.yml#L149-L186) as the basis for this change. This ensures that during the publishing step, we download the Go SDK artifact which contains the correctly embedded version. We then use the `pulumi/publish-go-sdk-action` action to commit/push the new files and cut a new sdk tag for this.

Fixes: #1322