### PR TITLE
Permit aws.ec2.Vpc to use IPAM-allocated cidrBlock ranges

### DIFF
--- a/awsx/ec2/subnetDistributorLegacy.test.ts
+++ b/awsx/ec2/subnetDistributorLegacy.test.ts
@@ -14,7 +14,8 @@
 
 import fc from "fast-check";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
-import { getSubnetSpecsLegacy, SubnetSpec, validateRanges } from "./subnetDistributorLegacy";
+import { getSubnetSpecsLegacy, validateRanges } from "./subnetDistributorLegacy";
+import { SubnetSpec } from "./subnetSpecs";
 import { knownWorkingSubnets } from "./knownWorkingSubnets";
 import { extractSubnetSpecInputFromLegacyLayout } from "./vpc";
 import { getSubnetSpecs } from "./subnetDistributorNew";

--- a/awsx/ec2/subnetDistributorLegacy.ts
+++ b/awsx/ec2/subnetDistributorLegacy.ts
@@ -19,16 +19,7 @@ import * as pulumi from "@pulumi/pulumi";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import * as ipAddress from "ip-address";
 import { BigInteger } from "jsbn";
-
-export interface SubnetSpec {
-  cidrBlock: string;
-  type: SubnetTypeInputs;
-  azName: string;
-  subnetName: string;
-  tags?: pulumi.Input<{
-    [key: string]: pulumi.Input<string>;
-  }>;
-}
+import { SubnetSpec } from "./subnetSpecs";
 
 export function getSubnetSpecsLegacy(
   vpcName: string,

--- a/awsx/ec2/subnetDistributorNew.test.ts
+++ b/awsx/ec2/subnetDistributorNew.test.ts
@@ -58,7 +58,7 @@ describe("default subnet layout", () => {
         const vpcCidr = `10.0.0.0/${azCidrMask}`;
         const result = getSubnetSpecs("vpcName", vpcCidr, ["us-east-1a"], undefined);
 
-        validatePartialSubnetSpecs(result, ss => {
+        validatePartialSubnetSpecs(result, (ss) => {
           const x = ss.map((s) => ({ type: s.type, cidrMask: getCidrMask(s.cidrBlock) }));
           expect(x).toMatchObject([
             {
@@ -87,7 +87,7 @@ describe("default subnet layout", () => {
           const vpcCidr = `10.0.0.0/${vpcCidrMask}`;
 
           const specs = getSubnetSpecs("vpcName", vpcCidr, azs, subnetSpecs);
-          validatePartialSubnetSpecs(specs, result => {
+          validatePartialSubnetSpecs(specs, (result) => {
             for (const subnet of result) {
               const subnetMask = getCidrMask(subnet.cidrBlock);
               // Larger mask means smaller subnet
@@ -129,7 +129,7 @@ describe("default subnet layout", () => {
           ["us-east-1a"],
           [{ type: "Private" }, { type: "Public" }, { type: "Isolated" }],
         );
-        validatePartialSubnetSpecs(result, ss => {
+        validatePartialSubnetSpecs(result, (ss) => {
           const masks = ss.map((s) => ({ type: s.type, cidrMask: getCidrMask(s.cidrBlock) }));
           expect(masks).toMatchObject([
             {
@@ -174,7 +174,7 @@ describe("default subnet layout", () => {
 
           const result = getSubnetSpecs("vpcName", vpcCidr, ["us-east-1a"], subnetSpecs);
 
-          validatePartialSubnetSpecs(result, ss => validateSubnets(ss, getOverlappingSubnets));
+          validatePartialSubnetSpecs(result, (ss) => validateSubnets(ss, getOverlappingSubnets));
         },
       ),
     );
@@ -250,7 +250,7 @@ describe("validating exact layouts", () => {
       [{ type: "Public" }, { type: "Private" }, { type: "Isolated" }],
     );
     expect(() => {
-      validatePartialSubnetSpecs(result, ss => validateNoGaps(vpcCidr, ss));
+      validatePartialSubnetSpecs(result, (ss) => validateNoGaps(vpcCidr, ss));
     }).toThrowError(
       "Please fix the following gaps: vpcName-isolated-1 (ending 10.0.191.254) ends before VPC ends (at 10.0.255.254})",
     );

--- a/awsx/ec2/subnetDistributorNew.ts
+++ b/awsx/ec2/subnetDistributorNew.ts
@@ -28,7 +28,13 @@ export function getSubnetSpecsWithPartialCidr(
   subnetInputs: SubnetSpecInputs[] | undefined,
   azCidrMask?: number,
 ): SubnetSpecPartial[] {
-  const allocatedCidrBlocks = allocateSubnetCidrBlocksInput(vpcName, vpcCidr, azNames, subnetInputs, azCidrMask);
+  const allocatedCidrBlocks = allocateSubnetCidrBlocksInput(
+    vpcName,
+    vpcCidr,
+    azNames,
+    subnetInputs,
+    azCidrMask,
+  );
   const subnetSpecs = subnetInputs ?? defaultSubnetInputsBare();
   return azNames.flatMap((azName, azIndex) => {
     const azNum = azIndex + 1;
@@ -75,19 +81,24 @@ export function allocateSubnetCidrBlocksInput(
   azNames: string[],
   subnetInputs: SubnetSpecInputs[] | undefined,
   azCidrMask?: number,
-): Record<SubnetAllocationID, {cidrBlock: pulumi.Input<string>}> {
+): Record<SubnetAllocationID, { cidrBlock: pulumi.Input<string> }> {
   if (typeof vpcCidr === "string") {
     return allocateSubnetCidrBlocks(vpcName, vpcCidr, azNames, subnetInputs, azCidrMask);
   }
-  const alloc = pulumi.output(vpcCidr).apply(vpcCidr =>
-    allocateSubnetCidrBlocks(vpcName, vpcCidr, azNames, subnetInputs, azCidrMask));
+  const alloc = pulumi
+    .output(vpcCidr)
+    .apply((vpcCidr) =>
+      allocateSubnetCidrBlocks(vpcName, vpcCidr, azNames, subnetInputs, azCidrMask),
+    );
   const subnetSpecs = subnetInputs ?? defaultSubnetInputsBare();
-  const result: Record<SubnetAllocationID, {cidrBlock: pulumi.Input<string>}> = {};
+  const result: Record<SubnetAllocationID, { cidrBlock: pulumi.Input<string> }> = {};
   azNames.forEach((_, azIndex) => {
     const azNum = azIndex + 1;
     return subnetSpecs.map((subnetSpec, subnetIndex) => {
       const subnetAllocID = subnetAllocationID(vpcName, subnetSpec, azNum, subnetIndex);
-      result[subnetAllocID] = {cidrBlock: alloc.apply(a => pulumi.output(a[subnetAllocID].cidrBlock))};
+      result[subnetAllocID] = {
+        cidrBlock: alloc.apply((a) => pulumi.output(a[subnetAllocID].cidrBlock)),
+      };
     });
   });
   return result;
@@ -99,8 +110,8 @@ function allocateSubnetCidrBlocks(
   azNames: string[],
   subnetInputs: SubnetSpecInputs[] | undefined,
   azCidrMask?: number,
-): Record<SubnetAllocationID, {cidrBlock: pulumi.Input<string>}> {
-  const allocation: Record<string, {cidrBlock: pulumi.Input<string>}> = {};
+): Record<SubnetAllocationID, { cidrBlock: pulumi.Input<string> }> {
+  const allocation: Record<string, { cidrBlock: pulumi.Input<string> }> = {};
   const vpcNetmask = new Netmask(vpcCidr);
   const azBitmask = azCidrMask ?? vpcNetmask.bitmask + newBits(azNames.length);
 
@@ -158,10 +169,7 @@ function allocateSubnetCidrBlocks(
 }
 
 function defaultSubnetInputsBare(): SubnetSpecInputs[] {
-  return [
-    {type: "Private"},
-    {type: "Public"},
-  ];
+  return [{ type: "Private" }, { type: "Public" }];
 }
 
 export function defaultSubnetInputs(azBitmask: number): SubnetSpecInputs[] {

--- a/awsx/ec2/subnetDistributorNew.ts
+++ b/awsx/ec2/subnetDistributorNew.ts
@@ -18,7 +18,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import { Netmask } from "netmask";
-import { SubnetSpec } from "./subnetSpecs";
+import { SubnetSpec, SubnetSpecPartial } from "./subnetSpecs";
 
 export function getSubnetSpecs(
   vpcName: string,
@@ -26,7 +26,7 @@ export function getSubnetSpecs(
   azNames: string[],
   subnetInputs: SubnetSpecInputs[] | undefined,
   azCidrMask?: number,
-): SubnetSpec[] {
+): SubnetSpecPartial[] {
   const vpcNetmask = new Netmask(vpcCidr);
   const azBitmask = azCidrMask ?? vpcNetmask.bitmask + newBits(azNames.length);
 

--- a/awsx/ec2/subnetDistributorNew.ts
+++ b/awsx/ec2/subnetDistributorNew.ts
@@ -21,7 +21,7 @@ import { Netmask } from "netmask";
 import { SubnetSpec, SubnetSpecPartial } from "./subnetSpecs";
 
 // Like getSubnetSpecs but tolerates partially known vpcCidr.
-export function getSubnetSpecsWithPartialCidr(
+export function getSubnetSpecs(
   vpcName: string,
   vpcCidr: pulumi.Input<string>,
   azNames: string[],
@@ -62,16 +62,6 @@ function subnetAllocationID(
 ): SubnetAllocationID {
   const name = subnetName(vpcName, subnetSpec, azNum);
   return `${name}#${subnetSpecIndex}`;
-}
-
-export function getSubnetSpecs(
-  vpcName: string,
-  vpcCidr: string,
-  azNames: string[],
-  subnetInputs: SubnetSpecInputs[] | undefined,
-  azCidrMask?: number,
-): SubnetSpecPartial[] {
-  return getSubnetSpecsWithPartialCidr(vpcName, vpcCidr, azNames, subnetInputs, azCidrMask);
 }
 
 // Like allocateSubnetCidrBlocks but accepts pulumi.Input for vpcCidr.

--- a/awsx/ec2/subnetDistributorNew.ts
+++ b/awsx/ec2/subnetDistributorNew.ts
@@ -18,16 +18,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { SubnetSpecInputs, SubnetTypeInputs } from "../schema-types";
 import { Netmask } from "netmask";
-
-export interface SubnetSpec {
-  cidrBlock: string;
-  type: SubnetTypeInputs;
-  azName: string;
-  subnetName: string;
-  tags?: pulumi.Input<{
-    [key: string]: pulumi.Input<string>;
-  }>;
-}
+import { SubnetSpec } from "./subnetSpecs";
 
 export function getSubnetSpecs(
   vpcName: string,

--- a/awsx/ec2/subnetDistributorNew.ts
+++ b/awsx/ec2/subnetDistributorNew.ts
@@ -98,7 +98,7 @@ function allocateSubnetCidrBlocks(
   vpcCidr: string,
   azNames: string[],
   subnetInputs: SubnetSpecInputs[] | undefined,
-  azCidrMask?: number
+  azCidrMask?: number,
 ): Record<SubnetAllocationID, {cidrBlock: pulumi.Input<string>}> {
   const allocation: Record<string, {cidrBlock: pulumi.Input<string>}> = {};
   const vpcNetmask = new Netmask(vpcCidr);

--- a/awsx/ec2/subnetSpecs.ts
+++ b/awsx/ec2/subnetSpecs.ts
@@ -28,13 +28,13 @@ export interface SubnetSpec {
 
 // Like SubnetSpec, but cidrBlock may not be fully known yet. This type supports scenarios where the cidrBlock is
 // allocated by IPAM and is only known after the underlying VPC provisions.
-export type SubnetSpecPartial = Omit<SubnetSpec, "cidrBlock"> & {cidrBlock: pulumi.Input<string> };
+export type SubnetSpecPartial = Omit<SubnetSpec, "cidrBlock"> & { cidrBlock: pulumi.Input<string> };
 
 // Runs check(specs) immediately if all specs are fully known, otherwise defers validation into the apply layer and
 // makes sure that validation is resolved before cidrBlock fields resolve.
 export function validatePartialSubnetSpecs(
   specs: SubnetSpecPartial[],
-  check: (specs: SubnetSpec[])=>void,
+  check: (specs: SubnetSpec[]) => void,
 ): SubnetSpecPartial[] {
   const promptSpecs = detectPromptSubnetSpecs(specs);
   if (promptSpecs) {
@@ -42,18 +42,18 @@ export function validatePartialSubnetSpecs(
     return specs;
   }
 
-  const checked: pulumi.Output<SubnetSpec[]> = pulumi.output(specs).apply(xs => {
+  const checked: pulumi.Output<SubnetSpec[]> = pulumi.output(specs).apply((xs) => {
     check(xs);
     return xs;
   });
-  return specs.map((s, index) => ({...s, cidrBlock: checked.apply(cs => cs[index].cidrBlock)}));
+  return specs.map((s, index) => ({ ...s, cidrBlock: checked.apply((cs) => cs[index].cidrBlock) }));
 }
 
-function detectPromptSubnetSpecs(specs: SubnetSpecPartial[]): SubnetSpec[]|undefined {
-  if (specs.every(s => typeof s.cidrBlock === "string")) {
-    return specs.map(s => {
+function detectPromptSubnetSpecs(specs: SubnetSpecPartial[]): SubnetSpec[] | undefined {
+  if (specs.every((s) => typeof s.cidrBlock === "string")) {
+    return specs.map((s) => {
       const cidrBlock: string = typeof s.cidrBlock === "string" ? s.cidrBlock : "";
-      return {...s, cidrBlock};
+      return { ...s, cidrBlock };
     });
   } else {
     return undefined;

--- a/awsx/ec2/subnetSpecs.ts
+++ b/awsx/ec2/subnetSpecs.ts
@@ -1,0 +1,27 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+
+import { SubnetTypeInputs } from "../schema-types";
+
+export interface SubnetSpec {
+  cidrBlock: string;
+  type: SubnetTypeInputs;
+  azName: string;
+  subnetName: string;
+  tags?: pulumi.Input<{
+    [key: string]: pulumi.Input<string>;
+  }>;
+}

--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -342,3 +342,24 @@ describe("picking subnet allocator", () => {
     expect(f("Exact")).toBe("NewAllocator"); // this case is a bit suspect
   });
 });
+
+describe("validating vpc args", () => {
+  it("permits ipv4IpamPoolId with cidrBlock", () => {
+    Vpc.validateVpcArgs({ ipv4IpamPoolId: "pool", cidrBlock: "10.0.0.0/16" });
+  });
+  it("permits ipv4IpamPoolId with mask", () => {
+    Vpc.validateVpcArgs({ ipv4IpamPoolId: "pool", ipv4NetmaskLength: 24 });
+  });
+  it("rejects ipv4IpamPoolId without mask or cidrBlock", () => {
+    expect(() => Vpc.validateVpcArgs({ ipv4IpamPoolId: "pool" })).toThrowError();
+  });
+  it("rejects ipv4IpamPoolId with both mask and cidrBlock", () => {
+    expect(() =>
+      Vpc.validateVpcArgs({
+        ipv4IpamPoolId: "pool",
+        cidrBlock: "10.0.0.0/24",
+        ipv4NetmaskLength: 24,
+      }),
+    ).toThrowError();
+  });
+});

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -71,7 +71,7 @@ export class Vpc extends schema.Vpc<VpcData> {
     name: string;
     args: schema.VpcArgs;
     opts: pulumi.ComponentResourceOptions;
-  }) {
+  }): Promise<VpcData> {
     const { name, args } = props;
     if (args.availabilityZoneNames && args.numberOfAvailabilityZones) {
       throw new Error(

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -75,6 +75,8 @@ export class Vpc extends schema.Vpc<VpcData> {
     args: schema.VpcArgs;
     opts: pulumi.ComponentResourceOptions;
   }): Promise<VpcData> {
+    Vpc.validateVpcArgs(props.args);
+
     const { name, args } = props;
     if (args.availabilityZoneNames && args.numberOfAvailabilityZones) {
       throw new Error(
@@ -301,6 +303,20 @@ export class Vpc extends schema.Vpc<VpcData> {
       isolatedSubnetIds,
       vpcId: vpc.id,
     };
+  }
+
+  // Internal. Exported for testing.
+  public static validateVpcArgs(args: schema.VpcArgs) {
+    if (args.ipv4IpamPoolId !== undefined) {
+      if (args.cidrBlock !== undefined && args.ipv4NetmaskLength !== undefined) {
+        throw new Error("Only one of 'cidrBlock', 'ipv4NetmaskLength' is allowed.");
+      }
+      if (args.ipv4NetmaskLength === undefined && args.cidrBlock === undefined) {
+        throw new Error(
+          "If 'ipv4IpamPoolId' is specified, 'ipv4NetmaskLength' or 'cidrBlock' must also be specified.",
+        );
+      }
+    }
   }
 
   // Decide the cidrBlock input parameter for the underlying aws.ec2.Vpc resource.

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -19,7 +19,7 @@ import { getSubnetSpecsLegacy } from "./subnetDistributorLegacy";
 import * as vpcConverters from "./vpcConverters";
 import { SubnetSpec, SubnetSpecPartial, validatePartialSubnetSpecs } from "./subnetSpecs";
 import {
-  getSubnetSpecsWithPartialCidr,
+  getSubnetSpecs,
   getSubnetSpecsExplicit,
   validateAndNormalizeSubnetInputs,
   NormalizedSubnetInputs,
@@ -469,7 +469,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           return getSubnetSpecsExplicit(name, availabilityZones, a.specs);
         case "NewAllocator":
         default:
-          return getSubnetSpecsWithPartialCidr(
+          return getSubnetSpecs(
             name,
             cidrBlock,
             availabilityZones,

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -15,8 +15,11 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as schema from "../schema-types";
-import * as vpcConverters from "./vpcConverters";
 import { getSubnetSpecsLegacy, SubnetSpec } from "./subnetDistributorLegacy";
+import * as vpcConverters from "./vpcConverters";
+import { getSubnetSpecsLegacy } from "./subnetDistributorLegacy";
+import { SubnetSpec } from "./subnetSpecs";
+
 import {
   getSubnetSpecs,
   getSubnetSpecsExplicit,

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -123,7 +123,7 @@ export class Vpc extends schema.Vpc<VpcData> {
 
     const subnetLayout = decidedSpecsAndLayout.subnetLayout;
 
-    const subnetSpecs = validatePartialSubnetSpecs(decidedSpecs, subnetSpecs => {
+    const subnetSpecs = validatePartialSubnetSpecs(decidedSpecs, (subnetSpecs) => {
       validateSubnets(subnetSpecs, getOverlappingSubnets);
       // Only prompt cidrBlock is validated; probably OK as non-prompt cidrBlock implies that ipv4NetmaskLength was
       // set to allocate the cidrBlock via IPAM.
@@ -358,7 +358,6 @@ export class Vpc extends schema.Vpc<VpcData> {
     subnetSpecs: SubnetSpecPartial[];
     subnetLayout: pulumi.Output<schema.ResolvedSubnetSpecOutputs[]>;
   } {
-
     const parsedSpecs: NormalizedSubnetInputs = validateAndNormalizeSubnetInputs(
       args.subnetSpecs,
       availabilityZones.length,
@@ -369,8 +368,10 @@ export class Vpc extends schema.Vpc<VpcData> {
       switch (a.allocator) {
         case "LegacyAllocator":
           if (typeof cidrBlock !== "string") {
-            throw new Error(`Dynamically allocated cidrBlock ranges are not supported with subnetStrategy="Legacy". `+
-              `"Try using subnetStrategy="Auto"`);
+            throw new Error(
+              `Dynamically allocated cidrBlock ranges are not supported with subnetStrategy="Legacy". ` +
+                `"Try using subnetStrategy="Auto"`,
+            );
           }
           const legacySubnetSpecs = getSubnetSpecsLegacy(
             name,
@@ -394,12 +395,14 @@ export class Vpc extends schema.Vpc<VpcData> {
     })();
 
     const subnetLayout: pulumi.Output<schema.ResolvedSubnetSpecOutputs[]> =
-      (subnetStrategy === "Legacy" || parsedSpecs?.normalizedSpecs === undefined)
-      ? pulumi.output(subnetSpecs)
-        .apply(ss => extractSubnetSpecInputFromLegacyLayout(ss, name, availabilityZones))
-        .apply(vpcConverters.toResolvedSubnetSpecOutputs)
-      : pulumi.output(parsedSpecs?.normalizedSpecs)
-        .apply(vpcConverters.toResolvedSubnetSpecOutputs);
+      subnetStrategy === "Legacy" || parsedSpecs?.normalizedSpecs === undefined
+        ? pulumi
+            .output(subnetSpecs)
+            .apply((ss) => extractSubnetSpecInputFromLegacyLayout(ss, name, availabilityZones))
+            .apply(vpcConverters.toResolvedSubnetSpecOutputs)
+        : pulumi
+            .output(parsedSpecs?.normalizedSpecs)
+            .apply(vpcConverters.toResolvedSubnetSpecOutputs);
 
     // Only warn if they're using a custom, non-explicit layout and haven't specified a strategy.
     if (
@@ -417,7 +420,7 @@ export class Vpc extends schema.Vpc<VpcData> {
       );
     }
 
-    return {subnetLayout, subnetSpecs};
+    return { subnetLayout, subnetSpecs };
   }
 
   async getDefaultAzs(azCount?: number): Promise<string[]> {
@@ -598,7 +601,10 @@ export function shouldCreateNatGateway(
   }
 }
 
-export function compareSubnetSpecs(spec1: Omit<SubnetSpec, "cidrBlock">, spec2: Omit<SubnetSpec, "cidrBlock">): number {
+export function compareSubnetSpecs(
+  spec1: Omit<SubnetSpec, "cidrBlock">,
+  spec2: Omit<SubnetSpec, "cidrBlock">,
+): number {
   if (spec1.type === spec2.type) {
     return 0;
   }

--- a/awsx/ec2/vpcConverters.ts
+++ b/awsx/ec2/vpcConverters.ts
@@ -19,11 +19,15 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as schema from "../schema-types";
 
-export function toResolvedSubnetSpecOutputs(s: schema.SubnetSpecInputs[]): schema.ResolvedSubnetSpecOutputs[] {
+export function toResolvedSubnetSpecOutputs(
+  s: schema.SubnetSpecInputs[],
+): schema.ResolvedSubnetSpecOutputs[] {
   return s.map(convSubnetSpecInputsToResolvedSubnetSpecOutputs);
 }
 
-function convSubnetSpecInputsToResolvedSubnetSpecOutputs(s: schema.SubnetSpecInputs): schema.ResolvedSubnetSpecOutputs {
+function convSubnetSpecInputsToResolvedSubnetSpecOutputs(
+  s: schema.SubnetSpecInputs,
+): schema.ResolvedSubnetSpecOutputs {
   return {
     name: s.name ? pulumi.output(s.name) : undefined,
     cidrBlocks: s.cidrBlocks ? pulumi.output(s.cidrBlocks) : undefined,

--- a/awsx/ec2/vpcConverters.ts
+++ b/awsx/ec2/vpcConverters.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Functions in module do not attempt any semantic processing and are simply helping the VPC resource translate
+// information between similar but distinct Input/Output forms. There might be an opportunity to use output tricks to
+// simplify these.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as schema from "../schema-types";
+
+export function toResolvedSubnetSpecOutputs(s: schema.SubnetSpecInputs[]): schema.ResolvedSubnetSpecOutputs[] {
+  return s.map(convSubnetSpecInputsToResolvedSubnetSpecOutputs);
+}
+
+function convSubnetSpecInputsToResolvedSubnetSpecOutputs(s: schema.SubnetSpecInputs): schema.ResolvedSubnetSpecOutputs {
+  return {
+    name: s.name ? pulumi.output(s.name) : undefined,
+    cidrBlocks: s.cidrBlocks ? pulumi.output(s.cidrBlocks) : undefined,
+    cidrMask: s.cidrMask ? pulumi.output(s.cidrMask) : undefined,
+    size: s.size ? pulumi.output(s.size) : undefined,
+    type: pulumi.output(s.type),
+  };
+}

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -587,18 +587,18 @@ export interface NatGatewayConfigurationOutputs {
 export type NatGatewayStrategyInputs = "None" | "Single" | "OnePerAz";
 export type NatGatewayStrategyOutputs = "None" | "Single" | "OnePerAz";
 export interface ResolvedSubnetSpecInputs {
-    readonly cidrBlocks?: string[];
-    readonly cidrMask?: number;
-    readonly name?: string;
-    readonly size?: number;
-    readonly type: SubnetTypeInputs;
+    readonly cidrBlocks?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly cidrMask?: pulumi.Input<number>;
+    readonly name?: pulumi.Input<string>;
+    readonly size?: pulumi.Input<number>;
+    readonly type: pulumi.Input<SubnetTypeInputs>;
 }
 export interface ResolvedSubnetSpecOutputs {
-    readonly cidrBlocks?: string[];
-    readonly cidrMask?: number;
-    readonly name?: string;
-    readonly size?: number;
-    readonly type: SubnetTypeOutputs;
+    readonly cidrBlocks?: pulumi.Output<string[]>;
+    readonly cidrMask?: pulumi.Output<number>;
+    readonly name?: pulumi.Output<string>;
+    readonly size?: pulumi.Output<number>;
+    readonly type: pulumi.Output<SubnetTypeOutputs>;
 }
 export type SubnetAllocationStrategyInputs = "Legacy" | "Auto" | "Exact";
 export type SubnetAllocationStrategyOutputs = "Legacy" | "Auto" | "Exact";

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -243,6 +243,7 @@ func TestVpcIpam(t *testing.T) {
 			With(integration.ProgramTestOptions{
 				Dir:                    dir,
 				RetryFailedSteps:       true,
+				NoParallel:             true, // test account has N=1 limit for IPAM
 				Quick:                  true,
 				ExtraRuntimeValidation: validate,
 			})
@@ -303,6 +304,7 @@ func TestVpcIpam(t *testing.T) {
 			With(integration.ProgramTestOptions{
 				Dir:                    dir,
 				RetryFailedSteps:       true,
+				NoParallel:             true, // test account has N=1 limit for IPAM
 				Quick:                  true,
 				ExtraRuntimeValidation: validate,
 			})

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -192,124 +192,122 @@ func TestVpcSpecificSubnetSpecArgs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-func TestVpcIpamIpv4AutoCidrBlock(t *testing.T) {
-	test := getNodeJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock"),
-			RetryFailedSteps: true,
-			Quick:            true,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				regionName := stack.Outputs["regionName"].(string)
+func TestVpcIpam(t *testing.T) {
+	t.Run("vpc-ipam-ipv4-auto-cidrblock", func(t *testing.T) {
+		dir := filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock")
+		validate := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			regionName := stack.Outputs["regionName"].(string)
+			assert.Equal(t, []interface{}{
+				map[string]interface{}{
+					"cidrMask": float64(27),
+					"type":     "Private",
+				},
+				map[string]interface{}{
+					"cidrMask": float64(28),
+					"type":     "Public",
+				},
+			}, stack.Outputs["subnetLayout"])
+			expectedSubnets := []interface{}{
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sa", regionName),
+					"cidrBlock":        "172.20.0.32/28",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sa", regionName),
+					"cidrBlock":        "172.20.0.0/27",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sb", regionName),
+					"cidrBlock":        "172.20.0.96/28",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sb", regionName),
+					"cidrBlock":        "172.20.0.64/27",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sc", regionName),
+					"cidrBlock":        "172.20.0.160/28",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sc", regionName),
+					"cidrBlock":        "172.20.0.128/27",
+				},
+			}
+			actualSubnets := stack.Outputs["subnets"].([]any)
+			assert.Equal(t, len(expectedSubnets), len(actualSubnets))
+			for _, expsub := range expectedSubnets {
+				assert.Contains(t, actualSubnets, expsub)
+			}
+		}
+		test := getNodeJSBaseOptions(t).
+			With(integration.ProgramTestOptions{
+				Dir:                    dir,
+				RetryFailedSteps:       true,
+				Quick:                  true,
+				ExtraRuntimeValidation: validate,
+			})
 
-				assert.Equal(t, []interface{}{
-					map[string]interface{}{
-						"cidrMask": float64(27),
-						"type":     "Private",
-					},
-					map[string]interface{}{
-						"cidrMask": float64(28),
-						"type":     "Public",
-					},
-				}, stack.Outputs["subnetLayout"])
-
-				expectedSubnets := []interface{}{
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sa", regionName),
-						"cidrBlock":        "172.20.0.32/28",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sa", regionName),
-						"cidrBlock":        "172.20.0.0/27",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sb", regionName),
-						"cidrBlock":        "172.20.0.96/28",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sb", regionName),
-						"cidrBlock":        "172.20.0.64/27",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sc", regionName),
-						"cidrBlock":        "172.20.0.160/28",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sc", regionName),
-						"cidrBlock":        "172.20.0.128/27",
-					},
-				}
-
-				actualSubnets := stack.Outputs["subnets"].([]any)
-				assert.Equal(t, len(expectedSubnets), len(actualSubnets))
-				for _, expsub := range expectedSubnets {
-					assert.Contains(t, actualSubnets, expsub)
-				}
-			},
-		})
-
-	integration.ProgramTest(t, &test)
-}
-
-func TestVpcIpamIpv4AutoCidrBlockWithSpecs(t *testing.T) {
-	dir := filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock-with-specs")
-	test := getNodeJSBaseOptions(t).
-		With(integration.ProgramTestOptions{
-			Dir:              dir,
-			RetryFailedSteps: true,
-			Quick:            true,
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				regionName := stack.Outputs["regionName"].(string)
-
-				assert.Equal(t, []interface{}{
-					map[string]interface{}{
-						"cidrMask": float64(25),
-						"size":     float64(128),
-						"name":     "private",
-						"type":     "Private",
-					},
-					map[string]interface{}{
-						"cidrMask": float64(27),
-						"size":     float64(32),
-						"name":     "public",
-						"type":     "Public",
-					},
-				}, stack.Outputs["subnetLayout"])
-
-				expectedSubnets := []interface{}{
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sa", regionName),
-						"cidrBlock":        "172.20.0.128/27",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sa", regionName),
-						"cidrBlock":        "172.20.0.0/25",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sb", regionName),
-						"cidrBlock":        "172.20.1.128/27",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sb", regionName),
-						"cidrBlock":        "172.20.1.0/25",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sc", regionName),
-						"cidrBlock":        "172.20.2.128/27",
-					},
-					map[string]interface{}{
-						"availabilityZone": fmt.Sprintf("%sc", regionName),
-						"cidrBlock":        "172.20.2.0/25",
-					},
-				}
-
-				actualSubnets := stack.Outputs["subnets"].([]any)
-				assert.Equal(t, len(expectedSubnets), len(actualSubnets))
-				for _, expsub := range expectedSubnets {
-					assert.Contains(t, actualSubnets, expsub)
-				}
-			},
-		})
-	integration.ProgramTest(t, &test)
+		integration.ProgramTest(t, &test)
+	})
+	t.Run("vpc-ipam-ipv4-auto-cidrblock-with-specs", func(t *testing.T) {
+		dir := filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock-with-specs")
+		validate := func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			regionName := stack.Outputs["regionName"].(string)
+			assert.Equal(t, []interface{}{
+				map[string]interface{}{
+					"cidrMask": float64(25),
+					"size":     float64(128),
+					"name":     "private",
+					"type":     "Private",
+				},
+				map[string]interface{}{
+					"cidrMask": float64(27),
+					"size":     float64(32),
+					"name":     "public",
+					"type":     "Public",
+				},
+			}, stack.Outputs["subnetLayout"])
+			expectedSubnets := []interface{}{
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sa", regionName),
+					"cidrBlock":        "172.20.0.128/27",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sa", regionName),
+					"cidrBlock":        "172.20.0.0/25",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sb", regionName),
+					"cidrBlock":        "172.20.1.128/27",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sb", regionName),
+					"cidrBlock":        "172.20.1.0/25",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sc", regionName),
+					"cidrBlock":        "172.20.2.128/27",
+				},
+				map[string]interface{}{
+					"availabilityZone": fmt.Sprintf("%sc", regionName),
+					"cidrBlock":        "172.20.2.0/25",
+				},
+			}
+			actualSubnets := stack.Outputs["subnets"].([]any)
+			assert.Equal(t, len(expectedSubnets), len(actualSubnets))
+			for _, expsub := range expectedSubnets {
+				assert.Contains(t, actualSubnets, expsub)
+			}
+		}
+		test := getNodeJSBaseOptions(t).
+			With(integration.ProgramTestOptions{
+				Dir:                    dir,
+				RetryFailedSteps:       true,
+				Quick:                  true,
+				ExtraRuntimeValidation: validate,
+			})
+		integration.ProgramTest(t, &test)
+	})
 }
 
 func TestVpc(t *testing.T) {

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -17,6 +17,7 @@
 package examples
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -191,7 +192,127 @@ func TestVpcSpecificSubnetSpecArgs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
-func TestVpcMultipleSimilarSubnetSpecArgs(t *testing.T) {
+func TestVpcIpamIpv4AutoCidrBlock(t *testing.T) {
+	test := getNodeJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:              filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock"),
+			RetryFailedSteps: true,
+			Quick:            true,
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				regionName := stack.Outputs["regionName"].(string)
+
+				assert.Equal(t, []interface{}{
+					map[string]interface{}{
+						"cidrMask": float64(27),
+						"type":     "Private",
+					},
+					map[string]interface{}{
+						"cidrMask": float64(28),
+						"type":     "Public",
+					},
+				}, stack.Outputs["subnetLayout"])
+
+				expectedSubnets := []interface{}{
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sa", regionName),
+						"cidrBlock":        "172.20.0.32/28",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sa", regionName),
+						"cidrBlock":        "172.20.0.0/27",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sb", regionName),
+						"cidrBlock":        "172.20.0.96/28",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sb", regionName),
+						"cidrBlock":        "172.20.0.64/27",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sc", regionName),
+						"cidrBlock":        "172.20.0.160/28",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sc", regionName),
+						"cidrBlock":        "172.20.0.128/27",
+					},
+				}
+
+				actualSubnets := stack.Outputs["subnets"].([]any)
+				assert.Equal(t, len(expectedSubnets), len(actualSubnets))
+				for _, expsub := range expectedSubnets {
+					assert.Contains(t, actualSubnets, expsub)
+				}
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestVpcIpamIpv4AutoCidrBlockWithSpecs(t *testing.T) {
+	dir := filepath.Join(getCwd(t), "vpc", "nodejs", "vpc-ipam-ipv4-auto-cidrblock-with-specs")
+	test := getNodeJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:              dir,
+			RetryFailedSteps: true,
+			Quick:            true,
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				regionName := stack.Outputs["regionName"].(string)
+
+				assert.Equal(t, []interface{}{
+					map[string]interface{}{
+						"cidrMask": float64(25),
+						"size":     float64(128),
+						"name":     "private",
+						"type":     "Private",
+					},
+					map[string]interface{}{
+						"cidrMask": float64(27),
+						"size":     float64(32),
+						"name":     "public",
+						"type":     "Public",
+					},
+				}, stack.Outputs["subnetLayout"])
+
+				expectedSubnets := []interface{}{
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sa", regionName),
+						"cidrBlock":        "172.20.0.128/27",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sa", regionName),
+						"cidrBlock":        "172.20.0.0/25",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sb", regionName),
+						"cidrBlock":        "172.20.1.128/27",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sb", regionName),
+						"cidrBlock":        "172.20.1.0/25",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sc", regionName),
+						"cidrBlock":        "172.20.2.128/27",
+					},
+					map[string]interface{}{
+						"availabilityZone": fmt.Sprintf("%sc", regionName),
+						"cidrBlock":        "172.20.2.0/25",
+					},
+				}
+
+				actualSubnets := stack.Outputs["subnets"].([]any)
+				assert.Equal(t, len(expectedSubnets), len(actualSubnets))
+				for _, expsub := range expectedSubnets {
+					assert.Contains(t, actualSubnets, expsub)
+				}
+			},
+		})
+	integration.ProgramTest(t, &test)
+}
+
+func TestVpc(t *testing.T) {
 	test := getNodeJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			RunUpdateTest:    false,

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/.gitignore
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/Pulumi.yaml
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: vpc-ipam-ipv4-auto-cidrblock-with-specs
+runtime:
+  name: nodejs
+description: Test inheriting the cidrBlock from an IPv4 IPAM pool and constraining the subnet specs
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/index.ts
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/index.ts
@@ -1,0 +1,62 @@
+import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+import { SubnetAllocationStrategy } from "@pulumi/awsx/ec2";
+
+const repository = "pulumi/pulumi-awsx";
+const testcase = "vpc-ipam-ipv4-auto-cidrblock-with-specs";
+
+const tags = {
+  "repository": repository,
+  "testcase": testcase,
+};
+
+const currentRegion = aws.getRegionOutput({});
+
+const myVpcIpam = new aws.ec2.VpcIpam("myVpcIpam", {
+  operatingRegions: [{
+    regionName: currentRegion.name,
+  }],
+  description: `IPAM for ${repository} example ${testcase}`,
+  tags: tags,
+});
+
+const myVpcIpamPool = new aws.ec2.VpcIpamPool("myVpcIpamPool", {
+  addressFamily: "ipv4",
+  ipamScopeId: myVpcIpam.privateDefaultScopeId,
+  locale: currentRegion.name,
+  tags: tags,
+});
+
+const myVpcIpamPoolCidr = new aws.ec2.VpcIpamPoolCidr("myVpcIpamPoolCidr", {
+  ipamPoolId: myVpcIpamPool.id,
+  cidr: "172.20.0.0/16",
+});
+
+const myVpc = new awsx.ec2.Vpc("myVpc", {
+  numberOfAvailabilityZones: 3,
+  subnetStrategy: SubnetAllocationStrategy.Auto,
+  ipv4IpamPoolId: myVpcIpamPool.id,
+  ipv4NetmaskLength: 22,
+  subnetSpecs: [
+    {
+      type: "Private",
+      name: "private",
+      cidrMask: 25,
+    },
+    {
+      type: "Public",
+      name: "public",
+      cidrMask: 27,
+    },
+  ],
+  tags: tags,
+}, {
+  dependsOn: [myVpcIpamPoolCidr],
+});
+
+export const regionName = currentRegion.name;
+export const subnetLayout = myVpc.subnetLayout;
+export const subnets = myVpc.subnets.apply(s => s.map(x => ({
+  availabilityZone: x.availabilityZone,
+  cidrBlock: x.cidrBlock
+})));

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/package.json
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "vpc-ipam-ipv4-auto-cidrblock-with-specs",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/tsconfig.json
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock-with-specs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/.gitignore
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/Pulumi.yaml
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: vpc-ipam-ipv4-auto-cidrblock
+runtime:
+  name: nodejs
+description: Test inheriting the cidrBlock from an IPv4 IPAM pool
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/index.ts
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/index.ts
@@ -35,6 +35,7 @@ const myVpc = new awsx.ec2.Vpc("myVpc", {
   ipv4IpamPoolId: myVpcIpamPool.id,
   ipv4NetmaskLength: 24,
   tags: tags,
+  subnetStrategy: "Auto",
 }, {
   dependsOn: [myVpcIpamPoolCidr],
 });

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/index.ts
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/index.ts
@@ -1,0 +1,47 @@
+import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+
+const repository = "pulumi/pulumi-awsx";
+const testcase = "vpc-ipam-ipv4-auto-cidrblock";
+
+const tags = {
+  "repository": repository,
+  "testcase": testcase,
+};
+
+const currentRegion = aws.getRegionOutput({});
+
+const myVpcIpam = new aws.ec2.VpcIpam("myVpcIpam", {
+  operatingRegions: [{
+    regionName: currentRegion.name,
+  }],
+  description: `IPAM for ${repository} example ${testcase}`,
+  tags: tags,
+});
+
+const myVpcIpamPool = new aws.ec2.VpcIpamPool("myVpcIpamPool", {
+  addressFamily: "ipv4",
+  ipamScopeId: myVpcIpam.privateDefaultScopeId,
+  locale: currentRegion.name,
+  tags: tags,
+});
+
+const myVpcIpamPoolCidr = new aws.ec2.VpcIpamPoolCidr("myVpcIpamPoolCidr", {
+  ipamPoolId: myVpcIpamPool.id,
+  cidr: "172.20.0.0/16",
+});
+
+const myVpc = new awsx.ec2.Vpc("myVpc", {
+  ipv4IpamPoolId: myVpcIpamPool.id,
+  ipv4NetmaskLength: 24,
+  tags: tags,
+}, {
+  dependsOn: [myVpcIpamPoolCidr],
+});
+
+export const regionName = currentRegion.name;
+export const subnetLayout = myVpc.subnetLayout;
+export const subnets = myVpc.subnets.apply(s => s.map(x => ({
+  availabilityZone: x.availabilityZone,
+  cidrBlock: x.cidrBlock
+})));

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/package.json
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "vpc-ipam-ipv4-auto-cidrblock",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/awsx": "^2.0.2",
+        "@pulumi/pulumi": "^3.113.0"
+    }
+}

--- a/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/tsconfig.json
+++ b/examples/vpc/nodejs/vpc-ipam-ipv4-auto-cidrblock/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/schema.json
+++ b/schema.json
@@ -581,30 +581,24 @@
                 "cidrBlocks": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "plain": true
+                        "type": "string"
                     },
-                    "plain": true,
                     "description": "An optional list of CIDR blocks to assign to the subnet spec for each AZ. If specified, the count must match the number of AZs being used for the VPC, and must also be specified for all other subnet specs."
                 },
                 "cidrMask": {
                     "type": "integer",
-                    "plain": true,
                     "description": "The netmask for the subnet's CIDR block. This is optional, the default value is inferred from the `cidrMask`, `cidrBlocks` or based on an even distribution of available space from the VPC's CIDR block after being divided evenly by availability zone."
                 },
                 "name": {
                     "type": "string",
-                    "plain": true,
                     "description": "The subnet's name. Will be templated upon creation."
                 },
                 "size": {
                     "type": "integer",
-                    "plain": true,
                     "description": "Optional size of the subnet's CIDR block - the number of hosts. This value must be a power of 2 (e.g. 256, 512, 1024, etc.). This is optional, the default value is inferred from the `cidrMask`, `cidrBlocks` or based on an even distribution of available space from the VPC's CIDR block after being divided evenly by availability zone."
                 },
                 "type": {
                     "$ref": "#/types/awsx:ec2:SubnetType",
-                    "plain": true,
                     "description": "The type of subnet."
                 }
             },

--- a/schemagen/pkg/gen/ec2.go
+++ b/schemagen/pkg/gen/ec2.go
@@ -367,28 +367,28 @@ func resolvedSubnetSpecType() schema.ComplexTypeSpec {
 			Properties: map[string]schema.PropertySpec{
 				"type": {
 					Description: "The type of subnet.",
-					TypeSpec: schema.TypeSpec{
-						Ref:   localRef("ec2", "SubnetType"),
-						Plain: true,
-					},
+					TypeSpec:    schema.TypeSpec{Ref: localRef("ec2", "SubnetType")},
 				},
 				"name": {
 					Description: "The subnet's name. Will be templated upon creation.",
-					TypeSpec:    plainString(),
+					TypeSpec:    schema.TypeSpec{Type: "string"},
 				},
 				"cidrMask": {
 					// The validation rules are too difficult to concisely describe here, so we'll leave that job to any
 					// error messages generated from the component itself.
 					Description: "The netmask for the subnet's CIDR block. This is optional, the default value is inferred from the `cidrMask`, `cidrBlocks` or based on an even distribution of available space from the VPC's CIDR block after being divided evenly by availability zone.",
-					TypeSpec:    plainInt(),
+					TypeSpec:    schema.TypeSpec{Type: "integer"},
 				},
 				"cidrBlocks": {
 					Description: "An optional list of CIDR blocks to assign to the subnet spec for each AZ. If specified, the count must match the number of AZs being used for the VPC, and must also be specified for all other subnet specs.",
-					TypeSpec:    plainArrayOfPlainStrings(),
+					TypeSpec: schema.TypeSpec{
+						Type:  "array",
+						Items: &schema.TypeSpec{Type: "string"},
+					},
 				},
 				"size": {
 					Description: "Optional size of the subnet's CIDR block - the number of hosts. This value must be a power of 2 (e.g. 256, 512, 1024, etc.). This is optional, the default value is inferred from the `cidrMask`, `cidrBlocks` or based on an even distribution of available space from the VPC's CIDR block after being divided evenly by availability zone.",
-					TypeSpec:    plainInt(),
+					TypeSpec:    schema.TypeSpec{Type: "integer"},
 				},
 			},
 			Required: []string{


### PR DESCRIPTION
Fixes issues with supporting the ipv4IpamPoolId parameter that ties a VPC to an IPAM pool. 

You should now be able to write the following to allows IPAM to allocate and manage a cidrBlock range. The VPC component now uses that dynamically allocated block to automatically configure subnets.

```typescript
new awsx.ec2.Vpc("myVpc", {
  ipv4IpamPoolId: myVpcIpamPool.id,
  ipv4NetmaskLength: 24,
  subnetStrategy: "Auto",
});
```

It is also possible to constrain the allocated subnets with subnetSpecs, while still using IPAM to manage the overall cidrBlock range:

```typescript
new awsx.ec2.Vpc("myVpc", {
  numberOfAvailabilityZones: 3,
  subnetStrategy: "Auto",
  ipv4IpamPoolId: myVpcIpamPool.id,
  ipv4NetmaskLength: 22,
  subnetSpecs: [
    {
      type: "Private",
      name: "private",
      cidrMask: 25,
    },
    {
      type: "Public",
      name: "public",
      cidrMask: 27,
    },
  ],
  tags: tags,
});
```

Fixes #872 

Note that `subnetStrategy: "Auto"` is required with this functionality, and "Legacy" strategy is not supported.