### PR TITLE
Adding security groups to NLB args.

### DIFF
--- a/awsx-classic/lb/loadBalancer.ts
+++ b/awsx-classic/lb/loadBalancer.ts
@@ -158,8 +158,7 @@ export interface LoadBalancerArgs {
     tags?: pulumi.Input<aws.Tags>;
 
     /**
-     * A list of security group IDs to assign to the LB. Only valid for Load Balancers of type
-     * `application`.
+     * A list of security group IDs to assign to the LB.
      */
     securityGroups?: ec2.SecurityGroupOrId[];
 }

--- a/awsx-classic/lb/network.ts
+++ b/awsx-classic/lb/network.ts
@@ -298,6 +298,11 @@ export interface NetworkLoadBalancerArgs {
      * If true, cross-zone load balancing of the load balancer will be enabled.  Defaults to `false`.
      */
     enableCrossZoneLoadBalancing?: pulumi.Input<boolean>;
+
+    /**
+     * A list of security group IDs to assign to the LB.
+     */
+    securityGroups?: ec2.SecurityGroupOrId[];
 }
 
 /**


### PR DESCRIPTION
Noticed how it was not added, and explicitly removed from the NLB args.
Docs mentioned that it's available: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html
I guess it's something that it was not possible before.
I have also tried it myself, receipt:
<img width="1014" height="549" alt="image" src="https://github.com/user-attachments/assets/8cfbf381-7d5c-434a-9479-2edafad87c93" />

No need to add any other lies as all the args are already passed to the underlying constructor. 
Would love to get this merged, such that I can remove my type hack.

Best,

J