### PR TITLE
feat: Add option to store docker build cache in ECR image resource

### DIFF
--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -111,6 +111,7 @@ export interface ImageArgs {
     readonly args?: pulumi.Input<Record<string, pulumi.Input<string>>>;
     readonly builderVersion?: BuilderVersionInputs;
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly cacheTo?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
     readonly imageName?: pulumi.Input<string>;
@@ -679,6 +680,7 @@ export interface DockerBuildInputs {
     readonly args?: pulumi.Input<Record<string, pulumi.Input<string>>>;
     readonly builderVersion?: BuilderVersionInputs;
     readonly cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
+    readonly cacheTo?: pulumi.Input<pulumi.Input<string>[]>;
     readonly context?: pulumi.Input<string>;
     readonly dockerfile?: pulumi.Input<string>;
     readonly imageName?: pulumi.Input<string>;
@@ -690,6 +692,7 @@ export interface DockerBuildOutputs {
     readonly args?: pulumi.Output<Record<string, string>>;
     readonly builderVersion?: BuilderVersionOutputs;
     readonly cacheFrom?: pulumi.Output<string[]>;
+    readonly cacheTo?: pulumi.Output<string[]>;
     readonly context?: pulumi.Output<string>;
     readonly dockerfile?: pulumi.Output<string>;
     readonly imageName?: pulumi.Output<string>;

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -812,6 +812,13 @@
                     },
                     "description": "Images to consider as cache sources"
                 },
+                "cacheTo": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "ECR repo where to store docker build cache"
+                },
                 "context": {
                     "type": "string",
                     "description": "Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating."
@@ -2191,6 +2198,13 @@
                         "type": "string"
                     },
                     "description": "Images to consider as cache sources"
+                },
+                "cacheTo": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "ECR repo where to store docker build cache"
                 },
                 "context": {
                     "type": "string",

--- a/provider/pkg/schemagen/ecr.go
+++ b/provider/pkg/schemagen/ecr.go
@@ -307,6 +307,15 @@ func dockerBuildProperties() map[string]schema.PropertySpec {
 				},
 			},
 		},
+		"cacheTo": {
+			Description: "ECR repo where to store docker build cache",
+			TypeSpec: schema.TypeSpec{
+				Type: "array",
+				Items: &schema.TypeSpec{
+					Type: "string",
+				},
+			},
+		},
 		"context": {
 			Description: "Path to a directory to use for the Docker build context, " +
 				"usually the directory in which the Dockerfile resides (although " +

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -79,6 +79,18 @@ namespace Pulumi.Awsx.Ecr
             set => _cacheFrom = value;
         }
 
+        [Input("cacheTo")]
+        private InputList<string>? _cacheTo;
+
+        /// <summary>
+        /// ECR repo where to store docker build cache
+        /// </summary>
+        public InputList<string> CacheTo
+        {
+            get => _cacheTo ?? (_cacheTo = new InputList<string>());
+            set => _cacheTo = value;
+        }
+
         /// <summary>
         /// Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         /// </summary>

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -46,6 +46,8 @@ type imageArgs struct {
 	BuilderVersion *BuilderVersion `pulumi:"builderVersion"`
 	// Images to consider as cache sources
 	CacheFrom []string `pulumi:"cacheFrom"`
+	// ECR repo where to store docker build cache
+	CacheTo []string `pulumi:"cacheTo"`
 	// Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
@@ -72,6 +74,8 @@ type ImageArgs struct {
 	BuilderVersion *BuilderVersion
 	// Images to consider as cache sources
 	CacheFrom pulumi.StringArrayInput
+	// ECR repo where to store docker build cache
+	CacheTo pulumi.StringArrayInput
 	// Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
 	Context pulumi.StringPtrInput
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -21,6 +21,8 @@ type DockerBuild struct {
 	BuilderVersion *BuilderVersion `pulumi:"builderVersion"`
 	// Images to consider as cache sources
 	CacheFrom []string `pulumi:"cacheFrom"`
+	// ECR repo where to store docker build cache
+	CacheTo []string `pulumi:"cacheTo"`
 	// Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
 	Context *string `pulumi:"context"`
 	// dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -64,6 +64,21 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * ECR repo where to store docker build cache
+     * 
+     */
+    @Import(name="cacheTo")
+    private @Nullable Output<List<String>> cacheTo;
+
+    /**
+     * @return ECR repo where to store docker build cache
+     * 
+     */
+    public Optional<Output<List<String>>> cacheTo() {
+        return Optional.ofNullable(this.cacheTo);
+    }
+
+    /**
      * Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
      * 
      */
@@ -189,6 +204,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         this.args = $.args;
         this.builderVersion = $.builderVersion;
         this.cacheFrom = $.cacheFrom;
+        this.cacheTo = $.cacheTo;
         this.context = $.context;
         this.dockerfile = $.dockerfile;
         this.imageName = $.imageName;
@@ -278,6 +294,37 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder cacheFrom(String... cacheFrom) {
             return cacheFrom(List.of(cacheFrom));
+        }
+
+        /**
+         * @param cacheTo ECR repo where to store docker build cache
+         * 
+         * @return builder
+         * 
+         */
+        public Builder cacheTo(@Nullable Output<List<String>> cacheTo) {
+            $.cacheTo = cacheTo;
+            return this;
+        }
+
+        /**
+         * @param cacheTo ECR repo where to store docker build cache
+         * 
+         * @return builder
+         * 
+         */
+        public Builder cacheTo(List<String> cacheTo) {
+            return cacheTo(Output.of(cacheTo));
+        }
+
+        /**
+         * @param cacheTo ECR repo where to store docker build cache
+         * 
+         * @return builder
+         * 
+         */
+        public Builder cacheTo(String... cacheTo) {
+            return cacheTo(List.of(cacheTo));
         }
 
         /**

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -47,6 +47,7 @@ export class Image extends pulumi.ComponentResource {
             resourceInputs["args"] = args ? args.args : undefined;
             resourceInputs["builderVersion"] = args ? args.builderVersion : undefined;
             resourceInputs["cacheFrom"] = args ? args.cacheFrom : undefined;
+            resourceInputs["cacheTo"] = args ? args.cacheTo : undefined;
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["dockerfile"] = args ? args.dockerfile : undefined;
             resourceInputs["imageName"] = args ? args.imageName : undefined;
@@ -80,6 +81,10 @@ export interface ImageArgs {
      * Images to consider as cache sources
      */
     cacheFrom?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * ECR repo where to store docker build cache
+     */
+    cacheTo?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
      */

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -24,6 +24,7 @@ class ImageArgs:
                  args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  builder_version: Optional['BuilderVersion'] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_name: Optional[pulumi.Input[str]] = None,
@@ -37,6 +38,7 @@ class ImageArgs:
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
         :param 'BuilderVersion' builder_version: The version of the Docker builder.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_to: ECR repo where to store docker build cache
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
         :param pulumi.Input[str] image_name: Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
@@ -52,6 +54,8 @@ class ImageArgs:
             pulumi.set(__self__, "builder_version", builder_version)
         if cache_from is not None:
             pulumi.set(__self__, "cache_from", cache_from)
+        if cache_to is not None:
+            pulumi.set(__self__, "cache_to", cache_to)
         if context is not None:
             pulumi.set(__self__, "context", context)
         if dockerfile is not None:
@@ -114,6 +118,18 @@ class ImageArgs:
     @cache_from.setter
     def cache_from(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "cache_from", value)
+
+    @property
+    @pulumi.getter(name="cacheTo")
+    def cache_to(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        ECR repo where to store docker build cache
+        """
+        return pulumi.get(self, "cache_to")
+
+    @cache_to.setter
+    def cache_to(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "cache_to", value)
 
     @property
     @pulumi.getter
@@ -208,6 +224,7 @@ class Image(pulumi.ComponentResource):
                  args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  builder_version: Optional['BuilderVersion'] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_name: Optional[pulumi.Input[str]] = None,
@@ -225,6 +242,7 @@ class Image(pulumi.ComponentResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
         :param 'BuilderVersion' builder_version: The version of the Docker builder.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_from: Images to consider as cache sources
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] cache_to: ECR repo where to store docker build cache
         :param pulumi.Input[str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
         :param pulumi.Input[str] dockerfile: dockerfile may be used to override the default Dockerfile name and/or location.  By default, it is assumed to be a file named Dockerfile in the root of the build context.
         :param pulumi.Input[str] image_name: Custom name for the underlying Docker image resource. If omitted, the image tag assigned by the provider will be used
@@ -261,6 +279,7 @@ class Image(pulumi.ComponentResource):
                  args: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  builder_version: Optional['BuilderVersion'] = None,
                  cache_from: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 cache_to: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  context: Optional[pulumi.Input[str]] = None,
                  dockerfile: Optional[pulumi.Input[str]] = None,
                  image_name: Optional[pulumi.Input[str]] = None,
@@ -283,6 +302,7 @@ class Image(pulumi.ComponentResource):
             __props__.__dict__["args"] = args
             __props__.__dict__["builder_version"] = builder_version
             __props__.__dict__["cache_from"] = cache_from
+            __props__.__dict__["cache_to"] = cache_to
             __props__.__dict__["context"] = context
             __props__.__dict__["dockerfile"] = dockerfile
             __props__.__dict__["image_name"] = image_name


### PR DESCRIPTION
Add `cacheTo` arg to configure the underlying docker cacheTo option, a list of ECR registries is expected.
I added some sane defaults to the config, but I would love a feedback on that.

Note that `imageManifest: true` and `ociMediaTypes: true` are required for ECR registries, but I don't really know if they can cause issues with other types of registries. In any case, I don't think it's a big deal, this is a component tailor-made for AWS solutions.

It falls back to the old behaviour (inline cache) if no parameter is specified