### PR TITLE
Rewrite a warning to avoid printing sub-properties as outputs

### DIFF
--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -489,7 +489,7 @@ export class Vpc extends schema.Vpc<VpcData> {
             .output(parsedSpecs?.normalizedSpecs)
             .apply(vpcConverters.toResolvedSubnetSpecOutputs);
 
-    const verifiedSubnetLayout = subnetLayout.apply((sl) => {
+    const verifiedSubnetLayout = pulumi.jsonStringify(subnetLayout).apply((sl) => {
       // Only warn if they're using a custom, non-explicit layout and haven't specified a strategy.
       if (
         args.subnetStrategy === undefined &&
@@ -497,15 +497,11 @@ export class Vpc extends schema.Vpc<VpcData> {
         parsedSpecs.isExplicitLayout === false
       ) {
         pulumi.log.warn(
-          `The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:\n\n${JSON.stringify(
-            sl,
-            undefined,
-            2,
-          )}`,
+          `The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:\n\n${sl}`,
           this,
         );
       }
-      return sl;
+      return subnetLayout;
     });
 
     return { subnetLayout: verifiedSubnetLayout, subnetSpecs };


### PR DESCRIPTION
Another fix for https://github.com/pulumi/pulumi-awsx/issues/1372 while https://github.com/pulumi/pulumi-awsx/pull/1374 only partially succeeded.

The previous attempt was successful in resolving the top-level output but child outputs were still unresolved. I was a bit surprised that was the case... outputs are hard!

The new attempt relies on `pulumi.jsonStringify` which is made exactly for this purpose. This drops JSON formatting but hopefully that not too bad for a small JSON. Example of the result:

```
 warning: The default subnetStrategy will change from "Legacy" to "Auto" in the next major version. Please specify the subnetStrategy explicitly. The current subnet layout can be specified via "Auto" as:
    
    [{"cidrMask":20,"type":"Public"}]
```