### PR TITLE
Add support for 32 vCPU Fargate task sizes

### DIFF
--- a/awsx/ecs/fargateMemoryAndCpu.test.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.test.ts
@@ -16,11 +16,11 @@ import { calculateFargateMemoryAndCPU, maxMemGB, maxVCPU } from "./fargateMemory
 
 describe("max vcpu and memory", () => {
   it("max cpu", async () => {
-    expect(maxVCPU).toBeGreaterThanOrEqual(16);
+    expect(maxVCPU).toBeGreaterThanOrEqual(32);
   });
 
   it("max memory", async () => {
-    expect(maxMemGB).toBeGreaterThanOrEqual(120);
+    expect(maxMemGB).toBeGreaterThanOrEqual(244);
   });
 
   it("can request valid exact values", async () => {
@@ -67,16 +67,16 @@ describe("max vcpu and memory", () => {
     expect(() => {
       calculateFargateMemoryAndCPU([
         {
-          cpu: 16 * 1024,
-          memory: 120 * 1024,
+          cpu: 17 * 1024,
+          memory: 123 * 1024,
         },
         {
-          cpu: 16 * 1024,
-          memory: 120 * 1024,
+          cpu: 17 * 1024,
+          memory: 123 * 1024,
         },
       ]);
     }).toThrowError(
-      `Requested resources exceed the maximum allowed for Fargate. Requested: 32 vCPU and 240GB. Max: ${maxVCPU} vCPU and ${maxMemGB}GB.`,
+      `Requested resources exceed the maximum allowed for Fargate. Requested: 34 vCPU and 246GB. Max: ${maxVCPU} vCPU and ${maxMemGB}GB.`,
     );
   });
   it("throws error if containers request more CPU than fargate allows", async () => {

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -40,6 +40,7 @@ const allConfigs = [
   ...cpuMemoryConfigs({ vcpu: 4, memGBs: range(8, 30) }),
   ...cpuMemoryConfigs({ vcpu: 8, memGBs: range(16, 60) }),
   ...cpuMemoryConfigs({ vcpu: 16, memGBs: range(32, 120) }),
+  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [64, 120, 244] })
 ].sort((c1, c2) => c1.cost - c2.cost);
 
 // exported for tests

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -40,7 +40,7 @@ const allConfigs = [
   ...cpuMemoryConfigs({ vcpu: 4, memGBs: range(8, 30) }),
   ...cpuMemoryConfigs({ vcpu: 8, memGBs: range(16, 60) }),
   ...cpuMemoryConfigs({ vcpu: 16, memGBs: range(32, 120) }),
-  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [60, 120, 244] })
+  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [60, 120, 244] }),
 ].sort((c1, c2) => c1.cost - c2.cost);
 
 // exported for tests

--- a/awsx/ecs/fargateMemoryAndCpu.ts
+++ b/awsx/ecs/fargateMemoryAndCpu.ts
@@ -40,7 +40,7 @@ const allConfigs = [
   ...cpuMemoryConfigs({ vcpu: 4, memGBs: range(8, 30) }),
   ...cpuMemoryConfigs({ vcpu: 8, memGBs: range(16, 60) }),
   ...cpuMemoryConfigs({ vcpu: 16, memGBs: range(32, 120) }),
-  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [64, 120, 244] })
+  ...cpuMemoryConfigs({ vcpu: 32, memGBs: [60, 120, 244] })
 ].sort((c1, c2) => c1.cost - c2.cost);
 
 // exported for tests


### PR DESCRIPTION
## Summary
- Add the new AWS Fargate 32 vCPU task size with the supported 60 GB, 120 GB, and 244 GB memory values.
- Update the Fargate memory/CPU unit tests for the new maximum CPU and memory limits.
- Fix formatting on the added config entry.

## Validation
- `yarn --cwd awsx test fargateMemoryAndCpu.test.ts --runInBand`
- `cd awsx && ./node_modules/.bin/prettier --check ecs/fargateMemoryAndCpu.ts ecs/fargateMemoryAndCpu.test.ts`
- `git diff --check`
- `make test_provider`
