### PR TITLE
Rebuild provider before SKDs in upgrade-aws script

### DIFF
--- a/scripts/upgrade-aws.sh
+++ b/scripts/upgrade-aws.sh
@@ -19,8 +19,10 @@ echo "V=$VER"
 # Ensure that we don't have any duplicate dependencies.
 (cd awsx && yarn run check-duplicate-deps)
 
+# Rebuild provider internals such as awsx/schema-types.ts
+# We need to run this before rebuilding the SDKs or they may be missing types
+make provider
+
 # Rebulid the SDKs, which will also rebuild the schema and all other files.
 make build_sdks
 
-# Rebuild provider internals such as awsx/schema-types.ts
-make provider


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-awsx/issues/1578

AWS version updates may require schema-types.ts to be regenerated before building the SDKs so we need to run `make provider` first