### PR TITLE
Switch AWS access to use ESC

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Install Go
       if: inputs.tools == 'all' || contains(inputs.tools, 'go')
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
       with:
         go-version: "1.21.x"
         cache-dependency-path: |

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache examples generation
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: |
             .pulumi/examples-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
       with:
         # The versions of golangci-lint and setup-go here cross-depend and need to update together.
         go-version: 1.23
@@ -55,7 +55,7 @@ jobs:
       continue-on-error: true
       run: make prepare_local_workspace
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+      uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6
       with:
         version: v1.64.6
         working-directory: provider

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -61,7 +61,7 @@ jobs:
         major-version: 2
         set-env: 'PROVIDER_VERSION'
     - name: Cache examples generation
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
       with:
         path: |
           .pulumi/examples-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,15 +77,19 @@ jobs:
       run: |-
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+    - name: Generate Pulumi Access Token
+      id: generate_pulumi_token
+      uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-region: ${{ env.AWS_REGION }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 7200
-        role-session-name: awsx@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        organization: pulumi
+        requested-token-type: urn:pulumi:token-type:access_token:organization
+        export-environment-variables: false
+    - name: Export AWS Credentials
+      uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+      with:
+        environment: logins/pulumi-ci
     - name: Install dependencies
       run: make install_${{ matrix.language}}_sdk
     - name: Run tests

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -82,15 +82,19 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      - name: Generate Pulumi Access Token
+        id: generate_pulumi_token
+        uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: awsx@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          export-environment-variables: false
+      - name: Export AWS Credentials
+        uses: pulumi/esc-action@41fd832f44f4820124b5350b5f84a00f741f234e # v1.3.0
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+        with:
+          environment: logins/pulumi-ci
       - name: Verify nodejs release
         uses: pulumi/verify-provider-release@v1
         with:

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -67,6 +67,9 @@ func TestRegress1112(t *testing.T) {
 		Dependencies: []string{
 			"@pulumi/awsx",
 		},
+		Config: map[string]string{
+			"aws:region": "us-west-2",
+		},
 		NoParallel:    true, // cannot use call t.Parallel after t.Setenv
 		RunUpdateTest: false,
 		Dir:           filepath.Join(getCwd(t), "ecs", "nodejs"),


### PR DESCRIPTION
This switches the AWS Access from hardcoded access keys that are pulled from GitHub secrets to use Pulumi ESC environments.

re [#3731](https://github.com/pulumi/home/issues/3731)