### PR TITLE
docs(ecr): clarify imageName behavior

### DIFF
--- a/examples/ts-ecr-simple/README.md
+++ b/examples/ts-ecr-simple/README.md
@@ -1,3 +1,5 @@
 # examples/ecr
 
 A simple ecr demo application.
+
+The `imageTag` option controls the pushed image tag. The older `imageName` input remains supported for backwards compatibility, but it is interpreted as the suffix in `repositoryUrl:imageName`, which is why `imageTag` is the clearer option for new programs.

--- a/examples/ts-ecr-simple/index.ts
+++ b/examples/ts-ecr-simple/index.ts
@@ -22,4 +22,6 @@ export const repositoryName = repository.repository.name;
 export const image = new awsx.ecr.Image("image", {
   repositoryUrl: repository.repository.repositoryUrl,
   context: "./app",
+  // imageTag sets the pushed image tag; imageName is kept for its existing tag-suffix behavior.
+  imageTag: "v1.0.0",
 }).imageUri;

--- a/provider/pkg/schemagen/ecr.go
+++ b/provider/pkg/schemagen/ecr.go
@@ -328,8 +328,10 @@ func dockerBuildProperties() map[string]schema.PropertySpec {
 			},
 		},
 		"imageName": {
-			Description: "Custom name for the underlying Docker image resource. If " +
-				"omitted, the image tag assigned by the provider will be used",
+			Description: "Custom tag suffix for the image pushed to the repository. " +
+				"This value is appended to repositoryUrl as `repositoryUrl:imageName`, " +
+				"so use `imageTag` when you want to set the pushed image tag explicitly. " +
+				"If omitted, the provider will use `imageTag` or generate a unique tag.",
 			TypeSpec: schema.TypeSpec{
 				Type: "string",
 			},


### PR DESCRIPTION
status: ready_with_verification_gap
workdir: /tmp/clawoss-1381-1773684677/pulumi-awsx
repo: pulumi/pulumi-awsx
issue: 1381
branch: clawoss/docs-1381-image-name
title: docs(ecr): clarify imageName behavior
body: |
  ## Summary
  - clarify that `imageName` is currently interpreted as the suffix in `repositoryUrl:imageName`
  - point users to `imageTag` for explicitly setting the pushed image tag
  - update the simple ECR example to use `imageTag` and explain the compatibility behavior

  ## Reproduction
  - inspected `awsx/ecr/image.ts`, which currently computes `canonicalImageName` as `${repositoryUrl}:${imageName}` and falls back from `imageName` to `imageTag`
  - inspected `provider/pkg/schemagen/ecr.go`, which previously documented `imageName` as the Docker image resource name, creating the mismatch reported in #1381

  ## Before Fix
  - doc-validation evidence: `provider/pkg/schemagen/ecr.go` described `imageName` as `Custom name for the underlying Docker image resource...`
  - source evidence: `awsx/ecr/image.ts` uses `imageName` as the tag suffix in `repositoryUrl:imageName`
  - focused test command could not run in this sandbox because repo JS dependencies are not installed:
    - `yarn --cwd awsx test image.test.ts --runInBand`
    - failed with `/bin/sh: 1: jest: command not found`

  ## After Fix
  - updated the schema source text in `provider/pkg/schemagen/ecr.go` to explain the current non-breaking behavior and recommend `imageTag`
  - updated `examples/ts-ecr-simple/index.ts` to demonstrate `imageTag`
  - updated `examples/ts-ecr-simple/README.md` to explain the compatibility nuance

  ## Verification
  - `grep -n "imageName" provider/pkg/schemagen/ecr.go` shows the clarified description in source
  - `git diff --stat` shows 3 files changed, 9 insertions, 3 deletions
  - attempted `make generate`, but local environment lacks `mise`:
    - `/bin/sh: 1: mise: command not found`
    - `make: *** [Makefile:67: mise_env] Error 127`

  ## AI Disclosure
  - This change was prepared by an AI coding agent and should be reviewed by a human maintainer before submission.
files_changed:
  - provider/pkg/schemagen/ecr.go
  - examples/ts-ecr-simple/index.ts
  - examples/ts-ecr-simple/README.md
test_evidence_before: |
  Doc/source mismatch reproduced by inspection:
  - `provider/pkg/schemagen/ecr.go` documented `imageName` as a Docker resource name.
  - `awsx/ecr/image.ts` builds `${repositoryUrl}:${imageName}`.

  Focused test execution attempt:
  $ yarn --cwd awsx test image.test.ts --runInBand
  /bin/sh: line 1: jest: command not found
  error Command failed with exit code 127.
test_evidence_after: |
  Source/doc verification:
  $ grep -n "imageName" provider/pkg/schemagen/ecr.go
  330:        "imageName": {
  332:                "This value is appended to repositoryUrl as `repositoryUrl:imageName`, " +

  Regeneration attempt:
  $ make generate
  /bin/sh: line 1: mise: command not found
  make: *** [Makefile:67: mise_env] Error 127
error_details: |
  Verification is incomplete because this sandbox does not provide the repo's expected toolchain.
  - JS test runner unavailable through repo deps (`jest: command not found`)
  - schema/sdk regeneration unavailable because `mise` is missing
  The branch contains only source/example changes and a local commit: 9ba4568d.
