### PR TITLE
Fix getRegion functions

### DIFF
--- a/awsx/s3/bucket.ts
+++ b/awsx/s3/bucket.ts
@@ -16,7 +16,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import { ResourceOptions } from "@pulumi/pulumi";
 import * as schema from "../schema-types";
-import { getRegion, getRegionFromOpts, parseArn } from "../utils";
+import { parseArn } from "../utils";
 
 export interface BucketId {
   name: pulumi.Output<string>;

--- a/awsx/utils.ts
+++ b/awsx/utils.ts
@@ -82,15 +82,12 @@ export function getRegionFromOpts(opts: pulumi.CustomResourceOptions): pulumi.Ou
 
 /** @internal */
 export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
-  // A little strange, but all we're doing is passing a fake type-token simply to get
-  // the AWS provider from this resource.
-  const provider = res.getProvider ? res.getProvider("aws::") : undefined;
-  return getRegionFromProvider(provider);
+  // uses the provider from the parent resource to fetch the region
+  return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
 }
 
 function getRegionFromProvider(provider: pulumi.ProviderResource | undefined) {
-  const region = provider ? (<any>provider).region : undefined;
-  return region || aws.config.region;
+  return aws.getRegionOutput({}, { provider }).apply(region => region.name as aws.Region);
 }
 
 /**

--- a/awsx/utils.ts
+++ b/awsx/utils.ts
@@ -83,11 +83,11 @@ export function getRegionFromOpts(opts: pulumi.CustomResourceOptions): pulumi.Ou
 /** @internal */
 export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
   // uses the provider from the parent resource to fetch the region
-  return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
+  return aws.getRegionOutput({}, { parent: res }).apply((region) => region.name as aws.Region);
 }
 
 function getRegionFromProvider(provider: pulumi.ProviderResource | undefined) {
-  return aws.getRegionOutput({}, { provider }).apply(region => region.name as aws.Region);
+  return aws.getRegionOutput({}, { provider }).apply((region) => region.name as aws.Region);
 }
 
 /**

--- a/awsx/utils.ts
+++ b/awsx/utils.ts
@@ -86,7 +86,9 @@ export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
   return aws.getRegionOutput({}, { parent: res }).apply((region) => region.name as aws.Region);
 }
 
-function getRegionFromProvider(provider: pulumi.ProviderResource | undefined) {
+function getRegionFromProvider(
+  provider: pulumi.ProviderResource | undefined,
+): pulumi.Output<aws.Region> {
   return aws.getRegionOutput({}, { provider }).apply((region) => region.name as aws.Region);
 }
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -18,6 +18,7 @@ package examples
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -43,6 +44,23 @@ func TestAccEcsCapacityProviderService(t *testing.T) {
 			Dir:           filepath.Join(getCwd(t), "ecs", "nodejs"),
 		})
 
+	integration.ProgramTest(t, &test)
+}
+
+func TestRegress1112(t *testing.T) {
+	t.Setenv("AWS_REGION", "")
+	os.Unsetenv("AWS_REGION")
+	test := integration.ProgramTestOptions{
+		Quick:                true,
+		SkipRefresh:          true,
+	}.With(integration.ProgramTestOptions{
+		Dependencies: []string{
+			"@pulumi/awsx",
+		},
+		NoParallel:    true, // cannot use call t.Parallel after t.Setenv
+		RunUpdateTest: false,
+		Dir:           filepath.Join(getCwd(t), "ecs", "nodejs"),
+	})
 	integration.ProgramTest(t, &test)
 }
 


### PR DESCRIPTION
The `getRegion` functions were incorrectly trying to extract the current region from the provider. This silently resolved to undefined in certain cases; e.g. when no `AWS_REGION` ENV variable was set.
In particular this caused ECS tasks to fail because they used `https://logs.undefined.amazonaws.com/` as the endpoint for cloudwatch.

Instead we should use the `getRegion` data source to correctly identify the current region.

Fixes #1112
Fixes #1279
