### PR TITLE
Add support for 32 vCPU and 60/120/244 memory

### DIFF
--- a/awsx/ecs/fargateMemoryAndCpu.test.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.test.ts
@@ -16,11 +16,11 @@ import { calculateFargateMemoryAndCPU, maxMemGB, maxVCPU } from "./fargateMemory
 
 describe("max vcpu and memory", () => {
   it("max cpu", async () => {
-    expect(maxVCPU).toBeGreaterThanOrEqual(16);
+    expect(maxVCPU).toBeGreaterThanOrEqual(32);
   });
 
   it("max memory", async () => {
-    expect(maxMemGB).toBeGreaterThanOrEqual(120);
+    expect(maxMemGB).toBeGreaterThanOrEqual(244);
   });
 
   it("can request valid exact values", async () => {
@@ -67,16 +67,16 @@ describe("max vcpu and memory", () => {
     expect(() => {
       calculateFargateMemoryAndCPU([
         {
-          cpu: 16 * 1024,
-          memory: 120 * 1024,
+          cpu: 17 * 1024,
+          memory: 123 * 1024,
         },
         {
-          cpu: 16 * 1024,
-          memory: 120 * 1024,
+          cpu: 17 * 1024,
+          memory: 123 * 1024,
         },
       ]);
     }).toThrowError(
-      `Requested resources exceed the maximum allowed for Fargate. Requested: 32 vCPU and 240GB. Max: ${maxVCPU} vCPU and ${maxMemGB}GB.`,
+      `Requested resources exceed the maximum allowed for Fargate. Requested: 34 vCPU and 246GB. Max: ${maxVCPU} vCPU and ${maxMemGB}GB.`,
     );
   });
   it("throws error if containers request more CPU than fargate allows", async () => {

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -40,6 +40,7 @@ const allConfigs = [
   ...cpuMemoryConfigs({ vcpu: 4, memGBs: range(8, 30) }),
   ...cpuMemoryConfigs({ vcpu: 8, memGBs: range(16, 60) }),
   ...cpuMemoryConfigs({ vcpu: 16, memGBs: range(32, 120) }),
+  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [64, 120, 244] })
 ].sort((c1, c2) => c1.cost - c2.cost);
 
 // exported for tests

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -40,7 +40,7 @@ const allConfigs = [
   ...cpuMemoryConfigs({ vcpu: 4, memGBs: range(8, 30) }),
   ...cpuMemoryConfigs({ vcpu: 8, memGBs: range(16, 60) }),
   ...cpuMemoryConfigs({ vcpu: 16, memGBs: range(32, 120) }),
-  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [64, 120, 244] })
+  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [60, 120, 244] })
 ].sort((c1, c2) => c1.cost - c2.cost);
 
 // exported for tests


### PR DESCRIPTION
## Summary
Added new Fargate CPU/memory combinations per the latest AWS ECS task definition parameters documentation.
Reference: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

## Compatibility
- [ ] No public behavior/API change
- [x] Public behavior/API changed - new specs can now be used without error

## Generated Artifacts
- [X] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

## Validation
- [ ] `make test_provider`
- [ ] `make lint`
- [ ] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed)
- [ ] `make test` (if integration-impacting; requires AWS creds/resources)
- [ ] Other targeted checks listed in PR body

## Risk
Low. No existing configurations are modified. Worst case the new entry is ignored; no existing functionality is affected.

## Rollback
Remove line 43 from awsx/ecs/fargateMemoryAndCpu.ts