### PR TITLE
Pass region through awsx.ec2.Vpc child resources

### DIFF
--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -401,9 +401,13 @@ describe("child resource api", () => {
     return new Promise((resolve) => (pulumi.Output.isInstance(x) ? x.apply(resolve) : resolve(x)));
   }
 
+  let invokeCalls: any[] = [];
+  let newResources: any[] = [];
+
   beforeAll(async () => {
     await runtime.setMocks({
       call(args) {
+        invokeCalls.push(args);
         switch (args.token) {
           case "aws:index/getAvailabilityZones:getAvailabilityZones":
             const result: pulumiAws.GetAvailabilityZonesResult = {
@@ -419,6 +423,7 @@ describe("child resource api", () => {
         }
       },
       newResource(args) {
+        newResources.push(args);
         if (args.type === "aws:ec2/vpc:Vpc" && args.inputs.assignGeneratedIpv6CidrBlock) {
           return {
             id: `mocked::${args.type}::${args.name}-id`,
@@ -438,6 +443,8 @@ describe("child resource api", () => {
 
   let vpc: Vpc;
   beforeEach(() => {
+    invokeCalls = [];
+    newResources = [];
     vpc = new Vpc("test", {
       tags: {
         share1: "parent",
@@ -507,6 +514,52 @@ describe("child resource api", () => {
       expect(tags?.share1).toBe("parent");
       expect(tags?.share2).toBe("parent");
     }
+  });
+
+  it("passes region through to child resources and AZ lookup", async () => {
+    invokeCalls = [];
+    newResources = [];
+
+    const regionalVpc = new Vpc("test-region", {
+      region: pulumiAws.Region.EUCentral1,
+      subnetStrategy: "Auto",
+      subnetSpecs: [{ type: "Public" }, { type: "Private" }],
+    });
+
+    await unwrap(regionalVpc.routeTables);
+
+    const azLookup = invokeCalls.find(
+      (call) =>
+        call.token === "aws:index/getAvailabilityZones:getAvailabilityZones" &&
+        call.inputs.region === pulumiAws.Region.EUCentral1,
+    );
+    expect(azLookup?.inputs.region).toBe(pulumiAws.Region.EUCentral1);
+
+    const childResourceTypes = new Set([
+      "aws:ec2/internetGateway:InternetGateway",
+      "aws:ec2/subnet:Subnet",
+      "aws:ec2/routeTable:RouteTable",
+      "aws:ec2/routeTableAssociation:RouteTableAssociation",
+      "aws:ec2/eip:Eip",
+      "aws:ec2/natGateway:NatGateway",
+      "aws:ec2/route:Route",
+    ]);
+
+    const regionalChildren = newResources.filter(
+      (resource) => childResourceTypes.has(resource.type) && resource.name.startsWith("test-region"),
+    );
+    expect(regionalChildren.length).toBeGreaterThan(0);
+    for (const resource of regionalChildren) {
+      expect(resource.inputs.region).toBe(pulumiAws.Region.EUCentral1);
+    }
+  });
+
+  it("requires a plain string region for default AZ discovery", () => {
+    expect(() =>
+      (Vpc as any).resolvePromptRegionForAzLookup(pulumi.output(pulumiAws.Region.EUCentral1)),
+    ).toThrowError(
+      "Vpc.region must be a plain string when availabilityZoneNames is not set. If region is dynamic, specify availabilityZoneNames explicitly.",
+    );
   });
 
   it("defaults subnet IPv6 assignment from VPC and honors explicit false", async () => {

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -85,8 +85,12 @@ export class Vpc extends schema.Vpc<VpcData> {
       );
     }
 
-    const availabilityZones =
-      args.availabilityZoneNames ?? (await this.getDefaultAzs(args.numberOfAvailabilityZones));
+    const availabilityZones = args.availabilityZoneNames
+      ? args.availabilityZoneNames
+      : await this.getDefaultAzs(
+          args.numberOfAvailabilityZones,
+          Vpc.resolvePromptRegionForAzLookup(args.region),
+        );
 
     const natGatewayStrategy: schema.NatGatewayStrategyInputs =
       args.natGateways?.strategy ?? "OnePerAz";
@@ -121,6 +125,7 @@ export class Vpc extends schema.Vpc<VpcData> {
     const igw = new aws.ec2.InternetGateway(
       `${name}`,
       {
+        region: args.region,
         vpcId: vpc.id,
         tags: sharedTags,
       },
@@ -152,6 +157,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           vpcEndpointType: spec.vpcEndpointType,
           vpcId: vpc.id,
           serviceName: spec.serviceName,
+          region: spec.region ?? args.region,
         },
         {
           parent: vpc,
@@ -181,6 +187,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           const subnet = new aws.ec2.Subnet(
             spec.subnetName,
             {
+              region: args.region,
               vpcId: vpc.id,
               availabilityZone: spec.azName,
               mapPublicIpOnLaunch: spec.type.toLowerCase() === "public",
@@ -210,6 +217,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           const routeTable = new aws.ec2.RouteTable(
             spec.subnetName,
             {
+              region: args.region,
               vpcId: vpc.id,
               tags: {
                 ...sharedTags,
@@ -224,6 +232,7 @@ export class Vpc extends schema.Vpc<VpcData> {
           const routeTableAssoc = new aws.ec2.RouteTableAssociation(
             spec.subnetName,
             {
+              region: args.region,
               routeTableId: routeTable.id,
               subnetId: subnet.id,
             },
@@ -241,6 +250,7 @@ export class Vpc extends schema.Vpc<VpcData> {
               const eip = new aws.ec2.Eip(
                 `${name}-${i + 1}`,
                 {
+                  region: args.region,
                   tags: {
                     ...args.tags,
                     Name: `${name}-${i + 1}`,
@@ -254,6 +264,7 @@ export class Vpc extends schema.Vpc<VpcData> {
             const natGateway = new aws.ec2.NatGateway(
               `${name}-${i + 1}`,
               {
+                region: args.region,
                 subnetId: subnet.id,
                 allocationId: createEip ? eips[i].allocationId : allocationIds[i],
                 tags: {
@@ -271,6 +282,7 @@ export class Vpc extends schema.Vpc<VpcData> {
             const route = new aws.ec2.Route(
               spec.subnetName,
               {
+                region: args.region,
                 routeTableId: routeTable.id,
                 gatewayId: igw.id,
                 destinationCidrBlock: "0.0.0.0/0",
@@ -292,6 +304,7 @@ export class Vpc extends schema.Vpc<VpcData> {
               const route = new aws.ec2.Route(
                 spec.subnetName,
                 {
+                  region: args.region,
                   routeTableId: routeTable.id,
                   natGatewayId,
                   destinationCidrBlock: "0.0.0.0/0",
@@ -526,9 +539,9 @@ export class Vpc extends schema.Vpc<VpcData> {
     return { subnetLayout: verifiedSubnetLayout, subnetSpecs };
   }
 
-  async getDefaultAzs(azCount?: number): Promise<string[]> {
+  async getDefaultAzs(azCount?: number, region?: string): Promise<string[]> {
     const desiredCount = azCount ?? 3;
-    const result = await aws.getAvailabilityZones(undefined, { parent: this });
+    const result = await aws.getAvailabilityZones(region ? { region } : undefined, { parent: this });
     if (!result.names) {
       throw new Error(
         "Could not fetch default Availability Zones. If this is an opt-in region, please enable the region first. Alternatively, you may specify an explicit list of zones in `availabilityZoneNames`.",
@@ -540,6 +553,15 @@ export class Vpc extends schema.Vpc<VpcData> {
       );
     }
     return result.names.slice(0, desiredCount);
+  }
+
+  private static resolvePromptRegionForAzLookup(region?: pulumi.Input<string>): string | undefined {
+    if (region !== undefined && typeof region !== "string") {
+      throw new Error(
+        "Vpc.region must be a plain string when availabilityZoneNames is not set. If region is dynamic, specify availabilityZoneNames explicitly.",
+      );
+    }
+    return region;
   }
 
   // Internal. Exported for testing.


### PR DESCRIPTION
## Summary
- pass `VpcArgs.region` through to VPC child AWS resources and AZ discovery
- preserve per-endpoint region overrides while defaulting VPC endpoints to the VPC region
- require a plain string `region` for default AZ discovery, with a clear error when `region` is dynamic and `availabilityZoneNames` is omitted
- add focused regression tests covering region propagation and the default-AZ validation path

Fixes #1928

## Testing
- `yarn --cwd awsx test ec2/vpc.test.ts --runInBand`
- `yarn --cwd awsx tsc --noEmit`
- `make test_provider`
