### PR TITLE
chore: ensure Renovate deduplicates dependencies

### DIFF
--- a/.mk/renovate.mk
+++ b/.mk/renovate.mk
@@ -1,2 +1,3 @@
 .PHONY: renovate
 renovate: generate_sdks
+	cd awsx && yarn run dedupe-deps


### PR DESCRIPTION
When Renovate bot updates dependencies for the provider, we want to make sure that the new set of dependencies does not result in any duplication aka several versions of `@pulumi/pulumi` being included.