### PR TITLE
Fix: do not over-specify the SDK versions

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -17,7 +17,6 @@
         "csharp": {
             "liftSingleValueMethodReturns": true,
             "packageReferences": {
-                "Pulumi": "3.*",
                 "Pulumi.Aws": "6.*",
                 "Pulumi.Docker": "4.*"
             },
@@ -43,7 +42,6 @@
                 "@aws-sdk/client-ecs": "^3.405.0",
                 "@pulumi/aws": "^6.47.0",
                 "@pulumi/docker": "^4.5.1",
-                "@pulumi/pulumi": "^3.0.0",
                 "@types/aws-lambda": "^8.10.23",
                 "aws-sdk": "^2.1450.0",
                 "docker-classic": "npm:@pulumi/docker@3.6.1",
@@ -63,7 +61,6 @@
             },
             "readme": "Pulumi Amazon Web Services (AWS) AWSX Components.",
             "requires": {
-                "pulumi": "\u003e=3.91.1,\u003c4.0.0",
                 "pulumi-aws": "\u003e=6.0.4,\u003c7.0.0",
                 "pulumi-docker": "\u003e=4.5.1,\u003c5.0.0"
             },

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -56,7 +56,6 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			"csharp": rawMessage(map[string]interface{}{
 				"packageReferences": map[string]string{
 					// We use .* format rather than [x,y) because then it prefers the maximum satisfiable version
-					"Pulumi":        "3.*",
 					"Pulumi.Aws":    "6.*",
 					"Pulumi.Docker": "4.*",
 				},
@@ -79,7 +78,6 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			"nodejs": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
 					"@aws-sdk/client-ecs": "^3.405.0",
-					"@pulumi/pulumi":      "^3.0.0",
 					"@pulumi/aws":         "^" + dependencies.Aws,
 					"@pulumi/docker":      "^" + dependencies.Docker,
 					"docker-classic":      "npm:@pulumi/docker@3.6.1",
@@ -96,7 +94,6 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"python": rawMessage(map[string]interface{}{
 				"requires": map[string]string{
-					"pulumi":        ">=3.91.1,<4.0.0",
 					"pulumi-aws":    ">=6.0.4,<7.0.0",
 					"pulumi-docker": fmt.Sprintf(">=%s,<5.0.0", dependencies.Docker),
 				},

--- a/sdk/dotnet/Pulumi.Awsx.csproj
+++ b/sdk/dotnet/Pulumi.Awsx.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="[3.66.1.0,4)" />
     <PackageReference Include="Pulumi.Aws" Version="6.*" ExcludeAssets="contentFiles" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" ExcludeAssets="contentFiles" />
   </ItemGroup>

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -18,7 +18,7 @@
         "@aws-sdk/client-ecs": "^3.405.0",
         "@pulumi/aws": "^6.47.0",
         "@pulumi/docker": "^4.5.1",
-        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/pulumi": "^3.133.0",
         "@types/aws-lambda": "^8.10.23",
         "aws-sdk": "^2.1450.0",
         "docker-classic": "npm:@pulumi/docker@3.6.1",

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_awsx"
   description = "Pulumi Amazon Web Services (AWS) AWSX Components."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.91.1,<4.0.0", "pulumi-aws>=6.0.4,<7.0.0", "pulumi-docker>=4.5.1,<5.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "pulumi-aws>=6.0.4,<7.0.0", "pulumi-docker>=4.5.1,<5.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   keywords = ["pulumi", "aws", "awsx", "kind/component", "category/cloud"]
   readme = "README.md"
   requires-python = ">=3.8"


### PR DESCRIPTION
Re: https://github.com/pulumi/ci-mgmt/issues/1091

Something is not quite right, I suspect might need to bump codegen as well here:

```
/Users/anton/code/pulumi-awsx/sdk/dotnet/Pulumi.Awsx.csproj : error NU1605: Detected package downgrade: Pulumi from 3.67.1 to 3.66.1. Reference the package directly from the project to select a different version. 
/Users/anton/code/pulumi-awsx/sdk/dotnet/Pulumi.Awsx.csproj : error NU1605:  Pulumi.Awsx -> Pulumi.Docker 4.5.6 -> Pulumi (>= 3.67.1) 
/Users/anton/code/pulumi-awsx/sdk/dotnet/Pulumi.Awsx.csproj : error NU1605:  Pulumi.Awsx -> Pulumi (>= 3.66.1 && < 4.0.0)
    0 Warning(s)
    1 Error(s)

```
