### PR TITLE
Update AMI

### DIFF
--- a/examples/ts-lb-attach-ec2/index.ts
+++ b/examples/ts-lb-attach-ec2/index.ts
@@ -8,7 +8,7 @@ const lb = new awsx.lb.ApplicationLoadBalancer("lb", { subnets: vpc.subnets });
 // Get the Amazon Linux AMI. We use a specific version because its id is serialized into the
 // recorded snapshot for upgrade tests. Using a later image requires re-recording the snapshot.
 const ami = aws.ec2.getAmiOutput({
-    filters: [{ name: "name", values: ["amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs"] }],
+    filters: [{ name: "name", values: ["amzn2-ami-hvm-2.0.20250623.0-x86_64-ebs"] }],
     owners: ["137112412989"], // Amazon
     mostRecent: true,
 }).id;


### PR DESCRIPTION
Tests are currently broken because this AMI is no longer available.