### PR TITLE
chore: remove unused aws-sdk dependency

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -44,7 +44,6 @@
                 "@pulumi/aws": "^6.47.0",
                 "@pulumi/docker": "^4.5.1",
                 "@types/aws-lambda": "^8.10.23",
-                "aws-sdk": "^2.1450.0",
                 "docker-classic": "npm:@pulumi/docker@3.6.1",
                 "mime": "^2.0.0"
             },

--- a/schemagen/pkg/gen/schema.go
+++ b/schemagen/pkg/gen/schema.go
@@ -83,7 +83,6 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 					"@pulumi/docker":      "^" + dependencies.Docker,
 					"docker-classic":      "npm:@pulumi/docker@3.6.1",
 					"@types/aws-lambda":   "^8.10.23",
-					"aws-sdk":             "^2.1450.0",
 					"mime":                "^2.0.0",
 				},
 				"devDependencies": map[string]string{

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -20,7 +20,6 @@
         "@pulumi/docker": "^4.5.1",
         "@pulumi/pulumi": "^3.134.1",
         "@types/aws-lambda": "^8.10.23",
-        "aws-sdk": "^2.1450.0",
         "docker-classic": "npm:@pulumi/docker@3.6.1",
         "mime": "^2.0.0"
     },


### PR DESCRIPTION
Looks like this was left behind after a migration to the V3 sdk.

fixes #1393