### PR TITLE
sort TaskDefinitionContainerDefinitionInputs by container name to reduce non-needed deploys

### DIFF
--- a/awsx/ecs/containers.ts
+++ b/awsx/ecs/containers.ts
@@ -48,9 +48,11 @@ export function computeContainerDefinitions(
 ): pulumi.Output<schema.TaskDefinitionContainerDefinitionInputs[]> {
   const computed = containers.apply((c) => {
     return pulumi.all(
-      Object.entries(c).map(([containerName, container]) =>
-        computeContainerDefinition(parent, containerName, container, logGroupId),
-      ),
+      Object.entries(c)
+        .sort(([a], [b]) => a.localeCompare(b)) // sort by container name to ensure deterministic order and reduce false positive redeploys
+        .map(([containerName, container]) =>
+          computeContainerDefinition(parent, containerName, container, logGroupId),
+        ),
     );
   });
   return computed;


### PR DESCRIPTION
My team has been running into issues with unnecessary container task definition updates for our services which causes lost time in waiting for these changes to be deployed.

The cause of this was having multiple containers where the containers would be getting mapped to the task definition in a non-predictable manor which lead to false positive changes.

This PR addresses that issue by ensuring we sort the containers for a task definition by their name in an effort to reduce these false positive changes from occurring.