### PR TITLE
chore: enable testing CI changes

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -242,3 +242,4 @@ on:
   pull_request:
     branches:
       - master
+      - test-ci-changes


### PR DESCRIPTION
With this change a PR can be stood up with changes to GitHub Actions workflows and the new version tested in that PR