### PR TITLE
Fix upgrade-aws job

### DIFF
--- a/scripts/upgrade-aws.sh
+++ b/scripts/upgrade-aws.sh
@@ -19,10 +19,12 @@ echo "V=$VER"
 # Ensure that we don't have any duplicate dependencies.
 (cd awsx && yarn run check-duplicate-deps)
 
+# Upgrade our SDK go dependency.
+(cd sdk && go get -u github.com/pulumi/pulumi-aws/sdk/v7)
+
 # Rebuild provider internals such as awsx/schema-types.ts
 # We need to run this before rebuilding the SDKs or they may be missing types
 make provider
 
 # Rebulid the SDKs, which will also rebuild the schema and all other files.
 make build_sdks
-


### PR DESCRIPTION
We started generating some new SDK types that aren't present in v7.0.0 of the AWS SDK. Update the script to have this SDK dependency track the version we're upgrading to.

Manually confirmed the script works again after this change.

Fixes https://github.com/pulumi/pulumi-awsx/issues/1669