### PR TITLE
Fix VPC support for Auto subnet layout strategy

### DIFF
--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -303,10 +303,9 @@ describe("picking subnet allocator", () => {
     expect(a.allocator).toBe("LegacyAllocator");
   });
 
-  // This behavior is suspect as NewAllocator supports working without any subnet specs defined.
-  it("picks legacy allocator for the auto strategy with no specs", () => {
+  it("picks NewAllocator for the auto strategy with no specs", () => {
     const a = Vpc.pickSubnetAllocator(undefined, "Auto");
-    expect(a.allocator).toBe("LegacyAllocator");
+    expect(a.allocator).toBe("NewAllocator");
   });
 
   // This behavior looks like a degenerate case perhaps marking the strategy as invalid and failing could be preferable.

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -374,7 +374,9 @@ export class Vpc extends schema.Vpc<VpcData> {
     | { allocator: "LegacyAllocator" | "NewAllocator" }
     | { allocator: "ExplicitAllocator"; specs: ExplicitSubnetSpecInputs[] } {
     if (parsedSpecs === undefined) {
-      return subnetStrategy === "Auto" ? {allocator: "NewAllocator"} : {allocator: "LegacyAllocator"};
+      return subnetStrategy === "Auto"
+        ? { allocator: "NewAllocator" }
+        : { allocator: "LegacyAllocator" };
     }
     if (subnetStrategy === "Legacy") {
       return { allocator: "LegacyAllocator" };

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -373,7 +373,10 @@ export class Vpc extends schema.Vpc<VpcData> {
   ):
     | { allocator: "LegacyAllocator" | "NewAllocator" }
     | { allocator: "ExplicitAllocator"; specs: ExplicitSubnetSpecInputs[] } {
-    if (parsedSpecs === undefined || subnetStrategy === "Legacy") {
+    if (parsedSpecs === undefined) {
+      return subnetStrategy === "Auto" ? {allocator: "NewAllocator"} : {allocator: "LegacyAllocator"};
+    }
+    if (subnetStrategy === "Legacy") {
       return { allocator: "LegacyAllocator" };
     }
     if (parsedSpecs.isExplicitLayout) {


### PR DESCRIPTION
The awsx.ec2.Vpc resource supports three subnet layout strategies: Auto, Exact, and Legacy. Consider the following program that does not specify the subnet specs:

    new awsx.ec2.Vpc("vpc", {
        subnetStrategy: "Auto",
    });

Prior to this change, the code would implicitly use the Legacy strategy for this program even though Auto is requested. This is now fixed. The Auto strategy already supports allocating subnets without any explicit specs provided.