### PR TITLE
Fix cloudtrail to cloudwatch logs access

### DIFF
--- a/.config/mise.lock
+++ b/.config/mise.lock
@@ -65,6 +65,11 @@ checksum = "sha256:70734c46e0bbeb7f45b721756ba0b2f1f1e1ef85a11e10d5a488f06b257da
 size = 195648709
 url = "https://corretto.aws/downloads/resources/11.0.28.6.1/amazon-corretto-11.0.28.6.1-linux-x64.tar.gz"
 
+[tools.java.platforms.macos-arm64]
+checksum = "sha256:5fd69f12b4c961ed2fce17e29c1475f9a7b667cff0fe0a8ba26eb154ee0ede74"
+size = 185512031
+url = "https://corretto.aws/downloads/resources/11.0.28.6.1/amazon-corretto-11.0.28.6.1-macosx-aarch64.tar.gz"
+
 [[tools.node]]
 version = "20.19.5"
 backend = "core:node"

--- a/examples/cloudtrail-with-logs/nodejs/Pulumi.yaml
+++ b/examples/cloudtrail-with-logs/nodejs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: cloudtrail-with-logs-nodejs
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/cloudtrail-with-logs/nodejs/index.ts
+++ b/examples/cloudtrail-with-logs/nodejs/index.ts
@@ -1,0 +1,15 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+
+const trail = new awsx.cloudtrail.Trail("with-logs", {
+  enableLogging: true,
+  cloudWatchLogsGroup: {
+    enable: true,
+    args: {
+      retentionInDays: 7,
+    },
+  },
+});
+
+export const logGroupArn = trail.logGroup.apply((lg) => lg?.arn);
+export const trailCloudWatchLogGroupArn = trail.trail.cloudWatchLogsGroupArn;

--- a/examples/cloudtrail-with-logs/nodejs/package.json
+++ b/examples/cloudtrail-with-logs/nodejs/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "nodejs",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/awsx": "^2.0.0",
+        "@pulumi/aws": "^6.0.0"
+    }
+}

--- a/examples/cloudtrail-with-logs/nodejs/tsconfig.json
+++ b/examples/cloudtrail-with-logs/nodejs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/cloudtrail/nodejs/index.ts
+++ b/examples/cloudtrail/nodejs/index.ts
@@ -5,48 +5,56 @@ import assert = require("assert");
 // No S3 bucket configuration given, so the default AES encryption is used.
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html
 const defaultTrail = new awsx.cloudtrail.Trail("example-trail", {
-    enableLogging: true,
-})
+  enableLogging: true,
+});
 
 // Same as above but explicit.
 const aesEncryptedBucketTrail = new awsx.cloudtrail.Trail("example-aes-bucket-trail", {
-    enableLogging: true,
-    s3Bucket: {
-        args: {
-            serverSideEncryptionConfiguration: {
-                rule: {
-                    applyServerSideEncryptionByDefault: {
-                        sseAlgorithm: "AES256",
-                    }
-                }
-            }
-        }
-    }
-})
+  enableLogging: true,
+  s3Bucket: {
+    args: {
+      serverSideEncryptionConfiguration: {
+        rule: {
+          applyServerSideEncryptionByDefault: {
+            sseAlgorithm: "AES256",
+          },
+        },
+      },
+    },
+  },
+});
 
 const kmsEncryptedBucketTrail = new awsx.cloudtrail.Trail("example-kms-bucket-trail", {
-    enableLogging: true,
-    s3Bucket: {
-        args: {
-            serverSideEncryptionConfiguration: {
-                rule: {
-                    applyServerSideEncryptionByDefault: {
-                        sseAlgorithm: "aws:kms",
-                    }
-                }
-            }
-        }
-    }
-})
+  enableLogging: true,
+  s3Bucket: {
+    args: {
+      serverSideEncryptionConfiguration: {
+        rule: {
+          applyServerSideEncryptionByDefault: {
+            sseAlgorithm: "aws:kms",
+          },
+        },
+      },
+    },
+  },
+});
 
-defaultTrail.bucket.apply(b => b!)
-    .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault.sseAlgorithm
-    .apply(alg => assert.strictEqual(alg, "AES256"));
+export const defaultTrailSSEAlgorithm = defaultTrail.bucket
+  .apply((b) => b!)
+  .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault?.apply(
+    (sse) => sse?.sseAlgorithm,
+  );
 
-aesEncryptedBucketTrail.bucket.apply(b => b!)
-    .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault.sseAlgorithm
-    .apply(alg => assert.strictEqual(alg, "AES256"));
+export const aesEncryptedTrailSSEAlgorithm = aesEncryptedBucketTrail.bucket
+  .apply((b) => b!)
+  .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault?.apply(
+    (sse) => sse?.sseAlgorithm,
+  );
 
-kmsEncryptedBucketTrail.bucket.apply(b => b!)
-    .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault.sseAlgorithm
-    .apply(kmsAlg => assert.strictEqual(kmsAlg, "aws:kms"));
+export const kmsEncryptedBucketTrailSSEAlgorithm = kmsEncryptedBucketTrail.bucket
+  .apply((b) => b!)
+  .serverSideEncryptionConfiguration.rule.applyServerSideEncryptionByDefault?.apply(
+    (sse) => sse?.sseAlgorithm,
+  );
+
+export const defaultTrailCloudWatchLogsRoleArn = defaultTrail.trail.cloudWatchLogsRoleArn;


### PR DESCRIPTION
It doesn't look like the CloudTrail => CloudWatch Logs integration ever
worked for awsx. This PR fixes that by created an IAM role with the
necessary permissions.

Also, previously we had the property name incorrect, which means it
didn't even try to setup the log group.

Added a new test to assert that we create everything correctly, and
updated an existing test to show that we don't create the role if we
don't create the group.

fixes #1745