### PR TITLE
Bump ECS client lower bound for fast-xml-parser advisory

### DIFF
--- a/awsx-classic/package.json
+++ b/awsx-classic/package.json
@@ -13,7 +13,7 @@
         "lint": "tslint -c tslint.json -p tsconfig.json"
     },
     "dependencies": {
-        "@aws-sdk/client-ecs": "^3.405.0",
+        "@aws-sdk/client-ecs": "^3.974.0",
         "@pulumi/aws": "^7.0.0",
         "@pulumi/docker": "4.5.8",
         "@pulumi/pulumi": "^3.34.0",

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -43,7 +43,7 @@
         },
         "nodejs": {
             "dependencies": {
-                "@aws-sdk/client-ecs": "^3.405.0",
+                "@aws-sdk/client-ecs": "^3.974.0",
                 "@pulumi/aws": "^7.34.0",
                 "@pulumi/docker": "^4.6.0",
                 "@pulumi/docker-build": "^0.0.14",

--- a/provider/pkg/schemagen/schema.go
+++ b/provider/pkg/schemagen/schema.go
@@ -83,7 +83,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 			}),
 			"nodejs": rawMessage(map[string]interface{}{
 				"dependencies": map[string]string{
-					"@aws-sdk/client-ecs":  "^3.405.0",
+					"@aws-sdk/client-ecs":  "^3.974.0",
 					"@pulumi/aws":          "^" + dependencies.Aws,
 					"@pulumi/docker":       "^" + dependencies.Docker,
 					"@pulumi/docker-build": "^" + dependencies.DockerBuild,

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -15,7 +15,7 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@aws-sdk/client-ecs": "^3.405.0",
+        "@aws-sdk/client-ecs": "^3.974.0",
         "@pulumi/aws": "^7.34.0",
         "@pulumi/docker": "^4.6.0",
         "@pulumi/docker-build": "^0.0.14",


### PR DESCRIPTION
## Summary
- Bump `@aws-sdk/client-ecs` from `^3.405.0` to `^3.974.0` in schema metadata and awsx-classic.
- Regenerate the provider schema and Node.js SDK package metadata.
- Set the dependency floor above the AWS SDK releases that still audit as vulnerable through `@aws-sdk/xml-builder` / `fast-xml-parser`.

Fixes #1856.

## Validation
- `make -B schema`
- `make -B generate`
- `mise x -- schema-tools compare -p awsx --old-path /tmp/awsx-schema-old.json --new-path provider/cmd/pulumi-resource-awsx/schema.json -m -1 --json --summary` -> `[]`
- `make test_provider`
- `make build_dotnet`
- `mise exec -- make build_nodejs`
- npm audit check for exact `@aws-sdk/client-ecs@3.974.0` -> 0 vulnerabilities; resolved packages include `@aws-sdk/client-ecs@3.974.0` and `@aws-sdk/xml-builder@3.972.33`, with no `fast-xml-parser` package in the lockfile.

## Notes
- `yarn --cwd awsx-classic lint` was also run because awsx-classic package metadata changed. It still fails on pre-existing trailing-comma lint errors in `awsx-classic/apigateway/api.ts` and `awsx-classic/cloudwatch/metric.ts`, unrelated to this dependency bump.
- The previous .NET/DockerBuild blocker from #2003 is no longer reproducing locally: `make build_dotnet` restores and builds the net6 SDK successfully.