### PR TITLE
Increase timeout for `TestAccEcsParallel`

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -350,8 +350,9 @@ func TestVpc(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+// Verifies that ECS services are created/updated in parallel. This took 1+ hours to run before fixing pulumi/pulumi#7629
 func TestAccEcsParallel(t *testing.T) {
-	maxDuration(15*time.Minute, t, func(t *testing.T) {
+	maxDuration(30*time.Minute, t, func(t *testing.T) {
 		test := getNodeJSBaseOptions(t).
 			With(integration.ProgramTestOptions{
 				RunUpdateTest: false,


### PR DESCRIPTION
This test verifies that components like ECS services are created/updated in parallel. This took 1+ hours to run before fixing pulumi/pulumi#7629.
The test started to become more flaky recently (see https://github.com/pulumi/pulumi-awsx/issues/1488), this coincides with upgrading the GitHub runners to Ubuntu 24.04 and onboarding awsx to ci-mgmt. Those changes might've affected the test runtime and 15 minutes were probably a bit too aggressive.
Updated the timeout to 30min, which is still well below the 1 hour it took before.

Fixes https://github.com/pulumi/pulumi-awsx/issues/1488