### PR TITLE
chore: ensure deduplicated dependencies

### DIFF
--- a/.mk/build.mk
+++ b/.mk/build.mk
@@ -14,6 +14,7 @@ AWSX_SRC := $(wildcard awsx/*.*) $(wildcard awsx/*/*.ts)
 .make/provider/darwin-arm64: TARGET := node16-macos-arm64
 .make/provider/windows-amd64: TARGET := node16-win-x64
 .make/provider/%: .make/awsx_bin .make/gen_types
+	cd awsx && yarn run check-duplicate-deps
 	cd awsx && yarn run pkg . ${PKG_ARGS} --target "${TARGET}" --output "${PROVIDER_BIN}"
 	mkdir -p .make/provider
 	@touch $@

--- a/.mk/renovate.mk
+++ b/.mk/renovate.mk
@@ -1,2 +1,3 @@
 .PHONY: renovate
 renovate: generate_sdks
+	cd awsx && yarn run dedupe-deps


### PR DESCRIPTION
This is an important check to include to fail early. If Renovate updates dependencies in a way that causes several copies of `@pulumi/pulumi` SDK to be included then the provider fails at runtime with an obscure error about invokes, as in https://github.com/pulumi/pulumi-awsx/pull/1479 - this will fail the build early instead.