### PR TITLE
Perf/lazy construct and provider threading

### DIFF
--- a/awsx/ecs/ec2Service.ts
+++ b/awsx/ecs/ec2Service.ts
@@ -40,11 +40,16 @@ export class EC2Service extends schema.EC2Service {
     if (args.taskDefinition !== undefined && args.taskDefinitionArgs !== undefined) {
       throw new Error("Only one of `taskDefinition` or `taskDefinitionArgs` can be provided.");
     }
+    // Child AWS resources reuse the provider given to this component rather than
+    // spinning up a separate default provider instance.
+    const provider = opts.provider;
+
     let taskDefinitionIdentifier = args.taskDefinition;
     let taskDefinition: EC2TaskDefinition | undefined;
     if (args.taskDefinitionArgs) {
       taskDefinition = new EC2TaskDefinition(name, args.taskDefinitionArgs, {
         parent: this,
+        provider,
       });
       this.taskDefinition = taskDefinition.taskDefinition;
       taskDefinitionIdentifier = taskDefinition.taskDefinition.arn;
@@ -78,7 +83,7 @@ export class EC2Service extends schema.EC2Service {
           .apply((x) => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
-      { parent: this },
+      { parent: this, provider },
     );
 
     this.registerOutputs();

--- a/awsx/ecs/ec2TaskDefinition.ts
+++ b/awsx/ecs/ec2TaskDefinition.ts
@@ -55,9 +55,18 @@ export class EC2TaskDefinition extends schema.EC2TaskDefinition {
       },
     );
 
+    // Child AWS resources reuse the provider given to this component rather than
+    // spinning up a separate default provider instance.
+    const provider = opts.provider;
+
     const containers = normalizeTaskDefinitionContainers(args);
 
-    const { logGroup, logGroupId } = defaultLogGroup(name, args.logGroup, {}, { parent: this });
+    const { logGroup, logGroupId } = defaultLogGroup(
+      name,
+      args.logGroup,
+      {},
+      { parent: this, provider },
+    );
     this.logGroup = logGroup;
 
     const taskRole = role.defaultRoleWithPolicies(
@@ -67,7 +76,7 @@ export class EC2TaskDefinition extends schema.EC2TaskDefinition {
         assumeRolePolicy: role.defaultRoleAssumeRolePolicy(),
         policyArns: role.defaultTaskRolePolicyARNs(),
       },
-      { parent: this },
+      { parent: this, provider },
     );
     const executionRole = role.defaultRoleWithPolicies(
       `${name}-execution`,
@@ -76,7 +85,7 @@ export class EC2TaskDefinition extends schema.EC2TaskDefinition {
         assumeRolePolicy: role.defaultRoleAssumeRolePolicy(),
         policyArns: role.defaultExecutionRolePolicyARNs(),
       },
-      { parent: this },
+      { parent: this, provider },
     );
     this.taskRole = taskRole.role;
     this.executionRole = executionRole.role;
@@ -94,7 +103,7 @@ export class EC2TaskDefinition extends schema.EC2TaskDefinition {
         taskRole.roleArn,
         executionRole.roleArn,
       ),
-      { parent: this },
+      { parent: this, provider },
     );
   }
 }

--- a/awsx/ecs/fargateService.ts
+++ b/awsx/ecs/fargateService.ts
@@ -44,11 +44,16 @@ export class FargateService extends schema.FargateService {
     if (args.networkConfiguration !== undefined && args.assignPublicIp !== undefined) {
       throw new Error("Only one of `networkConfiguration` or `assignPublicIp` can be provided.");
     }
+    // Forward the provider this component was given so the child AWS resources
+    // reuse it instead of triggering a separate default provider instance.
+    const provider = opts.provider;
+
     let taskDefinitionIdentifier = args.taskDefinition;
     let taskDefinition: FargateTaskDefinition | undefined;
     if (args.taskDefinitionArgs) {
       taskDefinition = new FargateTaskDefinition(name, args.taskDefinitionArgs, {
         parent: this,
+        provider,
       });
       this.taskDefinition = taskDefinition.taskDefinition;
       taskDefinitionIdentifier = taskDefinition.taskDefinition.arn;
@@ -77,7 +82,7 @@ export class FargateService extends schema.FargateService {
         ...args,
         networkConfiguration:
           args.networkConfiguration ??
-          getDefaultNetworkConfiguration(name, this, args.assignPublicIp),
+          getDefaultNetworkConfiguration(name, this, args.assignPublicIp, provider),
         cluster: aws.ecs.Cluster.isInstance(args.cluster) ? args.cluster.arn : args.cluster,
         launchType,
         loadBalancers: args.loadBalancers ?? taskDefinition?.loadBalancers,
@@ -86,7 +91,7 @@ export class FargateService extends schema.FargateService {
           .apply((x) => !x),
         taskDefinition: taskDefinitionIdentifier,
       },
-      { parent: this },
+      { parent: this, provider },
     );
 
     this.registerOutputs();
@@ -97,8 +102,9 @@ function getDefaultNetworkConfiguration(
   name: string,
   parent: pulumi.Resource,
   assignPublicIp?: pulumi.Input<boolean>,
+  provider?: pulumi.ProviderResource,
 ): aws.types.input.ecs.ServiceNetworkConfiguration {
-  const defaultVpc = pulumi.output(getDefaultVpc({ parent }));
+  const defaultVpc = pulumi.output(getDefaultVpc({ parent, provider }));
   const sg = new aws.ec2.SecurityGroup(
     `${name}-sg`,
     {
@@ -124,6 +130,7 @@ function getDefaultNetworkConfiguration(
     },
     {
       parent,
+      provider,
     },
   );
   assignPublicIp = assignPublicIp ?? false;

--- a/awsx/ecs/fargateTaskDefinition.ts
+++ b/awsx/ecs/fargateTaskDefinition.ts
@@ -56,9 +56,18 @@ export class FargateTaskDefinition extends schema.FargateTaskDefinition {
       },
     );
 
+    // Child AWS resources reuse the provider given to this component rather than
+    // spinning up a separate default provider instance.
+    const provider = opts.provider;
+
     const containers = normalizeTaskDefinitionContainers(args);
 
-    const { logGroup, logGroupId } = defaultLogGroup(name, args.logGroup, {}, { parent: this });
+    const { logGroup, logGroupId } = defaultLogGroup(
+      name,
+      args.logGroup,
+      {},
+      { parent: this, provider },
+    );
     this.logGroup = logGroup;
 
     const taskRole = role.defaultRoleWithPolicies(
@@ -68,7 +77,7 @@ export class FargateTaskDefinition extends schema.FargateTaskDefinition {
         assumeRolePolicy: role.defaultRoleAssumeRolePolicy(),
         policyArns: role.defaultTaskRolePolicyARNs(),
       },
-      { parent: this },
+      { parent: this, provider },
     );
     const executionRole = role.defaultRoleWithPolicies(
       `${name}-execution`,
@@ -77,7 +86,7 @@ export class FargateTaskDefinition extends schema.FargateTaskDefinition {
         assumeRolePolicy: role.defaultRoleAssumeRolePolicy(),
         policyArns: role.defaultExecutionRolePolicyARNs(),
       },
-      { parent: this },
+      { parent: this, provider },
     );
     this.taskRole = taskRole.role;
     this.executionRole = executionRole.role;
@@ -95,7 +104,7 @@ export class FargateTaskDefinition extends schema.FargateTaskDefinition {
         taskRole.roleArn,
         executionRole.roleArn,
       ),
-      { parent: this },
+      { parent: this, provider },
     );
   }
 }

--- a/awsx/index.ts
+++ b/awsx/index.ts
@@ -14,7 +14,6 @@
 
 import * as pulumi from "@pulumi/pulumi";
 import { readFileSync } from "fs";
-import { Repository } from "./ecr";
 import { construct, functions } from "./resources";
 import { resourceToConstructResult } from "./utils";
 
@@ -26,7 +25,11 @@ class Provider implements pulumi.provider.Provider {
       construct: (name, type, urn) => {
         switch (type) {
           case "awsx:ecr:Repository":
-            return new Repository(name, <any>undefined, { urn });
+            return new (require("./ecr") as typeof import("./ecr")).Repository(
+              name,
+              <any>undefined,
+              { urn },
+            );
           default:
             throw new Error(`unknown resource type ${type}`);
         }

--- a/awsx/resources.ts
+++ b/awsx/resources.ts
@@ -12,28 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
-import { Trail } from "./cloudtrail";
-import * as ec2 from "./ec2";
-import { Image, RegistryImage, Repository } from "./ecr";
-import * as ecs from "./ecs";
-import * as lb from "./lb";
-import * as schemaTypes from "./schema-types";
+import type * as pulumi from "@pulumi/pulumi";
+import type * as schemaTypes from "./schema-types";
 
+// Each entry loads its owning module on first use so that constructing one
+// component type does not pull in the modules (and their transitive AWS/Docker
+// SDK graph) of the others.
 const resources: schemaTypes.ResourceConstructor = {
-  "awsx:cloudtrail:Trail": (...args) => new Trail(...args),
-  "awsx:ecs:FargateService": (...args) => new ecs.FargateService(...args),
-  "awsx:ecs:EC2Service": (...args) => new ecs.EC2Service(...args),
-  "awsx:ecs:EC2TaskDefinition": (...args) => new ecs.EC2TaskDefinition(...args),
-  "awsx:ecs:FargateTaskDefinition": (...args) => new ecs.FargateTaskDefinition(...args),
-  "awsx:lb:ApplicationLoadBalancer": (...args) => new lb.ApplicationLoadBalancer(...args),
-  "awsx:lb:NetworkLoadBalancer": (...args) => new lb.NetworkLoadBalancer(...args),
-  "awsx:lb:TargetGroupAttachment": (...args) => new lb.TargetGroupAttachment(...args),
-  "awsx:ec2:Vpc": (...args) => new ec2.Vpc(...args),
-  "awsx:ec2:DefaultVpc": (...args) => new ec2.DefaultVpc(...args),
-  "awsx:ecr:Repository": (...args) => new Repository(...args),
-  "awsx:ecr:Image": (...args) => new Image(...args),
-  "awsx:ecr:RegistryImage": (...args) => new RegistryImage(...args),
+  "awsx:cloudtrail:Trail": (...args) =>
+    new (require("./cloudtrail") as typeof import("./cloudtrail")).Trail(...args),
+  "awsx:ecs:FargateService": (...args) =>
+    new (require("./ecs") as typeof import("./ecs")).FargateService(...args),
+  "awsx:ecs:EC2Service": (...args) =>
+    new (require("./ecs") as typeof import("./ecs")).EC2Service(...args),
+  "awsx:ecs:EC2TaskDefinition": (...args) =>
+    new (require("./ecs") as typeof import("./ecs")).EC2TaskDefinition(...args),
+  "awsx:ecs:FargateTaskDefinition": (...args) =>
+    new (require("./ecs") as typeof import("./ecs")).FargateTaskDefinition(...args),
+  "awsx:lb:ApplicationLoadBalancer": (...args) =>
+    new (require("./lb") as typeof import("./lb")).ApplicationLoadBalancer(...args),
+  "awsx:lb:NetworkLoadBalancer": (...args) =>
+    new (require("./lb") as typeof import("./lb")).NetworkLoadBalancer(...args),
+  "awsx:lb:TargetGroupAttachment": (...args) =>
+    new (require("./lb") as typeof import("./lb")).TargetGroupAttachment(...args),
+  "awsx:ec2:Vpc": (...args) => new (require("./ec2") as typeof import("./ec2")).Vpc(...args),
+  "awsx:ec2:DefaultVpc": (...args) =>
+    new (require("./ec2") as typeof import("./ec2")).DefaultVpc(...args),
+  "awsx:ecr:Repository": (...args) =>
+    new (require("./ecr") as typeof import("./ecr")).Repository(...args),
+  "awsx:ecr:Image": (...args) => new (require("./ecr") as typeof import("./ecr")).Image(...args),
+  "awsx:ecr:RegistryImage": (...args) =>
+    new (require("./ecr") as typeof import("./ecr")).RegistryImage(...args),
 };
 
 export function construct(
@@ -51,5 +60,5 @@ export function construct(
 }
 
 export const functions: schemaTypes.Functions = {
-  "awsx:ec2:getDefaultVpc": () => ec2.getDefaultVpc({}),
+  "awsx:ec2:getDefaultVpc": () => (require("./ec2") as typeof import("./ec2")).getDefaultVpc({}),
 };


### PR DESCRIPTION
## Summary
Two internal performance fixes to cut `Construct` latency and avoid a duplicate `@pulumi/aws` provider process when awsx components are used from a program pinned to a newer `@pulumi/aws` than the one awsx bundles.

- **Lazy resource-module loading** (`resources.ts`, `index.ts`): the `construct` dispatcher previously eagerly barrel-imported `cloudtrail`/`ec2`/`ecr`/`ecs`/`lb` at module load, so constructing any single component (e.g. `FargateService`) initialized `ec2/vpc.ts`, `lb`, `ecr` (+ `@pulumi/docker`, `@pulumi/docker-build`, `@aws-sdk/client-ecs`) and `cloudtrail`. Each branch now `require()`s only the module it needs, and the `registerResourceModule` rehydration callback lazily requires `./ecr`.
- **Thread the component provider to children** (`ecs/fargateService.ts`, `ecs/fargateTaskDefinition.ts`, `ecs/ec2Service.ts`, `ecs/ec2TaskDefinition.ts`): child `aws.*` resources previously received only `{ parent: this }`; they now also forward `opts.provider`. When no provider is passed, `opts.provider` is `undefined` and child opts are unchanged (parent inheritance). When a caller passes an explicit `provider`, it now reaches the children, overriding the default-provider version key so version-mismatched aws plugins collapse into one process (and the second provider's on-demand boot/Configure no longer folds into the `Construct` span).

## Compatibility
- [ ] No public behavior/API change
- [x] Public behavior/API changed (describe impact)

**Impact:** No schema/input/output changes. The provider-threading commit changes runtime behavior **only when a caller passes an explicit `provider`** to a Fargate/EC2 service or task definition: child `aws.*` resources now inherit that provider instead of the ambient default. Stacks that pass no provider are unaffected. Existing stacks that *do* pass a provider may see child resources move onto it (possible replacement) — intended, since silently dropping the provider on children was the bug being fixed.

## Generated Artifacts
- [x] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

Hand-written component source under `awsx/` only; no schema or SDK regeneration required.

## Validation
- [x] `make test_provider` — 443/443 tests pass across 14 suites (incl. `ecs/fargateService`, `ecs/ec2Service`, `ecs/ec2TaskDefinition`, `ec2/vpc`); `yarn tsc` clean
- [ ] `make lint` — ran it; it reports 49 **pre-existing** findings (48 `goconst`, 1 `gosec`) in `provider/pkg/schemagen/*.go` and `cmd/pulumi-gen-awsx/main.go`, all outside this PR's diff. This change is TypeScript-only (no `provider/**` Go changes), so it neither introduces nor fixes them; the target fails on upstream Go debt independent of this PR.
- [ ] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed) — N/A; `awsx-classic/**` unchanged
- [ ] `make test` (if integration-impacting; requires AWS creds/resources) — not run; requires live AWS
- [x] Other targeted checks listed in PR body — confirmed compiled `bin/resources.js` emits per-type lazy `require(...)` and `bin/index.js` no longer requires `./ecr` at top level

## Risk
Low; both changes are internal to the component provider.
- Lazy loading changes only *when* modules initialize, not behavior; `registerResourceModule` still registers `Repository` for resource-reference rehydration.
- Provider threading is a no-op unless a caller passes an explicit provider; in that path children correctly inherit it (previously they fell back to the ambient default). It interacts with the known default-provider edge cases (#930) only in that explicit-provider path.
- Not addressed: `utils.ts` still eagerly loads `@pulumi/aws` at startup, so the core aws-SDK load remains (possible follow-up). The `pkg --no-bytecode` build flag was left as-is — `pkg` cannot cross-compile V8 bytecode across architectures, and this repo cross-builds all OS/arch targets on one host.

## Rollback
Revert the two commits (`perf(construct): lazy-load resource modules on first use`, `perf(ecs): thread component provider to child resources`) or close without merging. No state/schema migration involved.
