### PR TITLE
Update CI to Python 3.9

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -24,9 +24,9 @@ runs:
         registry-url: https://registry.npmjs.org
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: Setup DotNet
       if: inputs.skip_dotnet_and_java != 'true'


### PR DESCRIPTION
Since the https://github.com/pulumi/pulumi/pull/17883 change Pulumi no longer supports 3.8 and tests need to be performed on 3.9 or later versions of Python.