### PR TITLE
Remove usage of deprecated stageName. Will avoid warnings during update.

### DIFF
--- a/awsx-classic/apigateway/api.ts
+++ b/awsx-classic/apigateway/api.ts
@@ -631,8 +631,6 @@ export function createAPI(parent: pulumi.Resource, name: string, args: APIArgs, 
     const deployment = new aws.apigateway.Deployment(name, {
         ...args.deploymentArgs,
         restApi: restAPI,
-        // Note: Set to empty to avoid creating an implicit stage, we'll create it explicitly below instead.
-        stageName: "",
         // Note: We set `variables` here because it forces recreation of the Deployment object
         // whenever the body hash changes.  Because we use a blank stage name above, there will
         // not actually be any stage created in AWS, and thus these variables will not actually


### PR DESCRIPTION
Running pulumi up with stageName in the deployment will print out a warning.
Such field should be avoided according to 
Terraform docs: https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta1/docs/guides/version-6-upgrade#migration-example
And pulumi/aws: https://github.com/pulumi/pulumi-aws/blob/master/sdk/nodejs/apigateway/deployment.ts#L264

I tried it locally and it worked fine.

pulumi up with `stageName: ""`
```
aws:apigateway:Deployment (myservice):
    warning: urn:pulumi:dev::myservice::aws:apigateway:x:API$aws:apigateway/deployment:Deployment::myservice verification warning: stage_name is deprecated. Use the aws_api_gateway_stage resource instead.
    ```
pulumi up without it prints no warnings.

