### PR TITLE
testing: examples/ecs/nodejs add missing dependsOn

### DIFF
--- a/examples/ecs/nodejs/index.ts
+++ b/examples/ecs/nodejs/index.ts
@@ -29,6 +29,8 @@ const service = new ecs.FargateService("my-service", {
         subnets: vpc.publicSubnetIds,
         assignPublicIp: true,
     },
+}, {
+    dependsOn: [lb.loadBalancer],
 });
 
 // Export the load balancer's address so that it's easy to access.


### PR DESCRIPTION
Pulumi was not recognizing that the underlying aws.ecs.Service should wait for the load balancer to be provisioned, causing a race that sporadically would flake up the test. This is now compensated by with a dependsOn option.

Fixes #1418