### PR TITLE
Add AWSX breaking change evaluation skill

### DIFF
--- a/.agents/skills/awsx-breaking-change-evaluation/SKILL.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: awsx-breaking-change-evaluation
+description: Tactical AWSX breaking-change evaluation guidance for pulumi-awsx. Use when assessing schema changes, generated SDK surface changes, child resource identity changes, aliases, changed defaults, provider or region behavior changes, and upgrade impact for existing users.
+---
+
+# AWSX Breaking Change Evaluation
+
+Use this skill to evaluate whether an AWSX change is compatibility-sensitive or
+breaking for existing users.
+
+This skill is for risk classification and required evidence. For component shape
+guidance, use `$awsx-component-design`. For proof strategy, use
+`$awsx-test-authoring`.
+
+## Rule Index
+
+- `rules/public-schema-surface.md`: schema and generated SDK public-surface
+  changes.
+- `rules/code-vs-behavior-breaks.md`: code-level breaks versus preview/update
+  behavior changes.
+- `rules/child-identity-and-aliases.md`: child logical names, parentage, URNs,
+  aliases, and migration paths.
+- `rules/defaults-and-supporting-resources.md`: defaults, default-created
+  resources, tags, and supporting-resource changes.
+- `rules/provider-region-behavior.md`: provider and region propagation changes.
+- `rules/upstream-inherited-breaks.md`: changes inherited from `@pulumi/aws` or
+  AWS behavior versus AWSX-added breakage.
+
+## How To Use
+
+1. Identify the user-visible surface touched by the change: schema, generated
+   SDKs, child resource identity, defaults, providers/regions, or preview/update
+   behavior.
+2. Read the matching rule file.
+3. Classify the change as clearly safe, compatibility-sensitive, or breaking.
+4. If compatibility-sensitive, require evidence: schema comparison, generated
+   diff, mock test, provider-upgrade preview, targeted acceptance test, or an
+   explicit maintainer decision.
+5. Check the upgrade scenarios that match the change: existing user code still
+   compiles, existing stack preview is stable, child resource identity remains
+   compatible, and new programs get the intended behavior.
+6. Report the classification and evidence. Do not smooth uncertainty into a
+   confident answer.
+
+## Stop Early
+
+Stop before approving compatibility if:
+
+- existing user code might need to change;
+- existing stacks might preview replacements, creates, deletes, or changed
+  inputs after upgrade;
+- child names, parentage, aliases, provider tokens, module paths, defaults, or
+  output presence changed;
+- the only evidence is that TypeScript compiles;
+- the change is inherited from upstream but AWSX may be adding extra behavior on
+  top.

--- a/.agents/skills/awsx-breaking-change-evaluation/agents/openai.yaml
+++ b/.agents/skills/awsx-breaking-change-evaluation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX Breaking Change Evaluation"
+  short_description: "Evaluate AWSX compatibility risk"
+  default_prompt: "Use $awsx-breaking-change-evaluation to assess whether an AWSX change is breaking."

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/child-identity-and-aliases.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/child-identity-and-aliases.md
@@ -1,0 +1,58 @@
+---
+title: Preserve Child Resource Identity
+tags: child-resources, names, parents, urns, aliases
+status: draft
+---
+
+## Rule
+
+Treat child resource logical names, parentage, and type tokens as
+compatibility-sensitive. Changing any of them can change URNs and resource
+identity.
+
+Prefer aliases or another automatic compatibility mechanism when moving
+identity. If user action is the only viable migration path, require an explicit
+compatibility decision and document why automatic migration is not possible.
+
+## Why
+
+AWSX components create child resources on behalf of users. Users may never see
+the child constructor code, but Pulumi state records each child's URN. Name,
+parent, or type changes can cause replacements even when public args are
+unchanged.
+
+## Check
+
+- Compare old and new child resource names.
+- Compare old and new parent hierarchy.
+- Compare old and new type tokens and aliases.
+- Verify aliases point at real historical names/types, not the current type as a
+  placeholder.
+- Use mocks only for the parts they can see: child type, logical name, provider,
+  and inputs. Parentage, aliases, and full URN compatibility need upgrade
+  preview, exported-state inspection, or another engine-visible proof.
+- Treat existing nested hierarchies, such as parts of `awsx/ec2/vpc.ts`, as
+  existing compatibility surface until audited.
+
+## Examples
+
+```text
+Safe:
+- Adding an alias that references a real historical child name or type without
+  changing current identity.
+
+Compatibility-sensitive:
+- Adding a new child resource for existing programs.
+- Reparenting an existing child under the component for consistency.
+
+Breaking:
+- Renaming or reparenting an existing child without aliases or another accepted
+  migration path.
+- Replacing a real legacy alias with a no-op alias to the current type.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` for the desired child ownership shape after the
+compatibility path is known. Use `$awsx-test-authoring` for alias or upgrade
+preview coverage.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/code-vs-behavior-breaks.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/code-vs-behavior-breaks.md
@@ -1,0 +1,59 @@
+---
+title: Separate Code-Level And Behavior-Level Breaks
+tags: code-break, behavior-break, preview, update
+status: draft
+---
+
+## Rule
+
+Classify both code-level breaks and behavior-level breaks.
+
+- Code-level break: an existing user must edit their program after upgrading.
+- Behavior-level break: existing code still compiles, but preview/update changes
+  deployed resources, inputs, outputs, replacements, creates, or deletes.
+
+Do not treat compile success as compatibility evidence.
+
+## Why
+
+AWSX can break users without changing the TypeScript API. Component constructors
+create child resources and set defaults; changing that behavior can alter an
+existing stack's next preview.
+
+## Check
+
+- For existing programs with no code changes: confirm whether generated SDK
+  source still compiles and whether preview is stable.
+- For existing stacks: inspect replacements, creates, deletes, changed inputs,
+  changed outputs, and child resource identity.
+- For new programs: confirm the new behavior is intentional and does not rely on
+  a compatibility-only legacy path.
+- Ask what an existing program sees on the next preview after upgrade.
+- Compare child resource types, names, parents, inputs, outputs, and defaulted
+  values.
+- For stateful changes, prefer provider-upgrade preview coverage or a recorded
+  preview fixture over a compile-only check.
+- If the behavior difference is intentional, require an explicit compatibility
+  decision and release note/migration note where appropriate.
+
+## Examples
+
+```text
+Safe:
+- Refactoring implementation helpers with identical child resources, inputs,
+  outputs, and preview behavior.
+
+Compatibility-sensitive:
+- Changing normalization logic that may alter a child input for existing args.
+- Adding a support resource for existing programs as part of a default behavior.
+
+Breaking:
+- Existing programs compile but preview replaces or deletes existing child
+  resources without an accepted migration path.
+- Existing programs must rename an arg or output.
+```
+
+## Hand Off When
+
+Use `$awsx-test-authoring` to choose the cheapest proof that honestly exercises
+the preview/update behavior.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/defaults-and-supporting-resources.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/defaults-and-supporting-resources.md
@@ -1,0 +1,59 @@
+---
+title: Evaluate Defaults By Upgrade Behavior
+tags: defaults, tags, supporting-resources, preview
+status: draft
+---
+
+## Rule
+
+Treat changed defaults as compatibility-sensitive when existing users may see a
+different preview/update after upgrade.
+
+Adding, removing, or replacing default-created support resources is not
+automatically breaking, but it requires explicit compatibility evaluation. Judge
+the user-facing behavior, preview/update effect, cost, permissions, output
+shape, and whether users can override the behavior.
+
+## Why
+
+Defaults are part of the value of AWSX abstractions, but they become persisted
+behavior in real stacks. A default can change resources, tags, IAM permissions,
+or service configuration without any user code change.
+
+## Check
+
+- Identify whether the default is AWSX-owned, `@pulumi/aws`-owned, or
+  service-owned.
+- Owning a default is not itself breaking. Changing the resolved behavior for
+  existing inputs is the compatibility-sensitive part.
+- Check whether existing programs would get new resources, removed resources,
+  changed tags, changed inputs, or changed outputs.
+- Be cautious with defaults that can drift outside AWSX, such as version-like
+  values or fast-moving best practices.
+- If AWSX is only inheriting an upstream default change, verify AWSX is not
+  adding extra breakage.
+
+## Examples
+
+```text
+Safe:
+- Adding a default only for a new optional feature that existing programs do not
+  enable.
+
+Compatibility-sensitive:
+- Adding a new default-created support resource for existing programs.
+- Changing default tags or tag propagation.
+- Changing an AWSX-owned calculation so the same existing inputs produce
+  different child resource inputs, such as CPU/memory normalization.
+
+Breaking:
+- Removing a default-created resource that existing stacks rely on, without an
+  accepted compatibility path.
+- Changing a default so existing stacks preview replacement or deletion.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` if the default should be redesigned around
+user-facing functionality. Use `$awsx-test-authoring` to prove the affected
+preview/update path.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/provider-region-behavior.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/provider-region-behavior.md
@@ -1,0 +1,55 @@
+---
+title: Treat Provider And Region Flow As Behavior
+tags: provider, region, invokes, child-inputs
+status: draft
+---
+
+## Rule
+
+Treat provider and region propagation changes as behavior changes. Passing
+`args.region` to a child that previously used provider configuration can change
+where resources are created or looked up.
+
+For new behavior, provider and region should flow consistently. For shipped
+components, do not retrofit propagation as cleanup without compatibility
+evaluation.
+
+## Why
+
+AWSX components often create many AWS resources. Provider and region context
+determine account, region, and invoke behavior. A region propagation fix can be
+correct and still compatibility-sensitive for existing stacks.
+
+## Check
+
+- Identify every child resource and invoke affected by provider or region
+  changes.
+- Compare whether each child previously used provider configuration, explicit
+  `region`, nested pass-through region, or no region.
+- Check existing schema surface for top-level `region` and nested per-child
+  region fields.
+- If changing behavior, require a focused test that asserts child resource or
+  invoke inputs.
+
+## Examples
+
+```text
+Safe:
+- New component consistently passes component-level region to every child from
+  the first release.
+
+Compatibility-sensitive:
+- Existing component exposes top-level region but did not pass it to all
+  children; adding propagation can change existing previews.
+- Changing an invoke to use a different provider or region source.
+
+Breaking:
+- Existing stacks move resources to a different region or provider because AWSX
+  changed propagation behavior without an accepted compatibility path.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` to define the intended provider/region contract.
+Use `$awsx-test-authoring` for mock assertions on child resource and invoke
+inputs.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/public-schema-surface.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/public-schema-surface.md
@@ -1,0 +1,197 @@
+---
+title: Treat Schema Changes As Public-Surface Risk
+tags: schema, sdk, public-surface, generated
+status: draft
+---
+
+## Rule
+
+Treat changes under `provider/pkg/schemagen/**` as public-surface risk until a
+schema-level comparison and generated SDK diff prove the impact.
+
+Input/output renames, removed resources/functions/types/properties, type
+changes, optional-to-required changes, enum or allowed-value changes, token
+remaps, and provider token/module path changes are breaking unless an explicit
+compatibility mechanism covers them.
+
+## Why
+
+AWSX components are schema-backed. A small schema edit can change every generated
+SDK, YAML usage, docs, or provider token shape even when TypeScript
+implementation code still compiles.
+
+## Check
+
+- Inspect the schema generator source diff, not only generated files.
+- Prefer `schema-tools compare` when a before/after schema is available.
+- Inspect generated SDK diffs for renamed tokens, removed inputs/outputs, type
+  changes, requiredness changes, and changed defaults.
+- Confirm generated files were produced from source changes; do not accept
+  manual edits in generated outputs as the source of truth.
+
+## Using schema-tools
+
+Run through `mise` so the repo-pinned version is used even if the shell has an
+older `schema-tools` earlier in `PATH`:
+
+```shell
+mise x -- schema-tools version
+mise x -- schema-tools compare --help
+```
+
+The `schema-tools` version pinned in `mise.toml` supports commit/tag
+comparisons, local schema files, JSON output, and summary-only output.
+
+For AWSX, prefer local schema-file comparison. Direct ref/tag comparison asks
+for `provider/cmd/pulumi-resource-awsx/bridge-metadata.json`, which existing
+AWSX refs do not provide.
+
+Default PR/local-change path: compare the current branch against the verified
+target ref after generating the new schema.
+
+```shell
+base_ref=origin/master
+
+git fetch origin master
+git show "$base_ref":provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-old.json
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  -m -1 \
+  --json > /tmp/awsx-schema-diff.json
+```
+
+Historical release comparison path: use full version tags when reviewing a
+published release boundary, writing release notes, or reconstructing an older
+upgrade. For normal PR review, use the base-ref recipe above.
+
+```shell
+git show v2.21.0:provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-v2.21.0.json
+
+git show v2.22.0:provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-v2.22.0.json
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-v2.21.0.json \
+  --new-path /tmp/awsx-schema-v2.22.0.json \
+  -m -1 \
+  --json > /tmp/awsx-schema-diff.json
+```
+
+Use the exact old and new refs relevant to the review. For a PR, prefer the
+merge base or target branch as the old schema source and the PR branch/head
+generated schema as the new schema source.
+
+`-p awsx` is still required when using `--old-path` and `--new-path`.
+
+Use summary mode for a quick category count:
+
+```shell
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --summary
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --json --summary
+```
+
+Smoke-test the pinned CLI before relying on the recipes in a review. Comparing
+the same schema file to itself should return an empty summary:
+
+```shell
+mise x -- schema-tools compare -p awsx \
+  --old-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  -m -1 \
+  --json --summary
+```
+
+Useful JSON queries:
+
+```shell
+# Summary of breaking-change categories.
+jq '.summary' /tmp/awsx-schema-diff.json
+
+# Changes for a specific resource.
+jq '.grouped.resources["awsx:ecr:Repository"]' /tmp/awsx-schema-diff.json
+
+# All displayed changes of a specific kind. Use `-m -1` when creating the JSON
+# file if this must mean all changes.
+jq '[.changes[] | select(.kind == "missing-input")]' /tmp/awsx-schema-diff.json
+
+# All breaking changes matching a token pattern.
+jq '[.changes[] | select(.breaking and (.token | test("ecr")))]' \
+  /tmp/awsx-schema-diff.json
+
+# List all affected tokens from the saved JSON.
+jq '[.changes[] | .token] | unique' /tmp/awsx-schema-diff.json
+```
+
+## Interpret schema-tools findings
+
+Read output as a blocking diagnostic, not as the final compatibility answer.
+JSON change entries include `scope`, `token`, `location`, `path`, `kind`,
+`severity`, `breaking`, and `message`.
+
+Use the `breaking` field as the schema-tools breaking signal. Do not treat
+`severity` as the breaking signal: a `warn` entry can still have
+`breaking: true`. `summary[].category` is a grouped count of findings, not a
+separate severity model.
+
+Current `kind` values:
+
+- `missing-input`: an existing input disappeared. Treat as breaking unless it
+  is covered by a rename, alias, or other explicit compatibility path.
+- `missing-output`: an existing output disappeared. Usually a source-level SDK
+  break for code, tests, mocks, or consumers that read the output.
+- `missing-property`: a nested type property disappeared. Check whether the
+  type is used for inputs, outputs, or both; input usage is usually more severe.
+- `missing-resource`, `missing-function`, `missing-type`: a token disappeared.
+  Check whether this is an actual removal, a token remap, or generated module
+  path/name drift.
+- `type-changed`: an input, output, or nested property changed shape. Inspect
+  the old and new types. Scalar/object versus array changes are source-level
+  SDK breaks even if the underlying AWS behavior is similar.
+- `optional-to-required`: existing callers may now need to pass a value or
+  construct a required nested field. Input-side cases are high risk.
+- `required-to-optional`: usually lower risk for callers, but still inspect
+  generated SDK diffs because language types may change.
+- `signature-changed`: function inputs or return shape changed. Treat as a
+  source-level SDK break until generated SDK diffs prove otherwise.
+- `token-remapped`: a resource or function moved to a different token. Check
+  import paths, generated SDK names, state compatibility, and aliases.
+- `new-resource`, `new-function`: additive schema findings. Not breaking by
+  themselves, but still review generated SDK placement and any behavior that
+  caused the new token to appear.
+
+`No breaking changes found` means schema-tools found no schema-level breaking
+category. It does not prove behavior compatibility, child resource identity
+compatibility, default compatibility, or generated SDK cleanliness.
+
+## Examples
+
+```text
+Safe:
+- Adding a new optional input with no changed default behavior, after schema and
+  generated SDK diffs show no existing surface changed.
+
+Compatibility-sensitive:
+- Adding a new resource or output; usually additive, but still needs generated
+  surface review and tests.
+
+Breaking:
+- Renaming an input, output, token, module path, enum value, or resource.
+- Changing an existing optional input to required.
+- Changing the type of an existing input or output.
+```
+
+## Hand Off When
+
+Use `$awsx-test-authoring` if schema behavior needs a regression test. Use
+`$awsx-component-design` if the schema shape itself needs redesign.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/upstream-inherited-breaks.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/upstream-inherited-breaks.md
@@ -1,0 +1,49 @@
+---
+title: Separate Upstream Breakage From AWSX Breakage
+tags: upstream, aws-provider, inherited, attribution
+status: draft
+---
+
+## Rule
+
+If a behavior change is inherited from `@pulumi/aws`, AWS, or another upstream
+dependency, identify that boundary explicitly. AWSX may accept upstream
+breakage, but should not add extra AWSX breakage on top without a separate
+decision.
+
+## Why
+
+AWSX wraps and composes lower-level provider behavior. Users still experience the
+upgrade through AWSX, but attribution matters for whether AWSX should add a
+compatibility shim, document the inherited change, or fix AWSX-owned behavior.
+
+## Check
+
+- Identify whether the changed behavior comes from AWSX code, generated schema,
+  `@pulumi/aws`, AWS service behavior, or another dependency.
+- Compare local AWSX integration points against the upstream change.
+- Verify AWSX is not changing child names, parentage, defaults, schema surface,
+  or provider/region behavior in addition to the upstream change.
+- If the upstream change requires user action, decide whether AWSX can shield it
+  or must document it.
+
+## Examples
+
+```text
+Safe:
+- AWSX passes through a new upstream optional input without changing existing
+  defaults or child identity.
+
+Compatibility-sensitive:
+- Upstream changes a default and AWSX also has an AWSX-owned default layered on
+  the same field.
+
+Breaking:
+- AWSX changes its schema or child behavior while claiming the break is only
+  inherited from upstream.
+```
+
+## Hand Off When
+
+Use issue triage or provider investigation workflows when attribution is unclear.
+Use `$awsx-test-authoring` when a discriminator test is needed.


### PR DESCRIPTION


## Summary
<!-- What changed and why. Link issue/task if relevant. -->

## Compatibility
- [ ] No public behavior/API change
- [ ] Public behavior/API changed (describe impact)

## Generated Artifacts
- [ ] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

## Validation
- [ ] `make test_provider`
- [ ] `make lint`
- [ ] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed)
- [ ] `make test` (if integration-impacting; requires AWS creds/resources)
- [ ] Other targeted checks listed in PR body

## Risk
<!-- Blast radius, failure modes, and mitigations. -->

## Rollback
<!-- Concrete rollback steps. -->
