### PR TITLE
[vpc/vpcEndpoints] use shared tags & expose endpoints

### DIFF
--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -414,13 +414,6 @@ describe("child resource api", () => {
   });
 
   it("internetGateway", async () => {
-    const vpc = new Vpc("test", {
-      tags: {
-        share1: "parent",
-        share2: "parent",
-      },
-      vpcEndpointSpecs: [{ serviceName: "test" }],
-    });
     const igw = await unwrap(vpc.internetGateway);
     const igwTags = await unwrap(igw.tags);
     expect(igwTags?.share1).toBe("parent");

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -146,7 +146,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           routeTableIds: spec.routeTableIds,
           securityGroupIds: spec.securityGroupIds,
           subnetIds: spec.subnetIds,
-          tags: spec.tags,
+          tags: { ...sharedTags, ...spec.tags },
           vpcEndpointType: spec.vpcEndpointType,
           vpcId: vpc.id,
           serviceName: spec.serviceName,
@@ -156,6 +156,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           dependsOn: [vpc],
         },
       );
+      vpcEndpoints.push(vpcEndpoint);
     });
 
     for (let i = 0; i < availabilityZones.length; i++) {


### PR DESCRIPTION
👋 I had some internal tagging policies fail when using the awsx.ec2.Vpc. I included the shared tags for the failing children (vpc endpoints) here. When testing it, I discovered that the vpc weren't being added to the component data, so I added that too. Along the way, I wrote some tests for other things that might have had the same problem, and I left them because they seem benign enough, and maybe even helpful.

I'm not familiar with this codebase, but it looks reasonable that `build_sdks` produced no output. 