### PR TITLE
Don't set provider version during pulumi upgrades

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -61,11 +61,6 @@ jobs:
         if ! git diff-files --quiet; then
           echo changes=1 >> "$GITHUB_OUTPUT"
         fi
-    - name: Calculate build version
-      if: steps.gomod.outputs.changes != 0
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Setup Node
       if: steps.gomod.outputs.changes != 0
       uses: actions/setup-node@v4


### PR DESCRIPTION
This causes the version to flip-flop between builds.

We don't want a real version because we're pushing the code back as a PR.