### PR TITLE
Remove unnecessary env vars from workflows

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,22 +9,9 @@ env:
     ALT_AWS_ACCESS_KEY_ID: ${{ secrets.ALT_AWS_ACCESS_KEY_ID }}
     ALT_AWS_SECRET_ACCESS_KEY: ${{ secrets.ALT_AWS_SECRET_ACCESS_KEY }}
     AWS_REGION: us-west-2
-    GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    GOLANGCI_LINT_VERSION: v1.61.0
-    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     PROVIDER: awsx
-    PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-    PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-    PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
     PULUMI_API: https://api.pulumi-staging.io
-    PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-    SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-    SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
     PULUMI_ENABLE_RESOURCE_REFERENCES: 1
-    PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
 esc:
     enabled: true
     environment: imports/github-secrets # No repo-specific secrets.

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -2,7 +2,6 @@
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,7 +2,6 @@
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,7 +3,6 @@
 env:
   IS_PRERELEASE: true
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
@@ -93,16 +92,7 @@ jobs:
       env:
         ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
         ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-        PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-        SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-        SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-        SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-        SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ on:
 env:
   IS_PRERELEASE: ${{ inputs.isPrerelease }}
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
@@ -148,7 +147,7 @@ jobs:
         # only saving the cache in the prerequisites job
         cache_save: false
     - name: Setup Node
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
       with:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,6 @@
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -13,7 +13,6 @@ on:
 env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ env:
   MISE_ENV: test
 
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
@@ -111,32 +110,14 @@ jobs:
       env:
         ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
         ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-        PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-        SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-        SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-        SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-        SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run pulumi/examples tests
       if: matrix.testTarget == 'pulumiExamples'
       run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -run TestPulumiExamples -parallel 4 .
       env:
         ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
         ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-        PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-        SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-        SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-        SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-        SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -38,7 +38,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.61.0
   PROVIDER: awsx
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
@@ -91,7 +90,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org
@@ -142,16 +141,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
           ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-          PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-          SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify python release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -163,16 +153,7 @@ jobs:
         env:
           ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
           ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-          PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-          SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify dotnet release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         with:
@@ -183,16 +164,7 @@ jobs:
         env:
           ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
           ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-          PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-          SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify go release
         uses: pulumi/verify-provider-release@679d5e6838ac4f68696bfa1bf9e2c5da94509dd6 # v1.3.1
         if: inputs.skipGoSdk == false
@@ -204,13 +176,4 @@ jobs:
         env:
           ALT_AWS_ACCESS_KEY_ID: ${{ steps.esc-secrets.outputs.ALT_AWS_ACCESS_KEY_ID }}
           ALT_AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.ALT_AWS_SECRET_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-          PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
-          PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
-          SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-          SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
-          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow is currently broken:

https://github.com/pulumi/pulumi-awsx/actions/runs/18697832953

```
[Invalid workflow file: .github/workflows/release.yml#L73](https://github.com/pulumi/pulumi-awsx/actions/runs/18697832953/workflow)
error parsing called workflow
".github/workflows/release.yml"
-> "./.github/workflows/publish.yml" (source tag with sha:7a6220b1539aecc7ee496b58e44c44650104ae74)
--> "./.github/workflows/verify-release.yml" (source tag with sha:7a6220b1539aecc7ee496b58e44c44650104ae74)
: (Line: 146, Col: 11): 'NODE_AUTH_TOKEN' is already defined
```

This removes most of the secrets from `.ci-mgmt.yaml` since they're already injected automatically into the steps that need them.