### PR TITLE
Use v3 of actions/download-artifact

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -346,9 +346,28 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: pulumi/pulumictl
-      - name: Add SDK version tag
-        run: git tag "sdk/v$PROVIDER_VERSION" && git push origin
-          "sdk/v$PROVIDER_VERSION"
+      - name: Download Go SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: go-sdk.tar.gz
+          path: $${{ github.workspace }}/sdk/
+      - name: Uncompress Go SDK
+        run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
+          ${{ github.workspace }}/sdk/go
+        shell: bash
+      - uses: pulumi/publish-go-sdk-action@v1
+        with:
+          repository: ${{ github.repository }}
+          base-ref: ${{ github.sha }}
+          source: sdk
+          path: sdk
+          version: ${{ needs.version.outputs.version }}
+          additive: false
+          # Avoid including other language SDKs & artifacts in the commit
+          files: |
+            go.*
+            go/**
+            !*.tar.gz
 name: prerelease
 on:
   push:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -347,10 +347,10 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Download Go SDK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: go-sdk.tar.gz
-          path: $${{ github.workspace }}/sdk/
+          path: ${{ github.workspace }}/sdk/
       - name: Uncompress Go SDK
         run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
           ${{ github.workspace }}/sdk/go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,10 +345,10 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Download Go SDK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: go-sdk.tar.gz
-          path: $${{ github.workspace }}/sdk/
+          path: ${{ github.workspace }}/sdk/
       - name: Uncompress Go SDK
         run: tar -zxf ${{ github.workspace }}/sdk/go.tar.gz -C
           ${{ github.workspace }}/sdk/go


### PR DESCRIPTION
https://github.com/pulumi/pulumi-awsx/pull/1323 used v4 of the download artifact action, which is incompatible with uploads using v3 of the upload action. See [FAQ](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible) for compatibility matrix.

This resulted in the release step [failing](https://github.com/pulumi/pulumi-awsx/actions/runs/9620941727/job/26540766895#step:4:36) to download the uploaded artifact.

This PR also updates the pre-release workflow while we're at it.

Note: I've opted to use v3 of the download action to maintain consistency with the rest of our GHA workflows. We can update to v4 in the future.