### PR TITLE
Expose grouped VPC subnet resources

### DIFF
--- a/awsx/ec2/vpc.test.ts
+++ b/awsx/ec2/vpc.test.ts
@@ -458,6 +458,7 @@ describe("child resource api", () => {
       subnetSpecs: [
         { type: "Public", tags: { share2: "override" } },
         { type: "Private", tags: { share2: "override" } },
+        { type: "Isolated", tags: { share2: "override" } },
       ],
     });
   });
@@ -491,11 +492,46 @@ describe("child resource api", () => {
 
   it("subnets", async () => {
     const subnets = await unwrap(vpc.subnets);
-    expect(subnets).toHaveLength(6);
+    expect(subnets).toHaveLength(9);
     for (const subnet of subnets) {
       const tags = await unwrap(subnet.tags);
       expect(tags?.share1).toBe("parent");
       expect(tags?.share2).toBe("override");
+    }
+  });
+
+  it("subnets by type", async () => {
+    const publicSubnets = await unwrap(vpc.publicSubnets);
+    const publicSubnetIds = await unwrap(vpc.publicSubnetIds);
+    expect(publicSubnets).toHaveLength(3);
+    expect(await Promise.all(publicSubnets.map((subnet) => unwrap(subnet.id)))).toEqual(publicSubnetIds);
+    for (const subnet of publicSubnets) {
+      const tags = await unwrap(subnet.tags);
+      expect(tags?.share1).toBe("parent");
+      expect(tags?.share2).toBe("override");
+      expect(tags?.SubnetType).toBe("Public");
+    }
+
+    const privateSubnets = await unwrap(vpc.privateSubnets);
+    const privateSubnetIds = await unwrap(vpc.privateSubnetIds);
+    expect(privateSubnets).toHaveLength(3);
+    expect(await Promise.all(privateSubnets.map((subnet) => unwrap(subnet.id)))).toEqual(privateSubnetIds);
+    for (const subnet of privateSubnets) {
+      const tags = await unwrap(subnet.tags);
+      expect(tags?.share1).toBe("parent");
+      expect(tags?.share2).toBe("override");
+      expect(tags?.SubnetType).toBe("Private");
+    }
+
+    const isolatedSubnets = await unwrap(vpc.isolatedSubnets);
+    const isolatedSubnetIds = await unwrap(vpc.isolatedSubnetIds);
+    expect(isolatedSubnets).toHaveLength(3);
+    expect(await Promise.all(isolatedSubnets.map((subnet) => unwrap(subnet.id)))).toEqual(isolatedSubnetIds);
+    for (const subnet of isolatedSubnets) {
+      const tags = await unwrap(subnet.tags);
+      expect(tags?.share1).toBe("parent");
+      expect(tags?.share2).toBe("override");
+      expect(tags?.SubnetType).toBe("Isolated");
     }
   });
 
@@ -511,7 +547,7 @@ describe("child resource api", () => {
 
   it("routeTables", async () => {
     const routeTables = await unwrap(vpc.routeTables);
-    expect(routeTables).toHaveLength(6);
+    expect(routeTables).toHaveLength(9);
     for (const routeTable of routeTables) {
       const tags = await unwrap(routeTable.tags);
       expect(tags?.share1).toBe("parent");

--- a/awsx/ec2/vpc.ts
+++ b/awsx/ec2/vpc.ts
@@ -31,6 +31,9 @@ import { isIPv6 } from "net";
 interface VpcData {
   vpc: aws.ec2.Vpc;
   subnets: aws.ec2.Subnet[];
+  publicSubnets: aws.ec2.Subnet[];
+  privateSubnets: aws.ec2.Subnet[];
+  isolatedSubnets: aws.ec2.Subnet[];
   vpcEndpoints: aws.ec2.VpcEndpoint[];
   routeTables: aws.ec2.RouteTable[];
   routes: aws.ec2.Route[];
@@ -53,6 +56,9 @@ export class Vpc extends schema.Vpc<VpcData> {
 
     this.vpc = data.vpc;
     this.subnets = data.subnets;
+    this.publicSubnets = data.publicSubnets;
+    this.privateSubnets = data.privateSubnets;
+    this.isolatedSubnets = data.isolatedSubnets;
     this.routeTables = data.routeTables;
     this.routes = data.routes;
     this.routeTableAssociations = data.routeTableAssociations;
@@ -134,6 +140,9 @@ export class Vpc extends schema.Vpc<VpcData> {
 
     const vpcEndpoints: aws.ec2.VpcEndpoint[] = [];
     const subnets: aws.ec2.Subnet[] = [];
+    const publicSubnets: aws.ec2.Subnet[] = [];
+    const privateSubnets: aws.ec2.Subnet[] = [];
+    const isolatedSubnets: aws.ec2.Subnet[] = [];
     const routeTables: aws.ec2.RouteTable[] = [];
     const routeTableAssociations: aws.ec2.RouteTableAssociation[] = [];
     const routes: aws.ec2.Route[] = [];
@@ -207,10 +216,13 @@ export class Vpc extends schema.Vpc<VpcData> {
           subnetIndex += availabilityZones.length;
           subnets.push(subnet);
           if (spec.type.toLowerCase() === "public") {
+            publicSubnets.push(subnet);
             publicSubnetIds.push(subnet.id);
           } else if (spec.type.toLowerCase() === "private") {
+            privateSubnets.push(subnet);
             privateSubnetIds.push(subnet.id);
           } else {
+            isolatedSubnets.push(subnet);
             isolatedSubnetIds.push(subnet.id);
           }
 
@@ -323,6 +335,9 @@ export class Vpc extends schema.Vpc<VpcData> {
       vpc,
       vpcEndpoints,
       subnets,
+      publicSubnets,
+      privateSubnets,
+      isolatedSubnets,
       igw,
       routeTables,
       routeTableAssociations,

--- a/awsx/schema-types.ts
+++ b/awsx/schema-types.ts
@@ -65,9 +65,12 @@ export abstract class Vpc<TData = any> extends (pulumi.ComponentResource)<TData>
     public eips!: aws.ec2.Eip[] | pulumi.Output<aws.ec2.Eip[]>;
     public internetGateway!: aws.ec2.InternetGateway | pulumi.Output<aws.ec2.InternetGateway>;
     public isolatedSubnetIds!: string[] | pulumi.Output<string[]>;
+    public isolatedSubnets!: aws.ec2.Subnet[] | pulumi.Output<aws.ec2.Subnet[]>;
     public natGateways!: aws.ec2.NatGateway[] | pulumi.Output<aws.ec2.NatGateway[]>;
     public privateSubnetIds!: string[] | pulumi.Output<string[]>;
+    public privateSubnets!: aws.ec2.Subnet[] | pulumi.Output<aws.ec2.Subnet[]>;
     public publicSubnetIds!: string[] | pulumi.Output<string[]>;
+    public publicSubnets!: aws.ec2.Subnet[] | pulumi.Output<aws.ec2.Subnet[]>;
     public routeTableAssociations!: aws.ec2.RouteTableAssociation[] | pulumi.Output<aws.ec2.RouteTableAssociation[]>;
     public routeTables!: aws.ec2.RouteTable[] | pulumi.Output<aws.ec2.RouteTable[]>;
     public routes!: aws.ec2.Route[] | pulumi.Output<aws.ec2.Route[]>;
@@ -77,7 +80,7 @@ export abstract class Vpc<TData = any> extends (pulumi.ComponentResource)<TData>
     public vpcEndpoints!: aws.ec2.VpcEndpoint[] | pulumi.Output<aws.ec2.VpcEndpoint[]>;
     public vpcId!: string | pulumi.Output<string>;
     constructor(name: string, args: pulumi.Inputs, opts: pulumi.ComponentResourceOptions = {}) {
-        super("awsx:ec2:Vpc", name, opts.urn ? { eips: undefined, internetGateway: undefined, isolatedSubnetIds: undefined, natGateways: undefined, privateSubnetIds: undefined, publicSubnetIds: undefined, routeTableAssociations: undefined, routeTables: undefined, routes: undefined, subnetLayout: undefined, subnets: undefined, vpc: undefined, vpcEndpoints: undefined, vpcId: undefined } : { name, args, opts }, opts);
+        super("awsx:ec2:Vpc", name, opts.urn ? { eips: undefined, internetGateway: undefined, isolatedSubnetIds: undefined, isolatedSubnets: undefined, natGateways: undefined, privateSubnetIds: undefined, privateSubnets: undefined, publicSubnetIds: undefined, publicSubnets: undefined, routeTableAssociations: undefined, routeTables: undefined, routes: undefined, subnetLayout: undefined, subnets: undefined, vpc: undefined, vpcEndpoints: undefined, vpcId: undefined } : { name, args, opts }, opts);
     }
 }
 export interface VpcArgs {

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -2093,6 +2093,13 @@
                         "type": "string"
                     }
                 },
+                "isolatedSubnets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/aws/v7.24.0/schema.json#/resources/aws:ec2%2fsubnet:Subnet"
+                    },
+                    "description": "The VPC's isolated subnets."
+                },
                 "natGateways": {
                     "type": "array",
                     "items": {
@@ -2106,11 +2113,25 @@
                         "type": "string"
                     }
                 },
+                "privateSubnets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/aws/v7.24.0/schema.json#/resources/aws:ec2%2fsubnet:Subnet"
+                    },
+                    "description": "The VPC's private subnets."
+                },
                 "publicSubnetIds": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "publicSubnets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/aws/v7.24.0/schema.json#/resources/aws:ec2%2fsubnet:Subnet"
+                    },
+                    "description": "The VPC's public subnets."
                 },
                 "routeTableAssociations": {
                     "type": "array",
@@ -2170,6 +2191,9 @@
             "required": [
                 "vpc",
                 "subnets",
+                "publicSubnets",
+                "privateSubnets",
+                "isolatedSubnets",
                 "routeTables",
                 "routeTableAssociations",
                 "routes",

--- a/provider/pkg/schemagen/ec2.go
+++ b/provider/pkg/schemagen/ec2.go
@@ -190,6 +190,18 @@ func vpcResource(awsSpec schema.PackageSpec) schema.ResourceSpec {
 					Description: "The VPC's subnets.",
 					TypeSpec:    arrayOfAwsResource(awsSpec, "aws:ec2/subnet:Subnet"),
 				},
+				"publicSubnets": {
+					Description: "The VPC's public subnets.",
+					TypeSpec:    arrayOfAwsResource(awsSpec, "aws:ec2/subnet:Subnet"),
+				},
+				"privateSubnets": {
+					Description: "The VPC's private subnets.",
+					TypeSpec:    arrayOfAwsResource(awsSpec, "aws:ec2/subnet:Subnet"),
+				},
+				"isolatedSubnets": {
+					Description: "The VPC's isolated subnets.",
+					TypeSpec:    arrayOfAwsResource(awsSpec, "aws:ec2/subnet:Subnet"),
+				},
 				"routeTables": {
 					Description: "The Route Tables for the VPC.",
 					TypeSpec:    arrayOfAwsResource(awsSpec, "aws:ec2/routeTable:RouteTable"),
@@ -254,8 +266,9 @@ func vpcResource(awsSpec schema.PackageSpec) schema.ResourceSpec {
 				},
 			},
 			Required: []string{
-				"vpc", "subnets", "routeTables", "routeTableAssociations", "routes", "internetGateway", "natGateways",
-				"eips", "subnetLayout", "publicSubnetIds", "privateSubnetIds", "isolatedSubnetIds", "vpcId", "vpcEndpoints",
+				"vpc", "subnets", "publicSubnets", "privateSubnets", "isolatedSubnets", "routeTables",
+				"routeTableAssociations", "routes", "internetGateway", "natGateways", "eips", "subnetLayout",
+				"publicSubnetIds", "privateSubnetIds", "isolatedSubnetIds", "vpcId", "vpcEndpoints",
 			},
 		},
 		InputProperties: inputProperties,

--- a/sdk/dotnet/Ec2/Vpc.cs
+++ b/sdk/dotnet/Ec2/Vpc.cs
@@ -78,6 +78,12 @@ namespace Pulumi.Awsx.Ec2
         public Output<ImmutableArray<string>> IsolatedSubnetIds { get; private set; } = null!;
 
         /// <summary>
+        /// The VPC's isolated subnets.
+        /// </summary>
+        [Output("isolatedSubnets")]
+        public Output<ImmutableArray<Pulumi.Aws.Ec2.Subnet>> IsolatedSubnets { get; private set; } = null!;
+
+        /// <summary>
         /// The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
         /// </summary>
         [Output("natGateways")]
@@ -86,8 +92,20 @@ namespace Pulumi.Awsx.Ec2
         [Output("privateSubnetIds")]
         public Output<ImmutableArray<string>> PrivateSubnetIds { get; private set; } = null!;
 
+        /// <summary>
+        /// The VPC's private subnets.
+        /// </summary>
+        [Output("privateSubnets")]
+        public Output<ImmutableArray<Pulumi.Aws.Ec2.Subnet>> PrivateSubnets { get; private set; } = null!;
+
         [Output("publicSubnetIds")]
         public Output<ImmutableArray<string>> PublicSubnetIds { get; private set; } = null!;
+
+        /// <summary>
+        /// The VPC's public subnets.
+        /// </summary>
+        [Output("publicSubnets")]
+        public Output<ImmutableArray<Pulumi.Aws.Ec2.Subnet>> PublicSubnets { get; private set; } = null!;
 
         /// <summary>
         /// The Route Table Associations for the VPC.

--- a/sdk/go/awsx/ec2/vpc.go
+++ b/sdk/go/awsx/ec2/vpc.go
@@ -74,10 +74,16 @@ type Vpc struct {
 	// The Internet Gateway for the VPC.
 	InternetGateway   ec2.InternetGatewayOutput `pulumi:"internetGateway"`
 	IsolatedSubnetIds pulumi.StringArrayOutput  `pulumi:"isolatedSubnetIds"`
+	// The VPC's isolated subnets.
+	IsolatedSubnets ec2.SubnetArrayOutput `pulumi:"isolatedSubnets"`
 	// The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
 	NatGateways      ec2.NatGatewayArrayOutput `pulumi:"natGateways"`
 	PrivateSubnetIds pulumi.StringArrayOutput  `pulumi:"privateSubnetIds"`
-	PublicSubnetIds  pulumi.StringArrayOutput  `pulumi:"publicSubnetIds"`
+	// The VPC's private subnets.
+	PrivateSubnets  ec2.SubnetArrayOutput    `pulumi:"privateSubnets"`
+	PublicSubnetIds pulumi.StringArrayOutput `pulumi:"publicSubnetIds"`
+	// The VPC's public subnets.
+	PublicSubnets ec2.SubnetArrayOutput `pulumi:"publicSubnets"`
 	// The Route Table Associations for the VPC.
 	RouteTableAssociations ec2.RouteTableAssociationArrayOutput `pulumi:"routeTableAssociations"`
 	// The Route Tables for the VPC.
@@ -303,6 +309,11 @@ func (o VpcOutput) IsolatedSubnetIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.IsolatedSubnetIds }).(pulumi.StringArrayOutput)
 }
 
+// The VPC's isolated subnets.
+func (o VpcOutput) IsolatedSubnets() ec2.SubnetArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.SubnetArrayOutput { return v.IsolatedSubnets }).(ec2.SubnetArrayOutput)
+}
+
 // The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
 func (o VpcOutput) NatGateways() ec2.NatGatewayArrayOutput {
 	return o.ApplyT(func(v *Vpc) ec2.NatGatewayArrayOutput { return v.NatGateways }).(ec2.NatGatewayArrayOutput)
@@ -312,8 +323,18 @@ func (o VpcOutput) PrivateSubnetIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PrivateSubnetIds }).(pulumi.StringArrayOutput)
 }
 
+// The VPC's private subnets.
+func (o VpcOutput) PrivateSubnets() ec2.SubnetArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.SubnetArrayOutput { return v.PrivateSubnets }).(ec2.SubnetArrayOutput)
+}
+
 func (o VpcOutput) PublicSubnetIds() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Vpc) pulumi.StringArrayOutput { return v.PublicSubnetIds }).(pulumi.StringArrayOutput)
+}
+
+// The VPC's public subnets.
+func (o VpcOutput) PublicSubnets() ec2.SubnetArrayOutput {
+	return o.ApplyT(func(v *Vpc) ec2.SubnetArrayOutput { return v.PublicSubnets }).(ec2.SubnetArrayOutput)
 }
 
 // The Route Table Associations for the VPC.

--- a/sdk/java/src/main/java/com/pulumi/awsx/ec2/Vpc.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ec2/Vpc.java
@@ -122,6 +122,20 @@ public class Vpc extends com.pulumi.resources.ComponentResource {
         return this.isolatedSubnetIds;
     }
     /**
+     * The VPC&#39;s isolated subnets.
+     * 
+     */
+    @Export(name="isolatedSubnets", refs={List.class,Subnet.class}, tree="[0,1]")
+    private Output<List<Subnet>> isolatedSubnets;
+
+    /**
+     * @return The VPC&#39;s isolated subnets.
+     * 
+     */
+    public Output<List<Subnet>> isolatedSubnets() {
+        return this.isolatedSubnets;
+    }
+    /**
      * The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
      * 
      */
@@ -141,11 +155,39 @@ public class Vpc extends com.pulumi.resources.ComponentResource {
     public Output<List<String>> privateSubnetIds() {
         return this.privateSubnetIds;
     }
+    /**
+     * The VPC&#39;s private subnets.
+     * 
+     */
+    @Export(name="privateSubnets", refs={List.class,Subnet.class}, tree="[0,1]")
+    private Output<List<Subnet>> privateSubnets;
+
+    /**
+     * @return The VPC&#39;s private subnets.
+     * 
+     */
+    public Output<List<Subnet>> privateSubnets() {
+        return this.privateSubnets;
+    }
     @Export(name="publicSubnetIds", refs={List.class,String.class}, tree="[0,1]")
     private Output<List<String>> publicSubnetIds;
 
     public Output<List<String>> publicSubnetIds() {
         return this.publicSubnetIds;
+    }
+    /**
+     * The VPC&#39;s public subnets.
+     * 
+     */
+    @Export(name="publicSubnets", refs={List.class,Subnet.class}, tree="[0,1]")
+    private Output<List<Subnet>> publicSubnets;
+
+    /**
+     * @return The VPC&#39;s public subnets.
+     * 
+     */
+    public Output<List<Subnet>> publicSubnets() {
+        return this.publicSubnets;
     }
     /**
      * The Route Table Associations for the VPC.

--- a/sdk/nodejs/ec2/vpc.ts
+++ b/sdk/nodejs/ec2/vpc.ts
@@ -75,11 +75,23 @@ export class Vpc extends pulumi.ComponentResource {
     declare public /*out*/ readonly internetGateway: pulumi.Output<pulumiAws.ec2.InternetGateway>;
     declare public /*out*/ readonly isolatedSubnetIds: pulumi.Output<string[]>;
     /**
+     * The VPC's isolated subnets.
+     */
+    declare public /*out*/ readonly isolatedSubnets: pulumi.Output<pulumiAws.ec2.Subnet[]>;
+    /**
      * The NAT Gateways for the VPC. If no NAT Gateways are specified, this will be an empty list.
      */
     declare public readonly natGateways: pulumi.Output<pulumiAws.ec2.NatGateway[]>;
     declare public /*out*/ readonly privateSubnetIds: pulumi.Output<string[]>;
+    /**
+     * The VPC's private subnets.
+     */
+    declare public /*out*/ readonly privateSubnets: pulumi.Output<pulumiAws.ec2.Subnet[]>;
     declare public /*out*/ readonly publicSubnetIds: pulumi.Output<string[]>;
+    /**
+     * The VPC's public subnets.
+     */
+    declare public /*out*/ readonly publicSubnets: pulumi.Output<pulumiAws.ec2.Subnet[]>;
     /**
      * The Route Table Associations for the VPC.
      */
@@ -145,8 +157,11 @@ export class Vpc extends pulumi.ComponentResource {
             resourceInputs["eips"] = undefined /*out*/;
             resourceInputs["internetGateway"] = undefined /*out*/;
             resourceInputs["isolatedSubnetIds"] = undefined /*out*/;
+            resourceInputs["isolatedSubnets"] = undefined /*out*/;
             resourceInputs["privateSubnetIds"] = undefined /*out*/;
+            resourceInputs["privateSubnets"] = undefined /*out*/;
             resourceInputs["publicSubnetIds"] = undefined /*out*/;
+            resourceInputs["publicSubnets"] = undefined /*out*/;
             resourceInputs["routeTableAssociations"] = undefined /*out*/;
             resourceInputs["routeTables"] = undefined /*out*/;
             resourceInputs["routes"] = undefined /*out*/;
@@ -159,9 +174,12 @@ export class Vpc extends pulumi.ComponentResource {
             resourceInputs["eips"] = undefined /*out*/;
             resourceInputs["internetGateway"] = undefined /*out*/;
             resourceInputs["isolatedSubnetIds"] = undefined /*out*/;
+            resourceInputs["isolatedSubnets"] = undefined /*out*/;
             resourceInputs["natGateways"] = undefined /*out*/;
             resourceInputs["privateSubnetIds"] = undefined /*out*/;
+            resourceInputs["privateSubnets"] = undefined /*out*/;
             resourceInputs["publicSubnetIds"] = undefined /*out*/;
+            resourceInputs["publicSubnets"] = undefined /*out*/;
             resourceInputs["routeTableAssociations"] = undefined /*out*/;
             resourceInputs["routeTables"] = undefined /*out*/;
             resourceInputs["routes"] = undefined /*out*/;

--- a/sdk/python/pulumi_awsx/ec2/vpc.py
+++ b/sdk/python/pulumi_awsx/ec2/vpc.py
@@ -575,8 +575,11 @@ class Vpc(pulumi.ComponentResource):
             __props__.__dict__["eips"] = None
             __props__.__dict__["internet_gateway"] = None
             __props__.__dict__["isolated_subnet_ids"] = None
+            __props__.__dict__["isolated_subnets"] = None
             __props__.__dict__["private_subnet_ids"] = None
+            __props__.__dict__["private_subnets"] = None
             __props__.__dict__["public_subnet_ids"] = None
+            __props__.__dict__["public_subnets"] = None
             __props__.__dict__["route_table_associations"] = None
             __props__.__dict__["route_tables"] = None
             __props__.__dict__["routes"] = None
@@ -614,6 +617,14 @@ class Vpc(pulumi.ComponentResource):
         return pulumi.get(self, "isolated_subnet_ids")
 
     @_builtins.property
+    @pulumi.getter(name="isolatedSubnets")
+    def isolated_subnets(self) -> pulumi.Output[Sequence['pulumi_aws.ec2.Subnet']]:
+        """
+        The VPC's isolated subnets.
+        """
+        return pulumi.get(self, "isolated_subnets")
+
+    @_builtins.property
     @pulumi.getter(name="natGateways")
     def nat_gateways(self) -> pulumi.Output[Sequence['pulumi_aws.ec2.NatGateway']]:
         """
@@ -627,9 +638,25 @@ class Vpc(pulumi.ComponentResource):
         return pulumi.get(self, "private_subnet_ids")
 
     @_builtins.property
+    @pulumi.getter(name="privateSubnets")
+    def private_subnets(self) -> pulumi.Output[Sequence['pulumi_aws.ec2.Subnet']]:
+        """
+        The VPC's private subnets.
+        """
+        return pulumi.get(self, "private_subnets")
+
+    @_builtins.property
     @pulumi.getter(name="publicSubnetIds")
     def public_subnet_ids(self) -> pulumi.Output[Sequence[_builtins.str]]:
         return pulumi.get(self, "public_subnet_ids")
+
+    @_builtins.property
+    @pulumi.getter(name="publicSubnets")
+    def public_subnets(self) -> pulumi.Output[Sequence['pulumi_aws.ec2.Subnet']]:
+        """
+        The VPC's public subnets.
+        """
+        return pulumi.get(self, "public_subnets")
 
     @_builtins.property
     @pulumi.getter(name="routeTableAssociations")


### PR DESCRIPTION
## Summary
- Add `publicSubnets`, `privateSubnets`, and `isolatedSubnets` outputs to `awsx.ec2.Vpc`.
- Populate the new outputs from the existing subnet creation path and regenerate schema/SDKs.
- Add a focused mock test that verifies the grouped subnet resources match the existing grouped subnet ID outputs.

Fixes #1015

## Compatibility
This is an additive schema/API change. Existing `subnets`, `publicSubnetIds`, `privateSubnetIds`, and `isolatedSubnetIds` behavior is preserved, and no child resources are renamed or reparented.

## Validation
- `make build` using the fixed local `pulumi-language-java` path inside `mise exec`
- `make test_provider`
- `schema-tools compare -p awsx --old-path /tmp/awsx-schema-old-1015.json --new-path provider/cmd/pulumi-resource-awsx/schema.json --json --summary`

Not run: full `make test` because it creates real AWS resources.