### PR TITLE
Add AWSX AI harness guidance

### DIFF
--- a/.agents/skills/awsx-aws-service-validation/SKILL.md
+++ b/.agents/skills/awsx-aws-service-validation/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: awsx-aws-service-validation
+description: Validate AWS service facts for pulumi-awsx changes. Use when an AWSX design, implementation, test, or review depends on AWS API behavior, CloudFormation resource support, service constraints, regional availability, documented best practices, or disagreement between AWS docs and the installed @pulumi/aws surface.
+---
+
+# AWSX AWS Service Validation
+
+Use this skill when an AWSX change depends on an AWS service fact. This skill is
+for evidence gathering, not for deciding whether AWSX should add a new
+abstraction.
+
+For component shape, use `$awsx-component-design`. For compatibility risk, use
+`$awsx-breaking-change-evaluation`. For proof strategy, use
+`$awsx-test-authoring`.
+
+## Source Order
+
+Use the narrowest authoritative source that can prove the claim:
+
+1. Installed `@pulumi/aws` schema, SDK types, generated docs, and provider
+   behavior for what AWSX can currently express through Pulumi.
+2. AWS documentation MCP tools or official AWS documentation for service
+   behavior, API constraints, CloudFormation support, regional availability,
+   examples, and best practices.
+3. Existing AWSX behavior and compatibility surface as context to reconcile with
+   the sources above, not as proof of an AWS service fact.
+4. Live AWS acceptance evidence when docs/schema are insufficient, ambiguous, or
+   contradicted by observed behavior.
+
+AWS docs describe what the service can do. The installed `@pulumi/aws` surface
+defines what AWSX can express without provider changes or escape hatches. Do not
+let AWS docs override AWSX compatibility constraints or the currently installed
+provider surface.
+
+Do not use model memory as the source for AWS service behavior. Do not use
+Terraform AWS provider docs as the default source for AWSX guidance; use them
+only as a last-resort hint that must be verified against Pulumi or AWS sources.
+
+## Local Provider Surface
+
+Use local, installed Pulumi sources before reasoning from memory:
+
+```shell
+# Use the same AWS provider version this checkout builds against.
+aws_version=$(node -p 'require("./awsx/package.json").dependencies["@pulumi/aws"]')
+
+# Discover resources and functions in an AWS module.
+pulumi package info "aws@${aws_version}" --module s3
+
+# Inspect one resource's inputs and outputs.
+pulumi package info "aws@${aws_version}" --module s3 --resource Bucket
+
+# Inspect one invoke/function shape.
+pulumi package info "aws@${aws_version}" --module ecr --function getAuthorizationToken
+
+# Inspect TypeScript definitions when implementation code imports @pulumi/aws.
+rg -n "interface BucketArgs|class Bucket" awsx/node_modules/@pulumi/aws/s3/bucket.d.ts
+```
+
+Also inspect the AWSX schema and generated implementation types when the claim
+crosses the AWSX public surface:
+
+```shell
+rg -n "awsx:ecr:Repository|RepositoryArgs" provider/cmd/pulumi-resource-awsx/schema.json awsx/schema-types.ts
+```
+
+## AWS Documentation Sources
+
+Choose the AWS source that matches the claim:
+
+- AWS API reference: request/response shape, service-side validation, and API
+  behavior.
+- CloudFormation resource docs: CloudFormation property support and update
+  behavior.
+- AWS user guide or developer guide: service concepts, recommended patterns, and
+  valid cross-resource configurations.
+- AWS regional availability data: Region-specific service, API, or
+  CloudFormation resource support.
+
+## Using AWS MCP
+
+If the AWS Documentation MCP server or similarly named AWS documentation MCP
+tools are available, prefer them over broad web search for AWS service facts:
+
+- Search AWS docs for the service, resource, property, API, or error.
+- Read the authoritative documentation page before relying on a snippet.
+- Record the source used in the final answer, PR note, or review comment.
+
+When working in an environment with MCP introspection, check the available MCP
+servers/tools first. Useful AWS tool names may look like
+`aws_documentation___search_documentation`,
+`aws_documentation___read_documentation`,
+`aws_documentation___read_sections`, or
+`aws_documentation___recommend`; exact names depend on the configured client.
+
+If AWS documentation MCP tools are unavailable, use official AWS documentation
+and the local installed `@pulumi/aws` surface instead. Do not block the task
+solely because the MCP server is not configured.
+
+## Check
+
+- Identify the exact AWS claim: property exists, value is valid, API behavior,
+  required relationship, regional availability, IAM or service integration, or
+  recommended pattern.
+- For feature-level validation, first enumerate the complete AWS happy-path
+  requirement set for the resource cluster in scope, then validate each
+  required resource, setting, default, and relationship. Do not stop after
+  proving only the property or constraint named by the issue.
+- Compare the AWS claim with the installed `@pulumi/aws` resource args, invoke
+  args, return types, and generated docs when relevant.
+- If AWS docs and `@pulumi/aws` disagree, classify the disagreement:
+  documentation drift, provider lag, AWSX schema limitation, or genuine design
+  choice.
+- Act on the disagreement:
+  - Documentation drift: prefer the installed provider surface for AWSX code and
+    cite the AWS documentation uncertainty.
+  - Provider lag: do not expose the feature through AWSX unless the provider
+    supports it, the change also upgrades `@pulumi/aws`, or a maintainer accepts
+    an explicit escape hatch.
+  - AWSX schema limitation: hand off to `$awsx-component-design` and
+    `$awsx-breaking-change-evaluation` before changing schema shape.
+  - Design choice: document why AWSX intentionally differs from the raw provider
+    or AWS service surface.
+- If the claim affects existing users, hand off to
+  `$awsx-breaking-change-evaluation`.
+- If the claim can only be proven by AWS accepting or observing the behavior,
+  hand off to `$awsx-test-authoring` for targeted acceptance proof.
+
+## Examples
+
+```text
+Safe source-backed design:
+- AWS docs say the API property is supported.
+- Installed @pulumi/aws exposes the matching resource argument.
+- Existing AWSX component shape can pass the value without changing existing
+  behavior.
+
+Needs escalation:
+- AWS docs show a service feature, but installed @pulumi/aws does not expose it.
+- AWS docs and provider schema use different names or shapes.
+- The feature is region-limited and AWSX would need to encode region behavior.
+- The correct behavior depends on AWS accepting a cross-resource integration.
+
+Not enough evidence:
+- "This is how ECS usually works" with no AWS docs, provider surface, local
+  pattern, or live proof.
+- A feature validation that proves one required property exists but does not
+  enumerate the other AWS settings needed for the happy path to work.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` after the AWS fact is known and the question becomes
+how to expose it in AWSX. Use `$awsx-breaking-change-evaluation` when the fact
+changes existing behavior or public surface. Use `$awsx-test-authoring` when the
+fact requires mock, schema, provider-upgrade, or live AWS proof.

--- a/.agents/skills/awsx-aws-service-validation/agents/openai.yaml
+++ b/.agents/skills/awsx-aws-service-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX AWS Service Validation"
+  short_description: "Validate AWS service facts for AWSX"
+  default_prompt: "Use $awsx-aws-service-validation to validate the AWS service facts behind an AWSX change."

--- a/.agents/skills/awsx-breaking-change-evaluation/SKILL.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: awsx-breaking-change-evaluation
+description: Tactical AWSX breaking-change evaluation guidance for pulumi-awsx. Use when assessing schema changes, generated SDK surface changes, child resource identity changes, aliases, changed defaults, provider or region behavior changes, and upgrade impact for existing users.
+---
+
+# AWSX Breaking Change Evaluation
+
+Use this skill to evaluate whether an AWSX change is compatibility-sensitive or
+breaking for existing users.
+
+This skill is for risk classification and required evidence. For component shape
+guidance, use `$awsx-component-design`. For proof strategy, use
+`$awsx-test-authoring`.
+
+## Rule Index
+
+- `rules/public-schema-surface.md`: schema and generated SDK public-surface
+  changes.
+- `rules/code-vs-behavior-breaks.md`: code-level breaks versus preview/update
+  behavior changes.
+- `rules/child-identity-and-aliases.md`: child logical names, parentage, URNs,
+  aliases, and migration paths.
+- `rules/defaults-and-supporting-resources.md`: defaults, default-created
+  resources, tags, and supporting-resource changes.
+- `rules/provider-region-behavior.md`: provider and region propagation changes.
+- `rules/upstream-inherited-breaks.md`: changes inherited from `@pulumi/aws` or
+  AWS behavior versus AWSX-added breakage.
+
+## How To Use
+
+1. Identify the user-visible surface touched by the change: schema, generated
+   SDKs, child resource identity, defaults, providers/regions, or preview/update
+   behavior.
+2. Read the matching rule file.
+3. Classify the change as clearly safe, compatibility-sensitive, or breaking.
+4. If compatibility-sensitive, require evidence: schema comparison, generated
+   diff, mock test, provider-upgrade preview, targeted acceptance test, or an
+   explicit maintainer decision.
+5. Check the upgrade scenarios that match the change: existing user code still
+   compiles, existing stack preview is stable, child resource identity remains
+   compatible, and new programs get the intended behavior.
+6. Report the classification and evidence. Do not smooth uncertainty into a
+   confident answer.
+
+## Stop Early
+
+Stop before approving compatibility if:
+
+- existing user code might need to change;
+- existing stacks might preview replacements, creates, deletes, or changed
+  inputs after upgrade;
+- child names, parentage, aliases, provider tokens, module paths, defaults, or
+  output presence changed;
+- the only evidence is that TypeScript compiles;
+- the change is inherited from upstream but AWSX may be adding extra behavior on
+  top.

--- a/.agents/skills/awsx-breaking-change-evaluation/agents/openai.yaml
+++ b/.agents/skills/awsx-breaking-change-evaluation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX Breaking Change Evaluation"
+  short_description: "Evaluate AWSX compatibility risk"
+  default_prompt: "Use $awsx-breaking-change-evaluation to assess whether an AWSX change is breaking."

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/child-identity-and-aliases.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/child-identity-and-aliases.md
@@ -1,0 +1,58 @@
+---
+title: Preserve Child Resource Identity
+tags: child-resources, names, parents, urns, aliases
+status: draft
+---
+
+## Rule
+
+Treat child resource logical names, parentage, and type tokens as
+compatibility-sensitive. Changing any of them can change URNs and resource
+identity.
+
+Prefer aliases or another automatic compatibility mechanism when moving
+identity. If user action is the only viable migration path, require an explicit
+compatibility decision and document why automatic migration is not possible.
+
+## Why
+
+AWSX components create child resources on behalf of users. Users may never see
+the child constructor code, but Pulumi state records each child's URN. Name,
+parent, or type changes can cause replacements even when public args are
+unchanged.
+
+## Check
+
+- Compare old and new child resource names.
+- Compare old and new parent hierarchy.
+- Compare old and new type tokens and aliases.
+- Verify aliases point at real historical names/types, not the current type as a
+  placeholder.
+- Use mocks only for the parts they can see: child type, logical name, provider,
+  and inputs. Parentage, aliases, and full URN compatibility need upgrade
+  preview, exported-state inspection, or another engine-visible proof.
+- Treat existing nested hierarchies, such as parts of `awsx/ec2/vpc.ts`, as
+  existing compatibility surface until audited.
+
+## Examples
+
+```text
+Safe:
+- Adding an alias that references a real historical child name or type without
+  changing current identity.
+
+Compatibility-sensitive:
+- Adding a new child resource for existing programs.
+- Reparenting an existing child under the component for consistency.
+
+Breaking:
+- Renaming or reparenting an existing child without aliases or another accepted
+  migration path.
+- Replacing a real legacy alias with a no-op alias to the current type.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` for the desired child ownership shape after the
+compatibility path is known. Use `$awsx-test-authoring` for alias or upgrade
+preview coverage.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/code-vs-behavior-breaks.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/code-vs-behavior-breaks.md
@@ -1,0 +1,59 @@
+---
+title: Separate Code-Level And Behavior-Level Breaks
+tags: code-break, behavior-break, preview, update
+status: draft
+---
+
+## Rule
+
+Classify both code-level breaks and behavior-level breaks.
+
+- Code-level break: an existing user must edit their program after upgrading.
+- Behavior-level break: existing code still compiles, but preview/update changes
+  deployed resources, inputs, outputs, replacements, creates, or deletes.
+
+Do not treat compile success as compatibility evidence.
+
+## Why
+
+AWSX can break users without changing the TypeScript API. Component constructors
+create child resources and set defaults; changing that behavior can alter an
+existing stack's next preview.
+
+## Check
+
+- For existing programs with no code changes: confirm whether generated SDK
+  source still compiles and whether preview is stable.
+- For existing stacks: inspect replacements, creates, deletes, changed inputs,
+  changed outputs, and child resource identity.
+- For new programs: confirm the new behavior is intentional and does not rely on
+  a compatibility-only legacy path.
+- Ask what an existing program sees on the next preview after upgrade.
+- Compare child resource types, names, parents, inputs, outputs, and defaulted
+  values.
+- For stateful changes, prefer provider-upgrade preview coverage or a recorded
+  preview fixture over a compile-only check.
+- If the behavior difference is intentional, require an explicit compatibility
+  decision and release note/migration note where appropriate.
+
+## Examples
+
+```text
+Safe:
+- Refactoring implementation helpers with identical child resources, inputs,
+  outputs, and preview behavior.
+
+Compatibility-sensitive:
+- Changing normalization logic that may alter a child input for existing args.
+- Adding a support resource for existing programs as part of a default behavior.
+
+Breaking:
+- Existing programs compile but preview replaces or deletes existing child
+  resources without an accepted migration path.
+- Existing programs must rename an arg or output.
+```
+
+## Hand Off When
+
+Use `$awsx-test-authoring` to choose the cheapest proof that honestly exercises
+the preview/update behavior.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/defaults-and-supporting-resources.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/defaults-and-supporting-resources.md
@@ -1,0 +1,59 @@
+---
+title: Evaluate Defaults By Upgrade Behavior
+tags: defaults, tags, supporting-resources, preview
+status: draft
+---
+
+## Rule
+
+Treat changed defaults as compatibility-sensitive when existing users may see a
+different preview/update after upgrade.
+
+Adding, removing, or replacing default-created support resources is not
+automatically breaking, but it requires explicit compatibility evaluation. Judge
+the user-facing behavior, preview/update effect, cost, permissions, output
+shape, and whether users can override the behavior.
+
+## Why
+
+Defaults are part of the value of AWSX abstractions, but they become persisted
+behavior in real stacks. A default can change resources, tags, IAM permissions,
+or service configuration without any user code change.
+
+## Check
+
+- Identify whether the default is AWSX-owned, `@pulumi/aws`-owned, or
+  service-owned.
+- Owning a default is not itself breaking. Changing the resolved behavior for
+  existing inputs is the compatibility-sensitive part.
+- Check whether existing programs would get new resources, removed resources,
+  changed tags, changed inputs, or changed outputs.
+- Be cautious with defaults that can drift outside AWSX, such as version-like
+  values or fast-moving best practices.
+- If AWSX is only inheriting an upstream default change, verify AWSX is not
+  adding extra breakage.
+
+## Examples
+
+```text
+Safe:
+- Adding a default only for a new optional feature that existing programs do not
+  enable.
+
+Compatibility-sensitive:
+- Adding a new default-created support resource for existing programs.
+- Changing default tags or tag propagation.
+- Changing an AWSX-owned calculation so the same existing inputs produce
+  different child resource inputs, such as CPU/memory normalization.
+
+Breaking:
+- Removing a default-created resource that existing stacks rely on, without an
+  accepted compatibility path.
+- Changing a default so existing stacks preview replacement or deletion.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` if the default should be redesigned around
+user-facing functionality. Use `$awsx-test-authoring` to prove the affected
+preview/update path.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/provider-region-behavior.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/provider-region-behavior.md
@@ -1,0 +1,55 @@
+---
+title: Treat Provider And Region Flow As Behavior
+tags: provider, region, invokes, child-inputs
+status: draft
+---
+
+## Rule
+
+Treat provider and region propagation changes as behavior changes. Passing
+`args.region` to a child that previously used provider configuration can change
+where resources are created or looked up.
+
+For new behavior, provider and region should flow consistently. For shipped
+components, do not retrofit propagation as cleanup without compatibility
+evaluation.
+
+## Why
+
+AWSX components often create many AWS resources. Provider and region context
+determine account, region, and invoke behavior. A region propagation fix can be
+correct and still compatibility-sensitive for existing stacks.
+
+## Check
+
+- Identify every child resource and invoke affected by provider or region
+  changes.
+- Compare whether each child previously used provider configuration, explicit
+  `region`, nested pass-through region, or no region.
+- Check existing schema surface for top-level `region` and nested per-child
+  region fields.
+- If changing behavior, require a focused test that asserts child resource or
+  invoke inputs.
+
+## Examples
+
+```text
+Safe:
+- New component consistently passes component-level region to every child from
+  the first release.
+
+Compatibility-sensitive:
+- Existing component exposes top-level region but did not pass it to all
+  children; adding propagation can change existing previews.
+- Changing an invoke to use a different provider or region source.
+
+Breaking:
+- Existing stacks move resources to a different region or provider because AWSX
+  changed propagation behavior without an accepted compatibility path.
+```
+
+## Hand Off When
+
+Use `$awsx-component-design` to define the intended provider/region contract.
+Use `$awsx-test-authoring` for mock assertions on child resource and invoke
+inputs.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/public-schema-surface.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/public-schema-surface.md
@@ -1,0 +1,197 @@
+---
+title: Treat Schema Changes As Public-Surface Risk
+tags: schema, sdk, public-surface, generated
+status: draft
+---
+
+## Rule
+
+Treat changes under `provider/pkg/schemagen/**` as public-surface risk until a
+schema-level comparison and generated SDK diff prove the impact.
+
+Input/output renames, removed resources/functions/types/properties, type
+changes, optional-to-required changes, enum or allowed-value changes, token
+remaps, and provider token/module path changes are breaking unless an explicit
+compatibility mechanism covers them.
+
+## Why
+
+AWSX components are schema-backed. A small schema edit can change every generated
+SDK, YAML usage, docs, or provider token shape even when TypeScript
+implementation code still compiles.
+
+## Check
+
+- Inspect the schema generator source diff, not only generated files.
+- Prefer `schema-tools compare` when a before/after schema is available.
+- Inspect generated SDK diffs for renamed tokens, removed inputs/outputs, type
+  changes, requiredness changes, and changed defaults.
+- Confirm generated files were produced from source changes; do not accept
+  manual edits in generated outputs as the source of truth.
+
+## Using schema-tools
+
+Run through `mise` so the repo-pinned version is used even if the shell has an
+older `schema-tools` earlier in `PATH`:
+
+```shell
+mise x -- schema-tools version
+mise x -- schema-tools compare --help
+```
+
+The `schema-tools` version pinned in `mise.toml` supports commit/tag
+comparisons, local schema files, JSON output, and summary-only output.
+
+For AWSX, prefer local schema-file comparison. Direct ref/tag comparison asks
+for `provider/cmd/pulumi-resource-awsx/bridge-metadata.json`, which existing
+AWSX refs do not provide.
+
+Default PR/local-change path: compare the current branch against the verified
+target ref after generating the new schema.
+
+```shell
+base_ref=origin/master
+
+git fetch origin master
+git show "$base_ref":provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-old.json
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  -m -1 \
+  --json > /tmp/awsx-schema-diff.json
+```
+
+Historical release comparison path: use full version tags when reviewing a
+published release boundary, writing release notes, or reconstructing an older
+upgrade. For normal PR review, use the base-ref recipe above.
+
+```shell
+git show v2.21.0:provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-v2.21.0.json
+
+git show v2.22.0:provider/cmd/pulumi-resource-awsx/schema.json \
+  > /tmp/awsx-schema-v2.22.0.json
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-v2.21.0.json \
+  --new-path /tmp/awsx-schema-v2.22.0.json \
+  -m -1 \
+  --json > /tmp/awsx-schema-diff.json
+```
+
+Use the exact old and new refs relevant to the review. For a PR, prefer the
+merge base or target branch as the old schema source and the PR branch/head
+generated schema as the new schema source.
+
+`-p awsx` is still required when using `--old-path` and `--new-path`.
+
+Use summary mode for a quick category count:
+
+```shell
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --summary
+
+mise x -- schema-tools compare -p awsx \
+  --old-path /tmp/awsx-schema-old.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --json --summary
+```
+
+Smoke-test the pinned CLI before relying on the recipes in a review. Comparing
+the same schema file to itself should return an empty summary:
+
+```shell
+mise x -- schema-tools compare -p awsx \
+  --old-path provider/cmd/pulumi-resource-awsx/schema.json \
+  --new-path provider/cmd/pulumi-resource-awsx/schema.json \
+  -m -1 \
+  --json --summary
+```
+
+Useful JSON queries:
+
+```shell
+# Summary of breaking-change categories.
+jq '.summary' /tmp/awsx-schema-diff.json
+
+# Changes for a specific resource.
+jq '.grouped.resources["awsx:ecr:Repository"]' /tmp/awsx-schema-diff.json
+
+# All displayed changes of a specific kind. Use `-m -1` when creating the JSON
+# file if this must mean all changes.
+jq '[.changes[] | select(.kind == "missing-input")]' /tmp/awsx-schema-diff.json
+
+# All breaking changes matching a token pattern.
+jq '[.changes[] | select(.breaking and (.token | test("ecr")))]' \
+  /tmp/awsx-schema-diff.json
+
+# List all affected tokens from the saved JSON.
+jq '[.changes[] | .token] | unique' /tmp/awsx-schema-diff.json
+```
+
+## Interpret schema-tools findings
+
+Read output as a blocking diagnostic, not as the final compatibility answer.
+JSON change entries include `scope`, `token`, `location`, `path`, `kind`,
+`severity`, `breaking`, and `message`.
+
+Use the `breaking` field as the schema-tools breaking signal. Do not treat
+`severity` as the breaking signal: a `warn` entry can still have
+`breaking: true`. `summary[].category` is a grouped count of findings, not a
+separate severity model.
+
+Current `kind` values:
+
+- `missing-input`: an existing input disappeared. Treat as breaking unless it
+  is covered by a rename, alias, or other explicit compatibility path.
+- `missing-output`: an existing output disappeared. Usually a source-level SDK
+  break for code, tests, mocks, or consumers that read the output.
+- `missing-property`: a nested type property disappeared. Check whether the
+  type is used for inputs, outputs, or both; input usage is usually more severe.
+- `missing-resource`, `missing-function`, `missing-type`: a token disappeared.
+  Check whether this is an actual removal, a token remap, or generated module
+  path/name drift.
+- `type-changed`: an input, output, or nested property changed shape. Inspect
+  the old and new types. Scalar/object versus array changes are source-level
+  SDK breaks even if the underlying AWS behavior is similar.
+- `optional-to-required`: existing callers may now need to pass a value or
+  construct a required nested field. Input-side cases are high risk.
+- `required-to-optional`: usually lower risk for callers, but still inspect
+  generated SDK diffs because language types may change.
+- `signature-changed`: function inputs or return shape changed. Treat as a
+  source-level SDK break until generated SDK diffs prove otherwise.
+- `token-remapped`: a resource or function moved to a different token. Check
+  import paths, generated SDK names, state compatibility, and aliases.
+- `new-resource`, `new-function`: additive schema findings. Not breaking by
+  themselves, but still review generated SDK placement and any behavior that
+  caused the new token to appear.
+
+`No breaking changes found` means schema-tools found no schema-level breaking
+category. It does not prove behavior compatibility, child resource identity
+compatibility, default compatibility, or generated SDK cleanliness.
+
+## Examples
+
+```text
+Safe:
+- Adding a new optional input with no changed default behavior, after schema and
+  generated SDK diffs show no existing surface changed.
+
+Compatibility-sensitive:
+- Adding a new resource or output; usually additive, but still needs generated
+  surface review and tests.
+
+Breaking:
+- Renaming an input, output, token, module path, enum value, or resource.
+- Changing an existing optional input to required.
+- Changing the type of an existing input or output.
+```
+
+## Hand Off When
+
+Use `$awsx-test-authoring` if schema behavior needs a regression test. Use
+`$awsx-component-design` if the schema shape itself needs redesign.

--- a/.agents/skills/awsx-breaking-change-evaluation/rules/upstream-inherited-breaks.md
+++ b/.agents/skills/awsx-breaking-change-evaluation/rules/upstream-inherited-breaks.md
@@ -1,0 +1,49 @@
+---
+title: Separate Upstream Breakage From AWSX Breakage
+tags: upstream, aws-provider, inherited, attribution
+status: draft
+---
+
+## Rule
+
+If a behavior change is inherited from `@pulumi/aws`, AWS, or another upstream
+dependency, identify that boundary explicitly. AWSX may accept upstream
+breakage, but should not add extra AWSX breakage on top without a separate
+decision.
+
+## Why
+
+AWSX wraps and composes lower-level provider behavior. Users still experience the
+upgrade through AWSX, but attribution matters for whether AWSX should add a
+compatibility shim, document the inherited change, or fix AWSX-owned behavior.
+
+## Check
+
+- Identify whether the changed behavior comes from AWSX code, generated schema,
+  `@pulumi/aws`, AWS service behavior, or another dependency.
+- Compare local AWSX integration points against the upstream change.
+- Verify AWSX is not changing child names, parentage, defaults, schema surface,
+  or provider/region behavior in addition to the upstream change.
+- If the upstream change requires user action, decide whether AWSX can shield it
+  or must document it.
+
+## Examples
+
+```text
+Safe:
+- AWSX passes through a new upstream optional input without changing existing
+  defaults or child identity.
+
+Compatibility-sensitive:
+- Upstream changes a default and AWSX also has an AWSX-owned default layered on
+  the same field.
+
+Breaking:
+- AWSX changes its schema or child behavior while claiming the break is only
+  inherited from upstream.
+```
+
+## Hand Off When
+
+Use issue triage or provider investigation workflows when attribution is unclear.
+Use `$awsx-test-authoring` when a discriminator test is needed.

--- a/.agents/skills/awsx-component-design/SKILL.md
+++ b/.agents/skills/awsx-component-design/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: awsx-component-design
+description: Tactical AWSX component-shape guidance for modern pulumi-awsx components. Use when a change is already in scope and Codex needs to design or review args, outputs, child resource ownership, child exposure, naming, provider/options/region propagation, defaults, registerOutputs behavior, or other AWSX component contract details.
+---
+
+# AWSX Component Design
+
+Use this skill after the change is already considered in scope for AWSX. Do not
+use it to decide whether AWSX should add a new abstraction.
+
+This skill is an index of focused component-shape rules. Load only the rule files
+that match the work in front of you.
+
+For implementation command flow, generated-file boundaries, and source
+locations, use `AGENTS.md`. For tests, use `$awsx-test-authoring`. For
+compatibility review, use `$awsx-breaking-change-evaluation`. For AWS service
+facts, use `$awsx-aws-service-validation`.
+
+## Rule Index
+
+- `rules/args-component-contract.md`: public args, schema-safe shapes,
+  intentional component semantics, `Input<T>`-friendly values, callbacks, flat
+  structures, and duplicate knobs.
+- `rules/outputs-and-exposed-children.md`: public outputs, exposed child
+  resources, private helper resources, and `registerOutputs`.
+- `rules/conditional-children.md`: optional child resources, skip/create/adopt
+  controls, and conditional outputs.
+- `rules/child-resource-ownership.md`: child parents, helper parent parameters,
+  nested resources, and ordering.
+- `rules/child-resource-names.md`: stable child logical names and rename risk.
+- `rules/provider-options-region.md`: provider inheritance, option composition,
+  aliases, top-level `region`, and regional child resources.
+- `rules/defaults-owned-by-awsx.md`: sensible defaults, override paths,
+  provider/service defaults, and default-created supporting resources.
+
+## How To Use
+
+1. Identify which part of the component contract is changing.
+2. Read the matching rule file before designing or reviewing the code.
+3. Validate the proposed shape against nearby AWSX components, the installed
+   `@pulumi/aws` resource surface, and AWS docs when the design depends on
+   service behavior. Use `$awsx-aws-service-validation` when the service fact is
+   not already proven.
+4. Follow the rule examples unless the local component has a documented
+   compatibility exception.
+5. If a rule points to compatibility risk, switch to
+   `$awsx-breaking-change-evaluation` before settling the design.
+6. If a rule needs proof, switch to `$awsx-test-authoring` for the test shape.
+
+## Stop Early
+
+Stop before editing or finalizing the design if:
+
+- the component shape needs a new public arg that is not schema-friendly;
+- the same behavior would be configurable in more than one place;
+- a child resource would be renamed, reparented, or newly exposed;
+- an existing component lacks `registerOutputs` and the right output contract is
+  unclear;
+- provider or region propagation conflicts with existing nested schema fields;
+- the design depends on an AWS service fact that is not verified from the
+  installed Pulumi AWS surface or AWS documentation.

--- a/.agents/skills/awsx-component-design/agents/openai.yaml
+++ b/.agents/skills/awsx-component-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX Component Design"
+  short_description: "Design modern AWSX component shape"
+  default_prompt: "Use $awsx-component-design to review the shape of a modern AWSX component."

--- a/.agents/skills/awsx-component-design/rules/args-component-contract.md
+++ b/.agents/skills/awsx-component-design/rules/args-component-contract.md
@@ -1,0 +1,196 @@
+---
+title: Design Args As The Component Contract
+tags: args, schema, inputs, cross-language, component-semantics
+status: draft
+---
+
+## Rule
+
+Use generated `schema.<Component>Args` shapes for modern `awsx/**` components.
+Design public args as the component entrypoint: schema-friendly, composable from
+Pulumi values, and named around the AWS service capability the user is
+configuring.
+
+Do not default to raw pass-through bags from child `@pulumi/aws` resources. Add
+pass-through surface only when AWSX intentionally exposes an escape hatch or must
+preserve existing schema surface.
+
+## Why
+
+AWSX components are schema-backed and consumed from generated SDKs. A public arg
+should be more than a leak of a child resource API: it should match the mental
+model a user has when configuring the component.
+
+AWSX components are also used for composition. If args only accept plain values,
+callers must use `.apply()` just to connect resources. If args contain callbacks
+or TypeScript-only constructs, generated SDKs cannot represent them. Deep
+artificial nesting makes generated SDKs harder to discover and use.
+
+## Avoid
+
+Hand-authored public shapes only TypeScript can consume:
+
+```ts
+export interface RepositoryArgs {
+  lifecyclePolicy?: {
+    transform?: (policy: aws.ecr.LifecyclePolicyArgs) => aws.ecr.LifecyclePolicyArgs;
+  };
+}
+
+export class Repository extends schema.Repository {
+  constructor(name: string, args: RepositoryArgs, opts: pulumi.ComponentResourceOptions) {
+    super(name, {}, opts);
+  }
+}
+```
+
+Raw child-resource bags as the main component API:
+
+```ts
+export interface RepositoryArgs {
+  repositoryArgs?: aws.ecr.RepositoryArgs;
+  lifecyclePolicyArgs?: aws.ecr.LifecyclePolicyArgs;
+}
+```
+
+Plain values that force callers to unwrap Outputs:
+
+```ts
+interface ServiceArgs {
+  vpcId: string;
+  port: number;
+}
+```
+
+Artificial nesting that only mirrors implementation structure:
+
+```ts
+interface TaskArgs {
+  runtime: {
+    compute: {
+      cpu: pulumi.Input<number>;
+      memory: pulumi.Input<number>;
+    };
+  };
+}
+```
+
+Duplicate knobs for one decision:
+
+```ts
+new Example("x", {
+  region: "us-west-2",
+  listener: { region: "us-east-1" },
+  targetGroup: { region: "us-east-2" },
+});
+```
+
+## Prefer
+
+Intentional component semantics:
+
+```ts
+new Repository("app", {
+  lifecyclePolicy: {
+    rules: [{
+      tagStatus: "untagged",
+      maximumNumberOfImages: 1,
+    }],
+  },
+});
+```
+
+Schema-backed implementation types:
+
+```ts
+export class Repository extends schema.Repository {
+  constructor(name: string, args: schema.RepositoryArgs, opts: pulumi.ComponentResourceOptions) {
+    super(name, {}, opts);
+    const { lifecyclePolicy, ...repoArgs } = args;
+    // Existing schema surface may include pass-through fields; preserve it
+    // intentionally rather than adding new raw pass-through bags by default.
+    this.repository = new aws.ecr.Repository(name.toLowerCase(), repoArgs, { parent: this });
+    this.registerOutputs({
+      repository: this.repository,
+    });
+  }
+}
+```
+
+Args that can compose with resource outputs:
+
+```ts
+export interface ServiceArgs {
+  vpcId: pulumi.Input<string>;
+  port: pulumi.Input<number>;
+}
+```
+
+Configuration instead of callbacks:
+
+```ts
+export interface RepositoryArgs {
+  namePrefix?: pulumi.Input<string>;
+  nameSuffix?: pulumi.Input<string>;
+}
+```
+
+Flat common controls:
+
+```ts
+export interface TaskArgs {
+  cpu?: pulumi.Input<number>;
+  memory?: pulumi.Input<number>;
+}
+```
+
+One component-level control for region-aware components:
+
+```ts
+new Example("x", {
+  region: "us-west-2",
+  listener: { port: 443 },
+});
+```
+
+An explicit mode or strategy when an existing public shape can represent the
+concept, but AWSX needs an opt-in way to apply owned defaults or generated child
+resource wiring:
+
+```ts
+new Example("x", {
+  existingSpecs: [{ name: "main" }],
+  existingSpecStrategy: "Auto",
+});
+```
+
+## AWSX Notes
+
+- Apply this rule at the schema design layer, then consume the generated
+  `schema.<Component>Args` type in implementation code.
+- Before adding a new arg shape, inspect similar AWSX components and the
+  underlying `@pulumi/aws` resource args. Prefer AWSX semantics over raw
+  pass-through bags, but do not invent a shape that conflicts with the provider
+  surface without a documented reason.
+- Use the schema generator as the public-surface source of truth; do not invent a
+  parallel TypeScript-only public interface in `awsx/**`.
+- Prefer AWS service terminology over invented names when it helps users map the
+  component to AWS docs and errors.
+- Existing schema may already expose pass-through fields. Preserve existing
+  behavior unless compatibility review settles a different path.
+- Before adding a second public API for a concept, ask whether the current
+  surface can be extended safely. A mode or strategy field can be a good
+  candidate when the old shape is valid but lacks AWSX-owned resolution
+  behavior. Do not use this as a default preference; compare it against other
+  designs and the long-term cost of supporting both surfaces.
+- Do not add a blanket "no unions" rule here. AWSX schema-backed components can
+  support union-shaped public surface when the schema supports it.
+- Nesting can be appropriate for real child concepts such as `listener`,
+  `defaultTargetGroup`, `natGateways`, or `lifecyclePolicy`. Avoid nesting that
+  only mirrors implementation structure.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if changing arg shape affects generated
+SDKs or existing programs. Use `$awsx-test-authoring` when Output/Input
+composition needs a regression test.

--- a/.agents/skills/awsx-component-design/rules/child-resource-names.md
+++ b/.agents/skills/awsx-component-design/rules/child-resource-names.md
@@ -1,0 +1,74 @@
+---
+title: Derive Stable Child Names From The Component Name
+tags: names, children, identity, aliases
+status: draft
+---
+
+## Rule
+
+Derive child logical names from the component `name`. Use stable suffixes such
+as `name`, `${name}-suffix`, or `${name}-${i}`. Do not hardcode child names.
+
+Do not rename existing children as cleanup.
+
+## Why
+
+Child logical names are part of Pulumi resource identity. Hardcoded names collide
+across component instances, and released name changes can cause replacement
+unless aliases or another compatibility path handles the move.
+
+## Avoid
+
+```ts
+this.loadBalancer = new aws.lb.LoadBalancer("load-balancer", lbArgs, {
+  parent: this,
+});
+
+this.listeners = listeners.map((args) =>
+  new aws.lb.Listener("listener", args, { parent: this }),
+);
+```
+
+## Prefer
+
+```ts
+this.loadBalancer = new aws.lb.LoadBalancer(name, lbArgs, {
+  parent: this,
+});
+
+this.listeners = listeners.map((args, i) =>
+  new aws.lb.Listener(`${name}-${i}`, args, { parent: this }),
+);
+
+this.registerOutputs({
+  loadBalancer: this.loadBalancer,
+  listeners: this.listeners,
+});
+```
+
+If a service requires a transformed physical name, derive that from the
+component name too:
+
+```ts
+const lowerCaseName = name.toLowerCase();
+this.repository = new aws.ecr.Repository(lowerCaseName, repoArgs, {
+  parent: this,
+});
+this.registerOutputs({
+  repository: this.repository,
+});
+```
+
+## AWSX Notes
+
+- Existing code may use `name` directly for the primary child and stable suffixes
+  for secondary children.
+- A child name that looks cosmetically odd may still be compatibility-sensitive
+  once released.
+- Do not use `awsx-classic/**` naming as the default model for modern `awsx/**`
+  code unless the change explicitly preserves legacy compatibility.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if a child name changes or aliases may be
+required.

--- a/.agents/skills/awsx-component-design/rules/child-resource-ownership.md
+++ b/.agents/skills/awsx-component-design/rules/child-resource-ownership.md
@@ -1,0 +1,79 @@
+---
+title: Parent New Children To The Component
+tags: children, parentage, ownership, dependsOn
+status: draft
+---
+
+## Rule
+
+Parent new child resources to the component with `{ parent: this }` unless the
+local component already has an intentional, compatibility-sensitive child
+hierarchy. Do not nest a child under another child just to express ordering; use
+`dependsOn` when ordering is the reason.
+
+## Why
+
+Parenting controls Pulumi hierarchy and provider/options inheritance. Accidental
+nesting changes the resource tree and can become compatibility-sensitive once
+released.
+
+## Avoid
+
+```ts
+const securityGroup = new aws.ec2.SecurityGroup(`${name}-sg`, securityGroupArgs);
+
+const listener = new aws.lb.Listener(`${name}-listener`, listenerArgs, {
+  // Do not use parentage as an ordering substitute.
+  parent: loadBalancer,
+});
+```
+
+Also avoid helpers that silently drop parent context:
+
+```ts
+function defaultBucket(name: string) {
+  return new aws.s3.Bucket(name);
+}
+```
+
+## Prefer
+
+```ts
+const securityGroup = new aws.ec2.SecurityGroup(`${name}-sg`, securityGroupArgs, {
+  parent: this,
+});
+
+const listener = new aws.lb.Listener(`${name}-listener`, listenerArgs, {
+  parent: this,
+  dependsOn: [this.loadBalancer],
+});
+```
+
+Pass parent/options through helper functions:
+
+```ts
+function defaultBucket(
+  name: string,
+  args: aws.s3.BucketArgs,
+  opts: pulumi.ResourceOptions,
+) {
+  return new aws.s3.Bucket(name, args, opts);
+}
+
+const bucket = defaultBucket(name, {}, { parent: this });
+```
+
+## AWSX Notes
+
+- `awsx/ec2/vpc.ts` has existing nested parents such as subnets under the VPC and
+  routes under route tables. When editing inside that component, follow the local
+  hierarchy unless the change is explicitly about reparenting.
+- Existing nested hierarchies need audit before changing or extending in a
+  different style.
+- If preserving a hierarchy requires aliases or migration behavior, that is not
+  a component-design-only decision.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` before changing parentage for any existing
+child resource.

--- a/.agents/skills/awsx-component-design/rules/conditional-children.md
+++ b/.agents/skills/awsx-component-design/rules/conditional-children.md
@@ -1,0 +1,87 @@
+---
+title: Make Optional Child Resources Explicit
+tags: conditional-children, skip, create-adopt, outputs
+status: draft
+---
+
+## Rule
+
+When a component conditionally creates child resources, make the user-facing
+functionality clear. Conditional creation is normal for an abstraction; the
+component API should explain the behavior users are enabling, disabling, or
+adopting without requiring them to understand every internal child resource.
+
+## Why
+
+Conditional children are often how AWSX implements functionality. Users need to
+understand the functional choice they are making and which public outputs may be
+undefined, but the API should not expose internals just because the
+implementation uses a child resource.
+
+## Avoid
+
+```ts
+// Does bucketName mean "create a bucket with this name" or "use an existing bucket"?
+const bucket = args.bucketName
+  ? new aws.s3.Bucket(args.bucketName, {}, { parent: this })
+  : new aws.s3.Bucket(name, {}, { parent: this });
+```
+
+## Prefer
+
+Use explicit component-level choices when the user can create or adopt a
+supporting resource:
+
+```ts
+const { bucket, bucketId } = requiredBucket(name, args.s3Bucket, {}, {
+  parent: this,
+});
+```
+
+Use skip-style controls for optional children:
+
+```ts
+if (!lifecyclePolicy?.skip) {
+  this.lifecyclePolicy = new aws.ecr.LifecyclePolicy(name, {
+    repository: this.repository.name,
+    policy: buildLifecyclePolicy(lifecyclePolicy),
+  }, {
+    parent: this,
+  });
+}
+
+this.registerOutputs({
+  lifecyclePolicy: this.lifecyclePolicy,
+});
+```
+
+Expose conditional outputs honestly:
+
+```ts
+this.lifecyclePolicy = lifecyclePolicy?.skip ? undefined : new aws.ecr.LifecyclePolicy(
+  name,
+  lifecyclePolicyArgs,
+  { parent: this },
+);
+
+this.registerOutputs({
+  lifecyclePolicy: this.lifecyclePolicy,
+});
+```
+
+## AWSX Notes
+
+- Existing helper patterns such as `requiredBucket`, `optionalLogGroup`, and
+  skip-style child args are useful examples to inspect before inventing a new
+  conditional-child shape.
+- A conditional child that used to be unconditional, or the reverse, can be
+  compatibility-sensitive. Evaluate the user-visible behavior, preview/update
+  effect, cost, permissions, and output shape.
+- Conditional outputs should match the generated schema output contract.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if conditional creation changes existing
+user-visible behavior, output presence, cost, permissions, or preview/update
+results. Use `$awsx-test-authoring` to prove the created/skipped/adopted
+branches.

--- a/.agents/skills/awsx-component-design/rules/defaults-owned-by-awsx.md
+++ b/.agents/skills/awsx-component-design/rules/defaults-owned-by-awsx.md
@@ -1,0 +1,92 @@
+---
+title: Provide Sensible Defaults With Clear Overrides
+tags: defaults, overrides, compatibility
+status: draft
+---
+
+## Rule
+
+Prefer sensible defaults when AWSX can provide or calculate useful behavior
+without blocking full customization. Defaults should reduce boilerplate while
+leaving an explicit override path.
+
+Defaults are part of the abstraction. Prefer stable, value-adding defaults that
+AWSX can preserve as compatibility surface.
+
+Be cautious with defaults that can drift outside AWSX, such as service-owned
+defaults, provider behavior, version-like values, or fast-moving best practices.
+
+## Why
+
+Defaults are a major part of the value of an AWSX abstraction. They let users get
+started without understanding every child resource detail. They are also
+user-visible behavior, so unstable or unclear defaults can become compatibility
+risks.
+
+## Avoid
+
+```ts
+// Pins a service-owned version-like value without making that choice explicit.
+const serviceArgs = {
+  ...args,
+  platformVersion: "1.4.0",
+};
+```
+
+## Prefer
+
+Default component-owned behavior when AWSX can preserve the contract:
+
+```ts
+const requiredMemoryAndCPU = containerDefinitions
+  .apply((defs) => calculateFargateMemoryAndCPU(defs));
+
+if (mutableArgs.cpu === undefined) {
+  mutableArgs.cpu = requiredMemoryAndCPU.cpu;
+}
+if (mutableArgs.memory === undefined) {
+  mutableArgs.memory = requiredMemoryAndCPU.memory;
+}
+```
+
+Omit or pass through service-owned/version-like values unless AWSX deliberately
+owns that default:
+
+```ts
+const serviceArgs: aws.ecs.ServiceArgs = {
+  ...args,
+  platformVersion: args.platformVersion,
+};
+```
+
+## AWSX Notes
+
+- Stable convenience defaults can be valid AWSX behavior when they are deliberate
+  and covered as part of the component contract.
+- Defaults can be calculated from other component inputs when that better
+  matches the component's semantics, as in Fargate CPU/memory derivation from
+  container definitions.
+- Defaults may create supporting resources when that is how AWSX implements the
+  user-facing functionality. Do not expose skip/create/adopt controls solely
+  because an implementation detail exists.
+- AWSX-owned defaults are also provisioned security posture. When AWSX creates
+  supporting resources by default, check whether the default silently creates
+  broader access than the component semantics require. Review concrete inputs
+  such as security groups, IAM roles and policies, bucket or resource policies,
+  service principals, public subnet or listener defaults, and log or debug
+  sinks. Keep clear override paths for security-relevant defaults.
+- When existing args can already express the concept but legacy behavior is too
+  pass-through to apply useful AWSX-owned defaults, consider an explicit mode or
+  strategy before creating a second long-lived API. This is a candidate design,
+  not a hard rule; compare it against compatibility risk and user clarity.
+- When AWSX does not add semantics, passing through to `@pulumi/aws` or AWS
+  service defaults can be the right behavior.
+- Version-like defaults and fast-moving best-practice defaults need extra care;
+  do not add them casually.
+- Changing an existing default is compatibility-sensitive even when TypeScript
+  still compiles.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if adding, removing, or changing a default
+can affect an existing user's next preview or update.

--- a/.agents/skills/awsx-component-design/rules/outputs-and-exposed-children.md
+++ b/.agents/skills/awsx-component-design/rules/outputs-and-exposed-children.md
@@ -1,0 +1,88 @@
+---
+title: Expose Outputs And Children Deliberately
+tags: outputs, children, registerOutputs, public-contract
+status: draft
+---
+
+## Rule
+
+Expose outputs users need to compose with other resources. Expose child resource
+objects only when users reasonably need the resource object, its ID/ARN/name, or
+direct dependency relationships.
+
+Assign public properties before calling `registerOutputs`. New component
+constructors should call `registerOutputs`; existing omissions should be fixed
+when touching the constructor or output-publishing path.
+
+## Why
+
+Outputs and public child properties become part of the component contract.
+Exposing too little blocks composition; exposing implementation helpers makes
+future internal changes harder.
+
+## Avoid
+
+```ts
+export class Repository extends schema.Repository {
+  constructor(name: string, args: schema.RepositoryArgs, opts: pulumi.ComponentResourceOptions) {
+    super(name, {}, opts);
+    const { lifecyclePolicy, ...repoArgs } = args;
+
+    const repository = new aws.ecr.Repository(name.toLowerCase(), repoArgs, { parent: this });
+    const lifecyclePolicyResource = new aws.ecr.LifecyclePolicy(name, {
+      repository: repository.name,
+      policy: "{}",
+    }, { parent: this });
+
+    // Public fields from the generated base are never assigned.
+    // registerOutputs is missing.
+  }
+}
+```
+
+## Prefer
+
+```ts
+export class Repository extends schema.Repository {
+  constructor(name: string, args: schema.RepositoryArgs, opts: pulumi.ComponentResourceOptions) {
+    super(name, {}, opts);
+    const { lifecyclePolicy, ...repoArgs } = args;
+
+    this.repository = new aws.ecr.Repository(name.toLowerCase(), repoArgs, {
+      parent: this,
+    });
+    this.url = this.repository.repositoryUrl;
+
+    this.registerOutputs({
+      repository: this.repository,
+      url: this.url,
+    });
+  }
+}
+```
+
+Register exposed child resources explicitly:
+
+```ts
+this.trail = new aws.cloudtrail.Trail(name, trailArgs, { parent: this });
+this.registerOutputs({
+  trail: this.trail,
+});
+```
+
+## AWSX Notes
+
+- Existing generated bases may define the public output shape. Do not create a
+  second output contract by hand in implementation files.
+- Component-only args must be removed before forwarding args to child
+  `@pulumi/aws` resources.
+- Helper resources created only to wire the component should usually remain
+  private.
+- A missing `registerOutputs` is a design issue for new components or changes
+  that touch constructor/output-publishing behavior. Existing omissions outside
+  the touched path can be handled by a separate cleanup.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if exposing, hiding, or renaming an output
+or child resource changes existing public surface.

--- a/.agents/skills/awsx-component-design/rules/provider-options-region.md
+++ b/.agents/skills/awsx-component-design/rules/provider-options-region.md
@@ -1,0 +1,103 @@
+---
+title: Preserve Provider, Options, And Region Flow
+tags: providers, options, region, aliases
+status: draft
+---
+
+## Rule
+
+Let providers and other resource options flow through component parentage unless
+a child needs a different provider explicitly. Preserve caller options when
+adding component aliases or default options.
+
+For new component behavior, when a component has `args.region`, pass it to every
+child resource that accepts region. For existing shipped components, treat new
+region propagation as a compatibility-sensitive behavior change unless the
+change is already scoped to fix region behavior.
+
+## Why
+
+AWSX components create several child resources on the user's behalf. Provider and
+region propagation must behave as part of the component contract, not as an
+accidental property of one child.
+
+## Avoid
+
+```ts
+super(name, {}, {
+  aliases: [{ type: "awsx:lb:ApplicationLoadBalancer" }],
+});
+
+this.loadBalancer = new aws.lb.LoadBalancer(name, lbArgs, {
+  parent: this,
+});
+
+this.listener = new aws.lb.Listener(`${name}-0`, listenerArgs, {
+  parent: this,
+});
+```
+
+This drops caller `opts` and does not show how a top-level region reaches
+regional children. The alias is also a no-op because it names the current type
+instead of a real legacy type.
+
+## Prefer
+
+```ts
+super(
+  name,
+  {},
+  pulumi.mergeOptions(opts, {
+    aliases: [
+      {
+        type: "awsx:x:elasticloadbalancingv2:ApplicationLoadBalancer",
+      },
+    ],
+  }),
+);
+
+const lbArgs: aws.lb.LoadBalancerArgs = {
+  ...restArgs,
+  region: args.region,
+};
+
+this.loadBalancer = new aws.lb.LoadBalancer(name, lbArgs, {
+  parent: this,
+});
+
+this.listener = new aws.lb.Listener(`${name}-0`, {
+  ...listenerArgs,
+  region: args.region,
+  loadBalancerArn: this.loadBalancer.arn,
+}, {
+  parent: this,
+});
+
+this.registerOutputs({
+  loadBalancer: this.loadBalancer,
+  listener: this.listener,
+});
+```
+
+## AWSX Notes
+
+- Prefer `pulumi.mergeOptions` for new option composition so caller options are
+  preserved.
+- Alias examples must point at real historical names or types, such as the
+  legacy `awsx:x:*` aliases used by modern AWSX components. Do not add an alias
+  to the current type as a placeholder.
+- `awsx/ecr/registryImage.ts` is a narrow case where Docker resources use an
+  explicit provider. Do not generalize that pattern to ordinary AWS children.
+- Existing nested pass-through objects may already have their own `region`.
+  Avoid expanding that pattern; preserve existing behavior unless compatibility
+  review settles a different path.
+- Some existing components expose `region` in schema but do not yet pass it to
+  every child. Do not retrofit that behavior as cleanup inside an unrelated
+  component-shape change.
+- This rule is not a policy for when to add a lookup. It only applies once the
+  component already needs a child resource or invoke.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if provider or region propagation changes
+existing preview/update behavior.

--- a/.agents/skills/awsx-implement-approved-plan/SKILL.md
+++ b/.agents/skills/awsx-implement-approved-plan/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: awsx-implement-approved-plan
+description: Manual-only AWSX implementation session launcher. Use only when explicitly invoked to implement an already reviewed AWSX planning brief or approved plan.
+---
+
+# AWSX Implement Approved Plan
+
+This is a manual-only launcher skill. Use it only when the user explicitly
+invokes it with an approved plan or reviewed planning brief.
+
+## Inputs
+
+Use the approved plan supplied with the invocation, or a file/PR/comment the
+user identifies as the approved plan. If the approved plan is missing, ask for
+it and stop.
+
+## Workflow
+
+1. Read the approved plan and the current checkout state.
+2. Do not reopen the design unless live evidence contradicts the approved plan.
+3. If the approved plan cannot satisfy the user-visible AWS outcome, stop and
+   report the blocker instead of substituting a narrower fix.
+4. Use the tactical AWSX skills as needed:
+   - `$awsx-component-design` for component/API details;
+   - `$awsx-breaking-change-evaluation` for compatibility-sensitive behavior;
+   - `$awsx-test-authoring` for focused proof;
+   - `$awsx-aws-service-validation` for new AWS service facts.
+5. Implement the smallest change that satisfies the approved user-visible
+   outcome.
+6. Do not run full `make test` locally. Run focused validation only, following
+   `AGENTS.md` and `$awsx-test-authoring`.
+7. Report what changed, what validation ran, what remains unproven, and any
+   deviation from the approved plan.
+
+## Stop Conditions
+
+Stop instead of coding if:
+
+- the approved plan is ambiguous or missing;
+- current code, provider surface, or AWS docs contradict the plan;
+- the implementation would need a broader API/product decision than the plan
+  approved;
+- satisfying the plan requires generated file edits without changing the source
+  of truth first;
+- only live AWS behavior could prove the central claim and the user has not
+  approved that validation path.

--- a/.agents/skills/awsx-implement-approved-plan/agents/openai.yaml
+++ b/.agents/skills/awsx-implement-approved-plan/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "AWSX Implement Approved Plan"
+  short_description: "Implement a reviewed AWSX issue plan"
+  default_prompt: "Use $awsx-implement-approved-plan with the issue URL and approved planning brief."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/awsx-issue-planning/SKILL.md
+++ b/.agents/skills/awsx-issue-planning/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: awsx-issue-planning
+description: Pre-implementation planning for nontrivial pulumi-awsx issues and feature requests. Use before editing when an AWSX issue may require API design, changed defaults, new child resources, compatibility-sensitive behavior, a checked-in spec, or a choice between a narrow fix and a better component shape.
+---
+
+# AWSX Issue Planning
+
+Use this skill before implementation when an AWSX issue is more than a narrow,
+already-scoped code change. The goal is to decide what should be built, whether
+AWSX should own the behavior, what artifact is needed, and what proof is needed
+before editing.
+
+For nontrivial GitHub issues, the planning brief is the deliverable. Stop after
+the brief by default. Do not implement in the same turn unless the user prompt
+explicitly says the plan is already approved or explicitly asks to proceed
+without a maintainer review checkpoint.
+
+A prompt that says "implement if the planning brief says implementation should
+proceed" is not pre-approval. That delegates the go/no-go decision back to the
+brief and still counts as self-approval.
+
+This skill is the gate before the tactical skills:
+
+- Use `$awsx-component-design` after selecting a component/API shape.
+- Use `$awsx-breaking-change-evaluation` when an option changes public schema,
+  child resources, defaults, providers, regions, or upgrade behavior.
+- Use `$awsx-test-authoring` after choosing the behavior that needs proof.
+- Use `$awsx-aws-service-validation` when AWS service behavior is part of the
+  decision.
+
+## When To Use
+
+Use this for:
+
+- GitHub issues where the literal fix may not be the right component design;
+- requests that add or deprecate public args, outputs, or child resources;
+- changed AWSX-owned defaults or default-created supporting resources;
+- cases where users might need resources created inside the same component;
+- bugs where existing users may already have a workaround with lower-level
+  `@pulumi/aws` resources;
+- any request where "smallest fix" and "ideal user experience" are different.
+
+Skip this for:
+
+- mechanical test fixes, lint fixes, docs-only edits, or already-approved plans;
+- narrow changes whose API shape and compatibility risk are already settled.
+
+## Planning Workflow
+
+1. Gather enough live context to avoid guessing:
+   - issue body, comments, related PRs, and linked examples;
+   - current AWSX code, schema source if relevant, and existing tests;
+   - installed `@pulumi/aws` resource surface for affected child resources;
+   - AWS documentation or API facts when service behavior matters.
+   Treat prior rollout summaries, memories, or old worktree diffs for the same
+   issue as historical attempts, not accepted design guidance. Re-check the
+   issue and repo shape before reusing any prior implementation pattern.
+2. Classify the problem:
+   - bug in current implementation;
+   - missing public API shape;
+   - confusing or unusable legacy API;
+   - documentation gap or user-error case;
+   - out-of-scope abstraction request.
+3. Check current usability:
+   - Can a user express the correct architecture today in one Pulumi program and
+     one update?
+   - If yes, is it through AWSX directly or by composing lower-level
+     `@pulumi/aws` resources after the component exists?
+   - If no, name exactly which values cannot be referenced or configured.
+4. Trace the user's end-to-end goal:
+   - write the user-visible definition of done in terms of the working AWS
+     outcome for the resource cluster in scope, not the issue's literal symptom
+     or the user's whole application architecture;
+   - list the AWS service requirements for that outcome, using
+     `$awsx-aws-service-validation` when the requirements are not already
+     certain;
+   - measure the current API and each candidate design against the full working
+     outcome, including required defaults and override paths;
+   - ask "what immediate follow-up issue would users file because this change
+     is incomplete?" and include the answer in the candidate comparison.
+5. Define the ideal user configuration:
+   - show the smallest realistic code shape a user would want to write;
+   - include required supporting resources, defaults, and override paths;
+   - distinguish AWSX-created resources from user-supplied resources.
+6. If public component surface is involved, perform an existing-surface
+   extension pass before recommending a new API:
+   - ask whether the current public API can satisfy the working outcome through
+     clearer defaults, an explicit mode or strategy, additional fields, or
+     composition with lower-level resources;
+   - check whether existing users are already successfully using the current
+     surface and what compatibility promise AWSX would inherit;
+   - if proposing a new public surface anyway, explain why extending the current
+     surface is insufficient;
+   - account for surface lifetime cost: whether old and new surfaces both remain
+     supported, how users know which one to use, and what behavior would be
+     duplicated across them.
+7. Compare candidate designs:
+   - do not force designs into fixed buckets; let the issue shape determine the
+     candidate set;
+   - for each candidate, state completeness against the user-visible outcome,
+     existing-user path, new-user path, compatibility risk, implementation size,
+     surface lifetime cost when relevant, migration story, immediate follow-up
+     issue risk, and proof required;
+   - do not select a narrow fix if it only fixes the named symptom while leaving
+     the user-visible outcome nonfunctional or forcing an immediate follow-up
+     issue.
+8. Recommend a path:
+   - choose one candidate design or state where maintainer input is needed;
+   - state why the rejected designs are not good enough;
+   - name the next tactical skills an implementation session should use.
+9. Stop after the brief unless the prompt explicitly pre-approves implementation
+   after planning. Do not self-approve by saying the brief is
+   implementation-ready and then editing in the same turn.
+
+## Choose The Artifact
+
+Use the smallest artifact that reduces real risk:
+
+- **Chat-only planning brief**: narrow fix, obvious API shape, and low
+  compatibility risk.
+- **Checked-in spec**: new public args or outputs, changed default-created
+  resources, multiple plausible component shapes, compatibility-sensitive child
+  resources, or behavior that affects generated SDK/schema surface.
+- **Handoff/status doc**: multi-session work with unresolved decisions,
+  temporary branch state, or validation that cannot be completed locally.
+
+Do not create `docs/specs/**` by default. Create a checked-in spec only when the
+planning brief shows that implementation would otherwise hide a product/API
+decision.
+
+Before drafting a checked-in spec for a public-surface change, checkpoint with
+the maintainer if multiple plausible surface directions remain. Summarize the
+decision pressure first: whether the existing surface can be extended, why a new
+surface may still be needed, and what long-term maintenance cost each direction
+creates.
+
+For a checked-in spec, prefer a compact Markdown document under `docs/specs/`
+with this shape:
+
+```markdown
+# <Topic> AWSX Component Design
+
+## Summary
+What is changing, who observes it, and why AWSX should own it.
+
+## Current Usability
+What users can and cannot express today, including one-update workarounds.
+
+## Desired User Experience
+Representative AWSX program shape and which resources AWSX creates or adopts.
+
+## Existing Surface Extension
+Whether the current public API can be extended before adding a second surface,
+including surface lifetime cost if a new API is still preferred.
+
+## Design
+Public args/outputs, child resources, defaults, override paths, and rejected
+alternatives.
+
+## Compatibility Risks
+Schema/SDK surface, child names/aliases, default resources, provider/region
+behavior, and migration.
+
+## Validation
+Focused tests/checks for each important invariant, plus what remains unproven.
+```
+
+Omit sections only when they truly add no information. Keep durable component
+semantics separate from temporary rollout notes if combining them would make the
+spec noisy.
+
+## Abstraction Discipline
+
+Favor AWSX ownership when the behavior is a broadly useful resource wrapper or a
+bounded component around one logical resource cluster. Be cautious when the
+request turns into an application blueprint, multi-service architecture, or a
+steady stream of highly specific variations.
+
+Defaults are allowed only when AWSX can intentionally own and preserve them as
+compatibility surface. Avoid owning service-version, provider, or AWS-managed
+defaults that are likely to drift outside AWSX.
+
+## Planning Brief Format
+
+Produce a concise planning brief:
+
+````markdown
+## Planning Brief
+
+Problem:
+- <what is broken or missing>
+
+Current usability:
+- <usable today? one-shot? workaround? what cannot be expressed?>
+
+User-visible definition of done:
+- <working AWS outcome, not just the issue symptom>
+
+Service requirements:
+- <AWS requirements for the happy path, including defaults/supporting resources>
+
+Ideal user configuration:
+```ts
+<short representative AWSX program shape>
+```
+
+Candidate designs:
+- <candidate design>: <completeness against definition of done, existing-user
+  path, new-user path, compatibility, surface lifetime cost if public API is
+  involved, next issue users would file, proof>
+- <candidate design>: <same checks>
+
+Artifact:
+- <chat-only brief, checked-in spec, or handoff/status doc>
+
+Recommendation:
+- <selected path or stop for input>
+
+Next proof:
+- <focused tests/checks; what remains unproven>
+````
+
+Keep the brief short enough for a maintainer to challenge it. The definition of
+done should usually be one or two lines, and service requirements should be a
+short checklist. Do not hide a product/API decision inside implementation
+details.
+
+End the turn after the brief unless the user's prompt explicitly pre-approves
+implementation after planning. If the next step is implementation, phrase it as
+a recommended follow-up, not permission to edit immediately.
+
+## Stop Before Editing
+
+Stop and ask for maintainer direction if:
+
+- the issue exposes an unusable or misleading public API rather than a local bug;
+- the best user experience requires a new public API or deprecating an old one;
+- a narrow fix helps one case but leaves the main workflow incomplete;
+- the narrow fix creates configured child resources that still do not satisfy
+  the user-visible AWS outcome;
+- existing users might see new child resources, renamed children, changed
+  defaults, replacements, or changed generated SDK surface;
+- AWSX would need to own a broad application pattern or a default likely to
+  drift with AWS or `@pulumi/aws`;
+- the proof would require live AWS behavior and only mock tests are available.

--- a/.agents/skills/awsx-issue-planning/agents/openai.yaml
+++ b/.agents/skills/awsx-issue-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX Issue Planning"
+  short_description: "Plan nontrivial AWSX issue fixes"
+  default_prompt: "Use $awsx-issue-planning to create a pre-implementation plan for this AWSX issue."

--- a/.agents/skills/awsx-start-issue-planning-session/SKILL.md
+++ b/.agents/skills/awsx-start-issue-planning-session/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: awsx-start-issue-planning-session
+description: Manual-only AWSX issue planning session starter. Use only when explicitly invoked to start a planning-only session for a GitHub issue or feature request, produce a planning brief, and stop before editing.
+---
+
+# AWSX Start Issue Planning Session
+
+This is a manual-only launcher skill. Use it only when the user explicitly
+invokes it. Its output is a planning brief, not code.
+
+## Inputs
+
+Use the issue, PR, branch, or task details supplied with the invocation. If the
+target is missing, ask for it and stop.
+
+## Workflow
+
+1. Use `$awsx-issue-planning` first.
+2. Do not edit files, implement code, commit, or create a checked-in spec.
+3. Re-check live context as required by `$awsx-issue-planning` instead of
+   trusting prior attempts.
+4. Treat rollout summaries, memories, old worktree diffs, and abandoned PRs as
+   historical attempts, not accepted design guidance.
+5. Use supporting AWSX skills only for planning evidence, following
+   `$awsx-issue-planning` routing.
+6. Produce the planning brief required by `$awsx-issue-planning`.
+7. Make the brief easy to carry into the implementation session. Prefer a
+   concise, copyable brief in chat. If the user asks for a durable handoff,
+   create or update the requested issue/PR comment, checked-in spec, or handoff
+   file instead of inventing a location.
+8. Stop after the brief.
+
+## Brief Requirements
+
+The brief must meet `$awsx-issue-planning` requirements, especially the
+definition-of-done, service-requirements, and immediate-follow-up issue
+sections.
+
+Delegated approval is not permission. A prompt like "implement if the brief says
+implementation should proceed" still delegates approval back to this same
+session; follow `$awsx-issue-planning` and stop after the brief.

--- a/.agents/skills/awsx-start-issue-planning-session/agents/openai.yaml
+++ b/.agents/skills/awsx-start-issue-planning-session/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "AWSX Start Issue Planning Session"
+  short_description: "Start a planning-only AWSX issue session"
+  default_prompt: "Use $awsx-start-issue-planning-session with the issue or PR URL to produce a planning brief only."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/awsx-test-authoring/SKILL.md
+++ b/.agents/skills/awsx-test-authoring/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: awsx-test-authoring
+description: Tactical AWSX test-authoring guidance for pulumi-awsx. Use when choosing or writing tests for modern awsx/** changes, including Jest mock tests, acceptance tests, provider upgrade tests, schema/SDK proof, and assertions that prove component behavior.
+---
+
+# AWSX Test Authoring
+
+Use this skill to choose and write proof for modern AWSX changes.
+
+This skill is for test selection and assertion quality. For component shape
+guidance, use `$awsx-component-design`. For compatibility classification, use
+`$awsx-breaking-change-evaluation`.
+
+## Rule Index
+
+- `rules/pure-typescript-logic.md`: deterministic helpers, validators,
+  allocators, and argument transformations.
+- `rules/component-construction-mocks.md`: Pulumi runtime mock tests for child
+  resources, args passed to children, providers, region flow, and outputs.
+- `rules/schema-and-sdk-proof.md`: schema generation, schema-tools comparison,
+  generated SDK diffs, and schemagen gaps.
+- `rules/provider-upgrade-tests.md`: recorded provider upgrade preview coverage
+  for existing programs and state.
+- `rules/acceptance-tests.md`: targeted examples and AWS-observed behavior.
+- `rules/assertion-quality.md`: exact assertions, weak smoke tests, and what
+  counts as proof.
+
+## How To Use
+
+1. Identify the behavior that needs proof: pure logic, component construction,
+   schema/SDK shape, existing-state upgrade, or AWS-observed behavior.
+2. Read the matching rule file before adding or accepting a test.
+3. Prefer the cheapest test surface that proves the behavior directly.
+4. If the change is compatibility-sensitive, pair the test choice with
+   `$awsx-breaking-change-evaluation`.
+5. Report what the test proves and what it does not prove.
+
+## Stop Early
+
+Stop before settling on a test plan if:
+
+- the proposed test only proves that TypeScript compiles or the program runs;
+- component logic is being pushed into an AWS-backed example instead of a Pulumi
+  runtime mock test;
+- AWS-observed behavior is being asserted only through mocked child resources;
+- schema changes are being judged without a generated schema or SDK diff;
+- provider-upgrade evidence is being treated as refresh/update proof when it
+  only checks preview/no replacements;
+- a broad acceptance test is proposed for a narrow deterministic change.

--- a/.agents/skills/awsx-test-authoring/agents/openai.yaml
+++ b/.agents/skills/awsx-test-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AWSX Test Authoring"
+  short_description: "Choose and write AWSX tests"
+  default_prompt: "Use $awsx-test-authoring to choose and write the right test for an AWSX change."

--- a/.agents/skills/awsx-test-authoring/rules/acceptance-tests.md
+++ b/.agents/skills/awsx-test-authoring/rules/acceptance-tests.md
@@ -1,0 +1,125 @@
+---
+title: Use Acceptance Tests For AWS Behavior
+tags: acceptance, examples, aws, runtime-validation
+status: draft
+---
+
+## Rule
+
+Use targeted `examples/**` acceptance tests when the behavior requires a real
+Pulumi program, provider-state validation, real AWS validation, or
+cross-resource service integration. Expose provider-state behavior through stack
+outputs and assert it in `ExtraRuntimeValidation`; when the claim is
+AWS-observed behavior, read AWS directly from the test. That AWS read may live
+in `ExtraRuntimeValidation` for `integration.ProgramTest` tests or in a direct
+`pulumitest` test body.
+
+## Why
+
+Mocks can prove AWSX construction decisions, but they cannot prove AWS accepts a
+resource shape, IAM policy, networking layout, or service integration. Live tests
+are expensive, so use them only for behavior that needs AWS.
+
+## Avoid
+
+Adding a broad smoke example for a narrow deterministic change:
+
+```go
+// Weak for narrow behavior: just runs a full example and checks no error.
+integration.ProgramTest(t, &integration.ProgramTestOptions{
+    Dir: "ts-vpc",
+    RunUpdateTest: false,
+})
+```
+
+Relying on language smoke tests as AWS-observed proof:
+
+```text
+The Go/Python/.NET example stood up, so tag propagation is validated.
+```
+
+## Prefer
+
+Output provider-state values and validate them:
+
+```ts
+export const subnetTags = subnets.apply(ss =>
+  ss.map(s => s.tags),
+);
+```
+
+```go
+ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+    tags := stack.Outputs["subnetTags"].([]interface{})
+    require.Equal(t, []interface{}{
+        map[string]interface{}{"Environment": "dev", "Name": "app-public-1"},
+        map[string]interface{}{"Environment": "dev", "Name": "app-private-1"},
+    }, tags)
+},
+```
+
+For AWS-observed behavior, query AWS in validation instead of only reading stack
+outputs. This shape fits `integration.ProgramTest` with `ExtraRuntimeValidation`:
+
+```go
+ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+    imageUri := stack.Outputs["imageUri"].(string)
+    repoName := stack.Outputs["repositoryName"].(string)
+
+    client := createEcrClient(t)
+    images, err := getEcrImageDetails(t, client, repoName, 1)
+    require.NoError(t, err)
+    require.NotEmpty(t, images.ImageDetails)
+    require.Contains(t, imageUri, *images.ImageDetails[0].ImageDigest)
+},
+```
+
+Direct `pulumitest` tests can query AWS from the Go test body instead:
+
+```go
+pt := pulumitest.NewPulumiTest(t, filepath.Join(cwd, "ts-ecr-registry-image"), options...)
+upResult := pt.Up(t)
+
+repoName := upResult.Outputs["repositoryName"].Value.(string)
+client := createEcrClient(t)
+images, err := getEcrImageDetails(t, client, repoName, 1)
+require.NoError(t, err)
+require.Len(t, images.ImageDetails, 1)
+```
+
+Name the lifecycle proof separately from the initial AWS acceptance proof:
+
+```go
+// Proves the initial resource shape is accepted and observable in AWS.
+upResult := pt.Up(t)
+
+// Proves a second preview is clean.
+pt.Preview(t, optpreview.ExpectNoChanges())
+
+// For update or refresh semantics, add an explicit update/refresh path such as
+// RunUpdateTest, pt.Up after config changes, Refresh with RunProgram, or a
+// provider-upgrade preview, depending on the compatibility claim.
+```
+
+## AWSX Notes
+
+- `examples/examples_nodejs_test.go` is the strongest current acceptance surface.
+  It includes both `integration.ProgramTest` cases with `ExtraRuntimeValidation`
+  and direct `pulumitest` cases with AWS SDK reads, such as ECR image behavior.
+  Check for `t.Skip` before citing a specific example as coverage.
+- `examples/examples_go_test.go`, `examples/examples_python_test.go`, and
+  `examples/examples_dotnet_test.go` are mostly smoke coverage. Use them for
+  language packaging/basic program coverage, not as deep behavior proof.
+- Many examples disable update coverage with `RunUpdateTest: false`. A passing
+  acceptance test may prove only one successful deployment unless it explicitly
+  runs no-diff preview, update, refresh, or provider-upgrade checks.
+- Local acceptance runs should be targeted and credential-aware. Do not use the
+  full examples suite as the default local loop.
+- Do not use `examples_legacy/**` as proof for modern `awsx/**` behavior unless
+  the change explicitly targets the legacy surface.
+
+## Hand Off When
+
+Use `rules/component-construction-mocks.md` if the behavior can be proved by
+recording child resources. Use `$awsx-breaking-change-evaluation` if the
+acceptance behavior changes existing stack compatibility.

--- a/.agents/skills/awsx-test-authoring/rules/assertion-quality.md
+++ b/.agents/skills/awsx-test-authoring/rules/assertion-quality.md
@@ -1,0 +1,79 @@
+---
+title: Make Assertions Prove Behavior
+tags: assertions, proof, smoke, snapshots, coverage
+status: draft
+---
+
+## Rule
+
+Write assertions that prove the behavior under review, not just that a program
+compiled, constructed, or ran. State the remaining gap when a test is only smoke
+coverage.
+
+## Why
+
+AWSX has several valid test surfaces. The common failure mode is choosing the
+right surface but making an assertion too weak to catch the regression: no exact
+child input checks, no output unwrapping, no AWS-observed validation, or no
+generated SDK inspection.
+
+## Avoid
+
+Smoke-only assertions for behavior changes:
+
+```ts
+new awsx.ec2.Vpc("vpc", args);
+expect(true).toBe(true);
+```
+
+Broad partial matching when exact shape matters:
+
+```ts
+expect(subnets).toEqual(expect.arrayContaining([
+  expect.objectContaining({ tags: { Environment: "dev" } }),
+]));
+```
+
+Golden or recorded-fixture-only proof for a semantic behavior:
+
+```text
+Updated the recorded fixture; no assertion names the behavior that changed.
+```
+
+## Prefer
+
+Assert exact resource counts and exact child inputs when those are the contract:
+
+```ts
+const subnets = resources.filter(r => r.type === "aws:ec2/subnet:Subnet");
+expect(subnets).toHaveLength(3);
+expect(subnets.map(s => s.inputs.tags)).toEqual([
+  { Environment: "dev", Name: "app-public-1" },
+  { Environment: "dev", Name: "app-public-2" },
+  { Environment: "dev", Name: "app-private-1" },
+]);
+```
+
+Name the proof limit:
+
+```text
+This mock test proves AWSX passes the expected tags to child subnets. It does
+not prove AWS accepts the resulting network layout.
+```
+
+## AWSX Notes
+
+- Existing modern Jest tests are mostly explicit and snapshot-light. There are
+  no Jest `.snap` files in the current audit.
+- Provider upgrade fixtures are useful golden evidence for preview
+  compatibility, but they do not replace direct assertions for new constructor
+  behavior.
+- Examples without `ExtraRuntimeValidation` are usually smoke tests, but direct
+  `pulumitest` cases can still prove AWS-observed behavior when they read AWS
+  directly and assert exact results.
+
+## Hand Off When
+
+Use the more specific rule file for the test surface in question. Use
+`$awsx-breaking-change-evaluation` if the assertion reveals changed behavior for
+existing users.

--- a/.agents/skills/awsx-test-authoring/rules/component-construction-mocks.md
+++ b/.agents/skills/awsx-test-authoring/rules/component-construction-mocks.md
@@ -1,0 +1,148 @@
+---
+title: Use Mocks For Component Construction
+tags: pulumi-mocks, component, child-resources, providers, outputs
+status: draft
+---
+
+## Rule
+
+Use Pulumi runtime mocks when the behavior is which child resources a component
+creates, what inputs it passes to them, what providers/options/regions it uses,
+or what outputs it exposes. Do not use live AWS tests for component construction
+logic.
+
+## Why
+
+AWSX components are imperative TypeScript constructors over schema-backed public
+surface. The component contract is usually visible in Pulumi resource
+registrations and outputs, so mocks can prove it quickly and deterministically.
+
+## Avoid
+
+Only asserting that construction does not throw:
+
+```ts
+new Repository("repo", { forceDelete: true }, {});
+```
+
+Only checking one constructor branch when the constructor also creates or
+normalizes other child resources:
+
+```ts
+expect(task.networkMode).toEqual("bridge");
+```
+
+## Prefer
+
+Record resource registrations and assert the exact child contract:
+
+```ts
+import * as pulumi from "@pulumi/pulumi";
+import { Repository } from "./repository";
+
+const resources: pulumi.runtime.MockResourceArgs[] = [];
+
+beforeAll(async () => {
+  await pulumi.runtime.setMocks({
+    newResource(args) {
+      resources.push(args);
+      const state =
+        args.type === "aws:ecr/repository:Repository"
+          ? { ...args.inputs, name: args.inputs.name ?? args.name }
+          : args.inputs;
+      return { id: `${args.name}_id`, state };
+    },
+    call(args) {
+      return args.inputs;
+    },
+  });
+});
+
+beforeEach(() => {
+  resources.length = 0;
+});
+
+function unwrap<T>(x: pulumi.Output<T> | T): Promise<T> {
+  return new Promise((resolve) =>
+    pulumi.Output.isInstance(x) ? x.apply(resolve) : resolve(x),
+  );
+}
+
+it("creates repository children with expected names and inputs", async () => {
+  const repository = new Repository("MyRepo", { forceDelete: true }, {});
+
+  expect(await unwrap(repository.repository.name)).toBe("myrepo");
+
+  const ecrChildren = resources
+    .filter((r) => r.type.startsWith("aws:ecr/"))
+    .map((r) => ({
+      type: r.type,
+      name: r.name,
+      forceDelete: r.inputs.forceDelete,
+      policy: r.inputs.policy,
+    }));
+
+  expect(ecrChildren).toEqual([
+    {
+      type: "aws:ecr/repository:Repository",
+      name: "myrepo",
+      forceDelete: true,
+      policy: undefined,
+    },
+    {
+      type: "aws:ecr/lifecyclePolicy:LifecyclePolicy",
+      name: "myrepo",
+      forceDelete: undefined,
+      policy: {
+        rules: [{
+          rulePriority: 1,
+          description: "remove untagged images",
+          selection: {
+            tagStatus: "untagged",
+            countType: "imageCountMoreThan",
+            countNumber: 1,
+          },
+          action: { type: "expire" },
+        }],
+      },
+    },
+  ]);
+});
+```
+
+## AWSX Notes
+
+- `awsx/ec2/vpc.test.ts` is the richest local pattern: it uses `setMocks`,
+  records `call` and `newResource`, instantiates components, unwraps Outputs,
+  and asserts child resource shape.
+- `awsx/ecr/auth.test.ts` and `awsx/ecr/image.test.ts` are smaller mock-test
+  examples.
+- The `Repository` test above is a distilled example of the pattern, not
+  current suite coverage. If changing `awsx/ecr/repository.ts`, add a real
+  focused test instead of treating the example as existing proof.
+- Current gap: some ECS tests prove only a narrow constructor slice. When
+  changing ECS constructor behavior, add assertions for normalized containers,
+  roles, `requiresCompatibilities`, load balancers, and outputs as relevant.
+- Assert exact cardinality when it matters. `arrayContaining` proves a value
+  exists, not that duplicate or extra resources were avoided.
+- Assert security-relevant child inputs exactly when they are part of the
+  behavior under review. Examples include security group ingress and egress,
+  IAM managed policies and policy statements, bucket policy conditions such as
+  `aws:SourceArn` or `aws:SourceAccount`, whether child resources are public or
+  internal, and whether sensitive args can reach log or debug sinks.
+- When the behavior under review is an input derived from another child
+  `Output`, write a focused assertion for that behavior and verify the mock
+  semantics first. Do not assume `MockResourceArgs.inputs` will always contain a
+  plain resolved value for unresolved, secret, or preview-unknown outputs.
+- Current Pulumi runtime mocks expose child type, logical name, inputs,
+  provider, custom flag, and ID. They do not expose enough engine state to prove
+  parentage, aliases, or full URN compatibility by themselves.
+- For provider or region behavior, include negative cases as relevant: explicit
+  provider without region, explicit `region` plus provider region, nested child
+  region fields, invokes using the wrong provider, and existing uneven behavior
+  that must be preserved until compatibility review says otherwise.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` if the test reveals changed child names,
+parentage, aliases, default-created children, providers, regions, or outputs.

--- a/.agents/skills/awsx-test-authoring/rules/provider-upgrade-tests.md
+++ b/.agents/skills/awsx-test-authoring/rules/provider-upgrade-tests.md
@@ -1,0 +1,82 @@
+---
+title: Use Upgrade Tests For Existing State
+tags: provider-upgrade, state, preview, replacements, compatibility
+status: draft
+---
+
+## Rule
+
+Use the provider upgrade harness when the question is whether an existing AWSX
+program or recorded state previews cleanly against the local provider. Do not use
+it as the default proof for ordinary component logic.
+
+## Why
+
+Compatibility risks often appear only when old state is evaluated with a new
+provider: child resource names, aliases, providers, defaults, and schema shape
+can cause creates, deletes, or replacements even when new programs compile.
+
+## Avoid
+
+Using a provider upgrade test to prove a narrow constructor branch:
+
+```text
+Changed tag normalization; added only a provider upgrade preview.
+```
+
+Overstating what the current harness proves:
+
+```text
+The upgrade test passed, so refresh and update behavior are fully compatible.
+```
+
+## Prefer
+
+Use upgrade tests for compatibility-sensitive state questions:
+
+```text
+Changed child logical names, parentage, aliases, or default-created children.
+Add or update a provider upgrade case and inspect preview for replacements,
+creates, deletes, and changed inputs.
+```
+
+Use upgrade or exported-state proof for identity that mocks cannot see:
+
+```text
+Changed child parentage or aliases.
+Mock tests can still prove child type/name/input shape, but they do not prove
+URN compatibility. Add an upgrade case, exported-state check, or another
+engine-visible fixture that shows the old child identity is preserved or
+migrated intentionally.
+```
+
+Pair the upgrade test with cheaper direct proof when needed:
+
+```text
+- Mock test proves the constructor now passes tags to the child resource.
+- Provider upgrade preview is inspected for replacements, creates, deletes, or
+  changed inputs. If the current helper is not enough, extend it or add a
+  focused assertion for the specific claim.
+```
+
+## AWSX Notes
+
+- Local harness files: `provider/provider_test.go` and
+  `provider/provider_nodejs_test.go`.
+- Existing recorded scenarios live under
+  `provider/testdata/recorded/TestProviderUpgrade/**`.
+- The current helper is intentionally narrow: it calls provider-upgrade preview
+  and asserts no replacements. That is not full refresh/update/state round-trip
+  proof, and it may not catch every create, delete, or changed-input risk unless
+  the preview result is inspected deliberately. If a change needs executable
+  assertions for creates, deletes, or changed inputs, extend the harness or add a
+  focused assertion instead of relying on the helper alone.
+- Check skipped cases before citing coverage. In the current suite, grep
+  `t.Skip` in `provider/provider_nodejs_test.go`; skipped cases are not
+  evidence.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` to decide whether existing-state proof is
+required. Use `rules/component-construction-mocks.md` for the direct constructor
+assertions that should accompany upgrade evidence.

--- a/.agents/skills/awsx-test-authoring/rules/pure-typescript-logic.md
+++ b/.agents/skills/awsx-test-authoring/rules/pure-typescript-logic.md
@@ -1,0 +1,79 @@
+---
+title: Test Pure Logic With Jest
+tags: jest, pure-logic, validators, allocators, transforms
+status: draft
+---
+
+## Rule
+
+Use focused Jest tests for deterministic TypeScript helpers, argument
+validators, subnet allocators, and input transformations. Assert exact outputs
+or exact errors.
+
+## Why
+
+Pure AWSX logic should be cheap to test and should not need Pulumi runtime mocks
+or live AWS resources. These tests are the fastest way to prove normalization,
+allocation, and validation behavior.
+
+## Avoid
+
+Using an example program or AWS-backed test to prove deterministic logic:
+
+```ts
+// Weak: only proves a program happened to run.
+new awsx.ec2.Vpc("vpc", { cidrBlock: "10.0.0.0/16" });
+```
+
+Swallowing expected failures so a case is not actually asserted:
+
+```ts
+try {
+  convertLegacySubnets(input);
+} catch (err) {
+  if (!String(err).includes("Subnets are too large for VPC")) {
+    throw err;
+  }
+}
+```
+
+## Prefer
+
+Table-driven exact outputs:
+
+```ts
+test.each([
+  {
+    input: { cidrBlock: "10.0.0.0/16", subnetCidrs: ["10.0.0.0/24"] },
+    expected: [{ cidrBlock: "10.0.0.0/24" }],
+  },
+])("allocates expected subnets", ({ input, expected }) => {
+  expect(distributeSubnets(input)).toEqual(expected);
+});
+```
+
+Exact validation failures:
+
+```ts
+expect(() => normalizeTaskDefinitionContainers({})).toThrow(
+  "Exactly one of [container] or [containers] must be provided",
+);
+```
+
+## AWSX Notes
+
+- Existing good anchors: `awsx/ec2/vpc.test.ts`,
+  `awsx/ec2/subnetDistributorLegacy.test.ts`,
+  `awsx/ec2/subnetDistributorNew.test.ts`,
+  `awsx/ecs/fargateMemoryAndCpu.test.ts`, and `awsx/utils.test.ts`.
+- Prefer table tests for allocators and validators with many input shapes.
+- If a helper accepts `pulumi.Input<T>` or returns `pulumi.Output<T>`, it may
+  need a component mock test instead of a pure logic test.
+- For Input/Output-sensitive behavior, include edge cases that match the change:
+  raw values versus Outputs, `undefined` versus empty collections, secrets,
+  preview unknowns, async outputs, and mixed raw/output values.
+
+## Hand Off When
+
+Use `rules/component-construction-mocks.md` when the behavior depends on Pulumi
+resource registration, child inputs, output unwrapping, providers, or parents.

--- a/.agents/skills/awsx-test-authoring/rules/schema-and-sdk-proof.md
+++ b/.agents/skills/awsx-test-authoring/rules/schema-and-sdk-proof.md
@@ -1,0 +1,60 @@
+---
+title: Prove Schema And SDK Shape
+tags: schema, sdk, schemagen, generated, schema-tools
+status: draft
+---
+
+## Rule
+
+For changes under `provider/pkg/schemagen/**` or any change that affects public
+schema shape, validate with regenerated schema, schema comparison, and generated
+SDK diff inspection. Do not treat TypeScript compilation as schema proof.
+
+## Why
+
+AWSX public component surface is schema-backed. A small generator change can
+rename tokens, alter requiredness, change nested types, or affect every
+generated SDK without breaking TypeScript implementation compilation.
+
+## Avoid
+
+Accepting source-only evidence for a schema change:
+
+```text
+The TypeScript provider tests pass, so the schema change is safe.
+```
+
+Hand-editing generated files to make a diff or test pass:
+
+```text
+Edited sdk/nodejs/repository.ts directly.
+```
+
+## Prefer
+
+Use the schema source and generated outputs as evidence:
+
+```text
+- Regenerated schema from source.
+- Compared old/new schema with schema-tools.
+- Inspected generated SDK diffs for token, args, output, requiredness, and type
+  changes.
+- Confirmed generated files were not hand-edited as the source of truth.
+```
+
+## AWSX Notes
+
+- The repo currently has no focused unit tests under `provider/pkg/schemagen/**`.
+  Until that changes, schema evidence is regeneration plus schema/SDK diff
+  review. Treat this as review evidence, not an executable regression net; add a
+  focused schemagen test when the generator bug is narrow and repeatable.
+- Use `$awsx-breaking-change-evaluation` for the `schema-tools` command shape
+  and category interpretation.
+- Schema diffs are necessary but not sufficient: still check component behavior
+  if constructor logic changed.
+
+## Hand Off When
+
+Use `$awsx-breaking-change-evaluation` when schema comparison finds public
+surface changes. Use `rules/component-construction-mocks.md` when schema changes
+also require constructor behavior proof.

--- a/.claude/skills/awsx-aws-service-validation
+++ b/.claude/skills/awsx-aws-service-validation
@@ -1,0 +1,1 @@
+../../.agents/skills/awsx-aws-service-validation

--- a/.claude/skills/awsx-breaking-change-evaluation
+++ b/.claude/skills/awsx-breaking-change-evaluation
@@ -1,0 +1,1 @@
+../../.agents/skills/awsx-breaking-change-evaluation

--- a/.claude/skills/awsx-component-design
+++ b/.claude/skills/awsx-component-design
@@ -1,0 +1,1 @@
+../../.agents/skills/awsx-component-design

--- a/.claude/skills/awsx-implement-approved-plan/SKILL.md
+++ b/.claude/skills/awsx-implement-approved-plan/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: awsx-implement-approved-plan
+description: Manual-only AWSX implementation session launcher. Use only when explicitly invoked to implement an already reviewed AWSX planning brief or approved plan.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: ISSUE_OR_PR_URL APPROVED_PLAN
+---
+
+# AWSX Implement Approved Plan
+
+Read `.agents/skills/awsx-implement-approved-plan/SKILL.md` now and follow it
+exactly. Do not take any other action until you have read it.
+
+The canonical instructions are in `.agents/skills/awsx-implement-approved-plan/SKILL.md`.
+
+This Claude wrapper exists because Claude's manual-only skill controls live in
+`SKILL.md` frontmatter, while the canonical `.agents` skill uses Codex's
+`agents/openai.yaml` invocation policy.

--- a/.claude/skills/awsx-issue-planning
+++ b/.claude/skills/awsx-issue-planning
@@ -1,0 +1,1 @@
+../../.agents/skills/awsx-issue-planning

--- a/.claude/skills/awsx-start-issue-planning-session/SKILL.md
+++ b/.claude/skills/awsx-start-issue-planning-session/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: awsx-start-issue-planning-session
+description: Manual-only AWSX issue planning session starter. Use only when explicitly invoked to start a planning-only session for a GitHub issue or feature request, produce a planning brief, and stop before editing.
+disable-model-invocation: true
+user-invocable: true
+argument-hint: ISSUE_OR_PR_URL
+---
+
+# AWSX Start Issue Planning Session
+
+Read `.agents/skills/awsx-start-issue-planning-session/SKILL.md` now and follow it
+exactly. Do not take any other action until you have read it.
+
+The canonical instructions are in `.agents/skills/awsx-start-issue-planning-session/SKILL.md`.
+
+This Claude wrapper exists because Claude's manual-only skill controls live in
+`SKILL.md` frontmatter, while the canonical `.agents` skill uses Codex's
+`agents/openai.yaml` invocation policy.

--- a/.claude/skills/awsx-test-authoring
+++ b/.claude/skills/awsx-test-authoring
@@ -1,0 +1,1 @@
+../../.agents/skills/awsx-test-authoring

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+[mcp_servers.aws_documentation]
+command = "uvx"
+args = ["awslabs.aws-documentation-mcp-server@latest"]
+startup_timeout_sec = 60
+
+[mcp_servers.aws_documentation.env]
+FASTMCP_LOG_LEVEL = "ERROR"
+AWS_DOCUMENTATION_PARTITION = "aws"

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ ci-scripts/
 
 **/venv
 
+!.codex/
+.codex/*
+!.codex/config.toml
+
 !/awsx/yarn.lock
 
 sdk/java/build

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "awslabs.aws-documentation-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "AWS_DOCUMENTATION_PARTITION": "aws"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,68 @@ Pulumi AWSX provider/component library. Core behavior is implemented in `awsx/` 
 ## Start Here
 - `Makefile` - canonical local command surface.
 - `.ci-mgmt.yaml` - source-of-truth for generated CI workflows and Make targets.
+- `docs/ai-harness/README.md` - current AI harness state and known gaps.
+- `docs/ai-harness/testing.md` - guidance for writing new AWSX tests.
+- `REVIEW.md` - AWSX-specific review notes that are not generic PR-review advice.
+- `.agents/skills/awsx-issue-planning/SKILL.md` - pre-implementation planning
+  for nontrivial issues where scope, API shape, compatibility, or spec needs
+  are unsettled.
+- `.agents/skills/awsx-start-issue-planning-session/SKILL.md` - manual-only
+  starter for planning an issue in a fresh session and stopping before edits.
+- `.agents/skills/awsx-implement-approved-plan/SKILL.md` - manual-only launcher
+  for implementing an already reviewed AWSX plan.
+- `.agents/skills/awsx-component-design/SKILL.md` - tactical authoring workflow
+  for modern `awsx/**` component changes.
+- `.agents/skills/awsx-breaking-change-evaluation/SKILL.md` - compatibility
+  and schema public-surface review workflow.
+- `.agents/skills/awsx-test-authoring/SKILL.md` - test-selection and assertion
+  guidance for modern AWSX changes.
+- `.agents/skills/awsx-aws-service-validation/SKILL.md` - AWS service fact,
+  docs, provider-surface, and regional availability validation.
+- `.claude/skills/` - symlinks to most repo-local `.agents/skills/` entries so
+  Claude Code sees the same skill sources; manual-only launcher skills may use
+  small Claude wrappers for Claude-specific invocation controls.
 - `provider/pkg/schemagen/` - schema generation logic.
 - `provider/cmd/pulumi-resource-awsx/` - provider schema output and embedding.
 - `awsx/` - TypeScript provider implementation + Jest tests.
 - `awsx-classic/` - legacy TypeScript components and compatibility surface.
 - `examples/` - integration/acceptance tests (real AWS resources).
 - `CONTRIBUTING.md` and `DEVELOPMENT.md` - contributor docs.
+
+## AI Harness
+- Keep harness docs small and AWSX-specific. Do not add placeholder docs or generic "remember to test" guidance.
+- Add harness material only when it captures a real repo pattern, repeated mistake, or concrete review rule.
+- If a session reveals missing guidance, update the smallest existing harness file first.
+
+Use the focused harness entry points this way:
+- `AGENTS.md` owns repo map, commands, generated boundaries, and path-triggered validation.
+- `REVIEW.md` owns the short AWSX-specific review checklist.
+- `.agents/skills/` is the skill source of truth. Keep `.claude/skills/` as
+  symlinks except when a skill needs Claude-specific invocation controls that
+  Codex skill validation does not allow in `.agents/skills`.
+- For GitHub issue implementation, use `.agents/skills/awsx-issue-planning/SKILL.md`
+  first unless the prompt explicitly says the plan/API shape is already
+  approved. For nontrivial issues, produce the planning brief and stop by
+  default; do not let the same session self-approve implementation unless the
+  prompt explicitly asks to proceed after planning without a maintainer review
+  checkpoint.
+- Use `.agents/skills/awsx-start-issue-planning-session/SKILL.md` and
+  `.agents/skills/awsx-implement-approved-plan/SKILL.md` only when explicitly
+  invoked as session launchers. They are control-flow wrappers around the
+  tactical AWSX skills, not ambient guidance.
+- Treat prior rollout summaries, memories, or old worktree diffs for the same
+  issue as historical attempts, not accepted design guidance.
+- `.agents/skills/awsx-issue-planning/SKILL.md` applies before editing when a
+  nontrivial issue needs scope, API-shape, current-usability, compatibility,
+  proof-strategy, or checked-in-spec decisions.
+- `.agents/skills/awsx-component-design/SKILL.md` applies when designing or reviewing modern `awsx/**` component shape: args, outputs, child resources, names, providers, regions, defaults, and `registerOutputs`.
+- `.agents/skills/awsx-breaking-change-evaluation/SKILL.md` applies when a change may affect existing users: schema or generated SDK surface, child identity, aliases, defaults, provider/region behavior, or upgrade previews.
+- `.agents/skills/awsx-test-authoring/SKILL.md` applies when choosing or writing proof: Jest mocks, schema/SDK checks, provider-upgrade tests, targeted acceptance tests, and assertion quality.
+- `.agents/skills/awsx-aws-service-validation/SKILL.md` applies when a change depends on AWS service behavior, API or CloudFormation constraints, regional availability, or disagreement between AWS docs and `@pulumi/aws`.
+- `docs/ai-harness/testing.md` is the human-readable overview for AWSX test choices; prefer the test-authoring skill for tactical rule-by-rule guidance.
+Known remaining harness gaps: final abstraction admission rules, component
+invariant audit for parentage/`registerOutputs`/region propagation, and modern
+component replay or snapshot fixture strategy.
 
 ## Command Canon
 - Build provider + SDKs + install SDKs: `make build`
@@ -20,8 +76,8 @@ Pulumi AWSX provider/component library. Core behavior is implemented in `awsx/` 
 - Build SDKs only: `make build_sdks`
 - Install SDKs only: `make install_sdks`
 - Lint: `make lint`
-- Provider unit tests (fast): `make test_provider`
-- Integration tests (AWS-backed): `make test`
+- AWSX TypeScript/Jest tests (fast): `make test_provider`
+- Full integration suite (AWS-backed, CI-only locally): `make test`
 - Targeted integration tests: `GOTESTARGS="-run TestName" make test`
 - Regenerate workflows/Makefile from ci-mgmt: `make ci-mgmt`
 
@@ -30,10 +86,12 @@ Never hand-edit generated outputs as the source of truth:
 - `sdk/**`
 - `provider/cmd/pulumi-resource-awsx/schema.json`
 - `provider/cmd/pulumi-resource-awsx/schema-embed.json`
-- `.github/workflows/**`
+- ci-mgmt-generated workflow YAML and gh-aw `.lock.yml` files under `.github/workflows/`
+- `.github/aw/actions-lock.json`
 - `Makefile`
 
 Use source files + regeneration commands instead.
+Some workflow source files also live under `.github/workflows/`. Edit those source files only when they are the source of truth, then regenerate/validate the generated outputs.
 
 When reviewing generated workflow or `Makefile` changes, do not assume they
 were hand-edited only because generated files changed. First check whether
@@ -47,7 +105,8 @@ change or documented regeneration reason.
 - `awsx-classic/**` -> run `yarn --cwd awsx-classic lint`
 - `provider/pkg/schemagen/**` -> run `make schema && make generate`
 - `.ci-mgmt.yaml` -> run `make ci-mgmt`
-- `examples/**` -> run targeted tests first, then full `make test` only if needed
+- `examples/**` -> run targeted acceptance tests locally; do not run the full `make test` suite locally
+- `docs/ai-harness/**` or `REVIEW.md` -> keep the guidance specific to AWSX and remove duplicated command lists
 
 ## Key Invariants
 - Schema generation changes can affect all language SDKs.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,11 +29,11 @@ For building the SDKs:
 - `make` builds the provider and all SDKs and installs for testing (same as `make build`)
 - `make development` is an alias for `make build` for backwards compatibility
 - `make build` builds the provider and all SDKs and installs them
-- `make test_provider` runs provider unit tests (Jest, no AWS required)
+- `make test_provider` runs the AWSX TypeScript/Jest tests (no AWS required)
 - `GOTESTARGS="-run TEST_NAME" make test` runs matching acceptance tests
 - `make clean` removes all build artifacts ready for a clean build
 - `make install_sdks` installs all SDKs
-- `make test` runs all acceptance tests
+- `make test` runs all acceptance tests; use CI for the full suite
 
 ### Implementing New Components
 
@@ -66,6 +66,10 @@ For running TypeScript examples locally:
 
 ## AI Review Workflow
 
+AWSX-specific review guidance lives in `REVIEW.md`. The shared gh-aw review
+plugin is sourced from `pulumi-labs/gh-aw-internal`; do not make repo-specific
+edits to the imported shared review plugin here.
+
 This repository includes these gh-aw workflow sources:
 - `.github/workflows/gh-aw-pr-review.md`
 - `.github/workflows/gh-aw-pr-rereview.md`
@@ -73,6 +77,7 @@ This repository includes these gh-aw workflow sources:
 They compile to:
 - `.github/workflows/gh-aw-pr-review.lock.yml`
 - `.github/workflows/gh-aw-pr-rereview.lock.yml`
+- `.github/aw/actions-lock.json`
 
 Behavior:
 - Auto review runs on `pull_request` opened events.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,66 @@
+# AWSX Review Notes
+
+Use this with `AGENTS.md`. Keep this file AWSX-specific; generic review advice
+does not belong here.
+
+Use the focused skills for detailed guidance:
+
+- `.agents/skills/awsx-component-design/SKILL.md` for modern `awsx/**`
+  component shape.
+- `.agents/skills/awsx-breaking-change-evaluation/SKILL.md` for schema,
+  generated SDK, identity, default, provider/region, or upgrade compatibility
+  risk.
+- `.agents/skills/awsx-test-authoring/SKILL.md` for test selection and
+  assertion quality.
+- `.agents/skills/awsx-aws-service-validation/SKILL.md` for AWS service
+  behavior, API or CloudFormation constraints, regional availability, and
+  provider-surface disagreements.
+
+## Current Checks
+
+- Schema changes under `provider/pkg/schemagen/**` are public-surface changes
+  until the generated diff proves otherwise. Inspect schema and SDK output for
+  renamed tokens, removed inputs/outputs, type changes, and changed defaults.
+- When a schema diff is available, prefer a schema-level comparison with
+  `schema-tools compare` before reviewing generated SDKs language by language.
+- Treat code-level breaks and behavior-level breaks as compatibility risks. A
+  change is breaking if existing users must update code or if their next
+  preview/update changes deployed resources.
+- Do not accept manual fixes in `sdk/**`, schema JSON, generated workflow locks,
+  or `Makefile` without the matching source change and regeneration command.
+- For modern AWSX behavior, prefer tests in `awsx/**` or `examples/**`.
+  `examples_legacy/**` only proves legacy behavior.
+- Treat child resource name changes as compatibility risks. They need aliases
+  or an explicit migration story.
+- A migration path that requires user action is not acceptable in a minor
+  version.
+- For new or touched components, child resources should normally use
+  `parent: this`. Nest under another child only when preserving an audited
+  existing hierarchy.
+- New components should call `registerOutputs`. For existing components, a
+  missing call is a review issue when the change touches constructor or
+  output-publishing behavior unless the change proves why it is not needed.
+- Explicit providers should flow through all child resources. Components that
+  expose a top-level `region` should pass it to child resources and invokes that
+  support region; see `pulumi/pulumi-awsx#1933` for the current tracking issue.
+- Avoid new AWSX-owned defaults that can drift with AWS or `@pulumi/aws`
+  behavior, such as version-like defaults.
+- Review AWSX-owned defaults as provisioned security controls, not only
+  convenience behavior.
+- When a change encodes AWS service behavior, verify it against AWS docs,
+  installed `@pulumi/aws` schema/SDK behavior, or live AWS evidence as
+  appropriate. Use `.agents/skills/awsx-aws-service-validation/SKILL.md` for the
+  detailed workflow.
+- For component construction, a useful test should assert child resource types,
+  names, tags, provider region, or invoke inputs. A test that only instantiates
+  the component is weak.
+- For AWS-backed examples, prefer targeted acceptance tests. Do not require or
+  run the full `make test` suite locally.
+
+## Missing Guidance
+
+These are not solved yet:
+
+- final abstraction admission rules, especially the L2/L2.5/L3 boundary;
+- where modern component replay/snapshot fixtures should live beyond the current
+  provider-upgrade preview fixtures.

--- a/docs/ai-harness/README.md
+++ b/docs/ai-harness/README.md
@@ -1,0 +1,66 @@
+# AWSX AI Harness
+
+This is intentionally small. `AGENTS.md` already owns the command list,
+generated-file rules, and basic repo map. Do not duplicate those here.
+
+Current harness files:
+
+- `docs/ai-harness/testing.md` - how to choose and write new AWSX tests.
+- `REVIEW.md` - AWSX-specific review notes.
+- `.agents/skills/awsx-issue-planning/SKILL.md` - pre-implementation planning
+  for nontrivial AWSX issues where scope, API shape, compatibility, or spec
+  needs are not already settled.
+- `.agents/skills/awsx-start-issue-planning-session/SKILL.md` - manual-only
+  starter for planning an issue in a fresh session and stopping before edits.
+- `.agents/skills/awsx-implement-approved-plan/SKILL.md` - manual-only launcher
+  for implementing an already reviewed AWSX plan.
+- `.agents/skills/awsx-component-design/SKILL.md` - tactical authoring workflow
+  for modern `awsx/**` component changes.
+- `.agents/skills/awsx-breaking-change-evaluation/SKILL.md` - compatibility
+  and schema public-surface review workflow.
+- `.agents/skills/awsx-test-authoring/SKILL.md` - test-selection and assertion
+  guidance for modern AWSX changes.
+- `.agents/skills/awsx-aws-service-validation/SKILL.md` - AWS service fact,
+  docs, provider-surface, and regional availability validation.
+- `.claude/skills/` - symlinks to most `.agents/skills/` directories for Claude
+  Code. Manual-only launcher skills may use small Claude wrappers for
+  Claude-specific invocation controls.
+
+Routing:
+
+- Use `AGENTS.md` first for repo map, commands, generated boundaries, and
+  required validation.
+- Use `REVIEW.md` for the short AWSX-specific review checklist.
+- Treat `.agents/skills/` as the source of truth for skill content. Keep
+  `.claude/skills/` as symlinks except when a skill needs Claude-specific
+  invocation controls that Codex skill validation does not allow in
+  `.agents/skills`.
+- Use `$awsx-issue-planning` first for GitHub issue implementation unless the
+  prompt explicitly says the plan/API shape is already approved. For nontrivial
+  issues, the planning brief is the first-session deliverable; stop there unless
+  the prompt explicitly asks to proceed after planning without a maintainer
+  review checkpoint.
+- Use `$awsx-start-issue-planning-session` and
+  `$awsx-implement-approved-plan` only when explicitly launching those
+  workflows. They are manual-only session wrappers, not skills that should
+  trigger from ordinary issue or implementation requests.
+- Treat prior rollout summaries, memories, or old worktree diffs for the same
+  issue as historical attempts, not accepted design guidance.
+- Use `$awsx-issue-planning` before implementation when the issue may require a
+  public API decision, changed defaults, new child resources, deprecation, a
+  checked-in spec, or a choice between a narrow fix and a better component
+  shape.
+- Use the `.agents/skills/awsx-*` skills for detailed tactical guidance:
+  issue planning, component shape, breaking-change evaluation, test authoring,
+  and AWS service fact validation.
+Add to this harness only when there is concrete AWSX guidance to capture. A new
+doc or skill should answer a question that `AGENTS.md`, `DEVELOPMENT.md`, and
+the source code do not already answer.
+
+Known remaining gaps:
+
+- component invariant audit for parentage, `registerOutputs`, and region
+  propagation;
+- where modern component snapshot/replay fixtures should live: section 3;
+- final AWSX abstraction admission rules, especially the L2/L2.5/L3 boundary:
+  this is intentionally not part of the current tactical skills.

--- a/docs/ai-harness/testing.md
+++ b/docs/ai-harness/testing.md
@@ -1,0 +1,93 @@
+# Writing AWSX Tests
+
+This is not a command reference. Use `AGENTS.md` for commands.
+
+## Pure TypeScript Logic
+
+Use Jest tests next to the code when the behavior is a deterministic helper,
+argument validator, subnet allocator, or input transformation.
+
+Existing examples:
+
+- `awsx/ec2/vpc.test.ts`
+- `awsx/ec2/subnetDistributorLegacy.test.ts`
+
+Good tests assert exact outputs or exact errors. Prefer table tests or property
+tests when the behavior is an allocator or validator with many input shapes.
+
+## Pulumi Component Construction
+
+Use Pulumi runtime mocks when the behavior is which child resources a component
+creates or what inputs it passes to them. Do not use AWS for this.
+
+This is the right level for component logic: conditionals on creating resources,
+conditionally setting properties, argument normalization, and the output shape
+the component should produce.
+
+Pattern to reuse:
+
+- call `runtime.setMocks`;
+- record `newResource` and `call` arguments;
+- instantiate the component;
+- unwrap `pulumi.Output` values;
+- assert resource types, names, tags, provider region, or invoke inputs.
+
+`awsx/ec2/vpc.test.ts` has examples under `describe("child resource api")`.
+
+## Schema Or SDK Shape
+
+Changes under `provider/pkg/schemagen/**` affect generated schema and SDKs. The
+repo does not currently have focused unit tests for schemagen. For now, validate
+these changes by regenerating and inspecting the schema/SDK diff.
+
+When possible, run a schema-level comparison with `schema-tools compare` instead
+of reasoning about each generated SDK language by hand.
+
+Do not hand-edit generated schema or SDK files to make a test pass.
+
+## Provider Upgrade Coverage
+
+Use the provider upgrade harness when the risk is compatibility of existing
+programs or state across provider versions. The harness lives in:
+
+- `provider/provider_test.go`
+- `provider/provider_nodejs_test.go`
+
+Do not use this as the default test for ordinary component logic. Use it when
+the question is "does an existing program preview cleanly against the local
+provider?" Inspect the preview for the compatibility risk under review:
+replacements, creates, deletes, and changed inputs can all matter. Do not cite
+skipped upgrade cases as evidence.
+
+## Acceptance Tests
+
+Add or update an example under `examples/**` when the behavior requires a real
+Pulumi program. If the important assertion is provider-state behavior, expose it
+through stack outputs and validate it in `ExtraRuntimeValidation`. If the
+important assertion is AWS-observed behavior, read AWS directly from
+`ExtraRuntimeValidation` or from a direct `pulumitest` test body.
+
+Use this path for resource-shape validity: cases where the question is whether
+AWS actually accepts the configured resources or whether cross-resource
+integration works. IAM permissions and service integrations are typical
+examples.
+
+For AWS-observed behavior, prefer proving the behavior once with a targeted live
+test. Use recorded provider-upgrade fixtures only when the risk is upgrade
+preview compatibility for existing programs or state. Do not cite general
+snapshot/replay coverage unless a concrete fixture exists for the behavior under
+review. Broad examples are smoke tests; they should not be the default
+validation path for a narrow agent change.
+
+Name the lifecycle claim being proved. A first successful `up` proves AWS
+accepted the shape once; no-diff preview, update, refresh, and provider-upgrade
+compatibility each need their own explicit path, such as
+`optpreview.ExpectNoChanges()`, `RunUpdateTest`, `Refresh` with `RunProgram`, or
+the provider upgrade harness.
+
+Local acceptance runs should be targeted. Do not run the full `make test` suite
+locally. Run a specific acceptance test only when AWS credentials and
+`AWS_REGION` are available.
+
+Do not use `examples_legacy/**` as proof for modern `awsx/**` behavior unless
+the change explicitly targets the legacy surface.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [tools]
 golangci-lint = "2.7.0"
+# Root mise.toml is the supported repo-local override for versions generated
+# into .config/mise.toml by ci-mgmt.
+"github:pulumi/schema-tools" = "0.7.1"


### PR DESCRIPTION
## Summary
- add focused repo-local AWSX skills for component design, breaking-change evaluation, test authoring, AWS service validation, and issue planning
- add manual-only planning/implementation launcher skills plus Claude wrappers/symlinks
- document AWSX harness routing, review notes, testing guidance, AWS documentation MCP config, and schema-tools mise override

## Supersedes
This combines the previous stacked PRs into one review surface:
- #2014
- #2015
- #2016
- #2017
- #2021
- #2018

## Validation
- `quick_validate.py` for every `.agents/skills/awsx-*` skill
- `.mcp.json`, `.codex/config.toml`, and `mise.toml` parse checks
- `.claude/skills` symlink target check
- `git diff --cached --check`