### PR TITLE
Rebuild awsx/schema-types.ts when upgrading AWS dependency

### DIFF
--- a/scripts/upgrade-aws.sh
+++ b/scripts/upgrade-aws.sh
@@ -21,3 +21,6 @@ echo "V=$VER"
 
 # Rebulid the SDKs, which will also rebuild the schema and all other files.
 make build_sdks
+
+# Rebuild provider internals such as awsx/schema-types.ts
+make provider


### PR DESCRIPTION
Fixes a small miss in the automation to keep the AWS dependency up-to-date. 