### PR TITLE
fix(ecr): pass top-level region through to Repository lifecycle policy

### DIFF
--- a/awsx/ecr/repository.test.ts
+++ b/awsx/ecr/repository.test.ts
@@ -1,0 +1,112 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as runtime from "@pulumi/pulumi/runtime";
+import * as pulumi from "@pulumi/pulumi";
+import * as pulumiAws from "@pulumi/aws";
+import { Repository } from "./repository";
+
+function unwrap<T>(x: pulumi.Output<T> | T): Promise<T> {
+  return new Promise((resolve) => (pulumi.Output.isInstance(x) ? x.apply(resolve) : resolve(x)));
+}
+
+describe("Repository region passthrough", () => {
+  let newResources: any[] = [];
+
+  beforeAll(async () => {
+    await runtime.setMocks({
+      call(args) {
+        throw new Error(`Mock call not implemented: ${args.token}`);
+      },
+      newResource(args) {
+        newResources.push(args);
+        return {
+          id: `mocked::${args.type}::${args.name}-id`,
+          state: args.inputs,
+        };
+      },
+    });
+  });
+
+  beforeEach(() => {
+    newResources = [];
+  });
+
+  function findCreatedResource(type: string, name: string): any {
+    const resource = newResources.find((r) => r.type === type && r.name === name);
+    expect(resource).toBeDefined();
+    return resource;
+  }
+
+  it("threads the top-level region through to the lifecycle policy", async () => {
+    const repo = new Repository("Region-Repo", { region: pulumiAws.Region.USWest2 }, {});
+
+    await unwrap(repo.repository.id);
+    await unwrap(repo.lifecyclePolicy!.id);
+
+    const repository = findCreatedResource("aws:ecr/repository:Repository", "region-repo");
+    const lifecyclePolicy = findCreatedResource(
+      "aws:ecr/lifecyclePolicy:LifecyclePolicy",
+      "region-repo",
+    );
+    expect(repository.inputs.region).toBe(pulumiAws.Region.USWest2);
+    expect(lifecyclePolicy.inputs.region).toBe(pulumiAws.Region.USWest2);
+  });
+
+  it("threads region through the auto-generated default lifecycle policy", async () => {
+    // No explicit lifecyclePolicy.rules: the component synthesizes the default
+    // "remove untagged images" rule. Region should still propagate.
+    const repo = new Repository(
+      "Default-Policy-Repo",
+      { region: pulumiAws.Region.EUCentral1, lifecyclePolicy: {} },
+      {},
+    );
+
+    await unwrap(repo.lifecyclePolicy!.id);
+
+    const lifecyclePolicy = findCreatedResource(
+      "aws:ecr/lifecyclePolicy:LifecyclePolicy",
+      "default-policy-repo",
+    );
+    expect(lifecyclePolicy.inputs.region).toBe(pulumiAws.Region.EUCentral1);
+    expect(lifecyclePolicy.inputs.policy).toBeDefined();
+  });
+
+  it("creates no lifecycle policy when skip is set", async () => {
+    const repo = new Repository(
+      "Skip-Repo",
+      { region: pulumiAws.Region.USWest2, lifecyclePolicy: { skip: true } },
+      {},
+    );
+
+    await unwrap(repo.repository.id);
+
+    expect(repo.lifecyclePolicy).toBeUndefined();
+    expect(newResources.some((r) => r.type === "aws:ecr/lifecyclePolicy:LifecyclePolicy")).toBe(
+      false,
+    );
+  });
+
+  it("does not add a region key to the lifecycle policy when region is omitted", async () => {
+    const repo = new Repository("No-Region-Repo", {}, {});
+
+    await unwrap(repo.lifecyclePolicy!.id);
+
+    const lifecyclePolicy = findCreatedResource(
+      "aws:ecr/lifecyclePolicy:LifecyclePolicy",
+      "no-region-repo",
+    );
+    expect("region" in lifecyclePolicy.inputs).toBe(false);
+  });
+});

--- a/awsx/ecr/repository.ts
+++ b/awsx/ecr/repository.ts
@@ -37,6 +37,10 @@ export class Repository extends schema.Repository {
         {
           repository: this.repository.name,
           policy: buildLifecyclePolicy(lifecyclePolicy),
+          // Thread the component's top-level region through to the lifecycle
+          // policy so it is evaluated in the same region as the repository
+          // rather than the ambient provider region (see #1935, #1933).
+          ...(args.region !== undefined ? { region: args.region } : {}),
         },
         {
           parent: this,


### PR DESCRIPTION
## Summary
A user who sets `region` on an `awsx.ecr.Repository` expects every child resource to land in that region. Today the repository itself is created in the requested region, but its auto-created lifecycle policy is silently created in the ambient provider region instead. That inconsistency is the bug.

The component exposes a top-level `region` input, and the root `aws.ecr.Repository` already receives it via the `repoArgs` spread. The auto-created `aws.ecr.LifecyclePolicy`, however, was constructed with only `{ repository, policy }`, so it never saw `region`. This threads `args.region` through to the `LifecyclePolicy` when it is set, and leaves behavior unchanged when `region` is omitted.

Concretely, `awsx/ecr/repository.ts` now spreads `region: args.region` into the `aws.ecr.LifecyclePolicy` args only when `args.region` is defined, so the existing no-region path is byte-for-byte unchanged. A new `awsx/ecr/repository.test.ts` uses the `@pulumi/pulumi/runtime` mock harness (same style as `awsx/ec2/vpc.test.ts`) to cover: region threads to the lifecycle policy; region threads through the auto-generated default "remove untagged images" policy; `skip: true` creates no policy; and omitting `region` adds no `region` key (no regression). This change does not touch `provider/pkg/schemagen/**`, so no schema regeneration or committed SDK diffs are required.

Fixes #1935. This is one item in the region-passthrough audit tracked by #1933; it mirrors the merged Vpc fix in #1942.

## Compatibility
- [x] No public behavior/API change

## Generated Artifacts
- [x] N/A

## Validation
- [x] `awsx` Jest suite for the touched files (`yarn jest ecr/repository.test.ts`) - 4 passing
- [x] `yarn tsc --noEmit` - clean
- [x] No new lint errors introduced in the touched files

## Risk
Low blast radius. The change adds `region` to a single child resource only when the component's `region` input is set; the no-region path produces identical args to before, so existing stacks see no diff. The lifecycle policy already supports the `region` argument (the same provider-wide argument the Vpc fix used). Worst case if wrong, the lifecycle policy would target an unexpected region, which the new tests guard against.

## Rollback
Revert this commit. The lifecycle policy reverts to being created in the ambient provider region, restoring the prior behavior. No state migration or schema regeneration is involved.

AI was used for assistance.
