### PR TITLE
Rewrite a warning to avoid printing an output directly

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -489,13 +489,13 @@ export class Vpc extends schema.Vpc<VpcData> {
             .output(parsedSpecs?.normalizedSpecs)
             .apply(vpcConverters.toResolvedSubnetSpecOutputs);
 
-    // Only warn if they're using a custom, non-explicit layout and haven't specified a strategy.
-    if (
-      args.subnetStrategy === undefined &&
-      parsedSpecs !== undefined &&
-      parsedSpecs.isExplicitLayout === false
-    ) {
-      subnetLayout.apply((sl) => {
+    const verifiedSubnetLayout = subnetLayout.apply((sl) => {
+      // Only warn if they're using a custom, non-explicit layout and haven't specified a strategy.
+      if (
+        args.subnetStrategy === undefined &&
+        parsedSpecs !== undefined &&
+        parsedSpecs.isExplicitLayout === false
+      ) {
         pulumi.log.warn(
           `The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:\n\n${JSON.stringify(
             sl,
@@ -504,10 +504,11 @@ export class Vpc extends schema.Vpc<VpcData> {
           )}`,
           this,
         );
-      });
-    }
+      }
+      return sl;
+    });
 
-    return { subnetLayout, subnetSpecs };
+    return { subnetLayout: verifiedSubnetLayout, subnetSpecs };
   }
 
   async getDefaultAzs(azCount?: number): Promise<string[]> {

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -495,14 +495,16 @@ export class Vpc extends schema.Vpc<VpcData> {
       parsedSpecs !== undefined &&
       parsedSpecs.isExplicitLayout === false
     ) {
-      pulumi.log.warn(
-        `The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:\n\n${JSON.stringify(
-          subnetLayout,
-          undefined,
-          2,
-        )}`,
-        this,
-      );
+      subnetLayout.apply((sl) => {
+        pulumi.log.warn(
+          `The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:\n\n${JSON.stringify(
+            sl,
+            undefined,
+            2,
+          )}`,
+          this,
+        );
+      });
     }
 
     return { subnetLayout, subnetSpecs };


### PR DESCRIPTION
We can't use JSON.stringify on an output directly, we need to do that inside an apply. 

Fix https://github.com/pulumi/pulumi-awsx/issues/1372