### PR TITLE
Install core provider agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,25 @@ sdk/java/gradlew.bat
 go.work
 go.work.sum
 
-# Local, per-developer Claude Code settings. The .claude/skills symlinks are tracked; this is not.
+# Local, per-developer Claude Code settings. The repo-owned .claude/skills
+# entries are tracked; APM-managed skills are deployed locally.
 .claude/settings.local.json
+
+# APM-managed agent dependencies
+apm_modules/
+.agents/skills/*
+!.agents/skills/awsx-aws-service-validation/
+!.agents/skills/awsx-breaking-change-evaluation/
+!.agents/skills/awsx-component-design/
+!.agents/skills/awsx-implement-approved-plan/
+!.agents/skills/awsx-issue-planning/
+!.agents/skills/awsx-start-issue-planning-session/
+!.agents/skills/awsx-test-authoring/
+.claude/skills/*
+!.claude/skills/awsx-aws-service-validation
+!.claude/skills/awsx-breaking-change-evaluation
+!.claude/skills/awsx-component-design
+!.claude/skills/awsx-implement-approved-plan/
+!.claude/skills/awsx-issue-planning
+!.claude/skills/awsx-start-issue-planning-session/
+!.claude/skills/awsx-test-authoring

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,13 @@ Pulumi AWSX provider/component library. Core behavior is implemented in `awsx/` 
 - `docs/ai-harness/README.md` - current AI harness state and known gaps.
 - `docs/ai-harness/testing.md` - guidance for writing new AWSX tests.
 - `REVIEW.md` - AWSX-specific review notes that are not generic PR-review advice.
+- `.agents/skills/triage-provider-issue/SKILL.md` - APM-managed initial issue
+  assessment when ownership or the next evidence artifact is unclear.
+- `.agents/skills/stage-pulumi-provider-repro/SKILL.md` - APM-managed durable
+  Pulumi repro staging when triage selects that next step.
 - `.agents/skills/awsx-issue-planning/SKILL.md` - pre-implementation planning
-  for nontrivial issues where scope, API shape, compatibility, or spec needs
-  are unsettled.
+  for nontrivial AWSX issues where scope, API shape, compatibility, or spec
+  needs are unsettled.
 - `.agents/skills/awsx-start-issue-planning-session/SKILL.md` - manual-only
   starter for planning an issue in a fresh session and stopping before edits.
 - `.agents/skills/awsx-implement-approved-plan/SKILL.md` - manual-only launcher
@@ -42,15 +46,19 @@ Pulumi AWSX provider/component library. Core behavior is implemented in `awsx/` 
 Use the focused harness entry points this way:
 - `AGENTS.md` owns repo map, commands, generated boundaries, and path-triggered validation.
 - `REVIEW.md` owns the short AWSX-specific review checklist.
-- `.agents/skills/` is the skill source of truth. Keep `.claude/skills/` as
-  symlinks except when a skill needs Claude-specific invocation controls that
-  Codex skill validation does not allow in `.agents/skills`.
-- For GitHub issue implementation, use `.agents/skills/awsx-issue-planning/SKILL.md`
-  first unless the prompt explicitly says the plan/API shape is already
-  approved. For nontrivial issues, produce the planning brief and stop by
-  default; do not let the same session self-approve implementation unless the
-  prompt explicitly asks to proceed after planning without a maintainer review
-  checkpoint.
+- Repo-owned `.agents/skills/awsx-*` entries are the source of truth for AWSX
+  skills. Core provider skills are declared in `apm.yml` and deployed locally;
+  do not edit their generated copies under `.agents/skills/` or
+  `.claude/skills/`.
+- Start issue work with `triage-provider-issue` when ownership or the next
+  evidence artifact is unclear. Use `stage-pulumi-provider-repro` when triage
+  selects a durable Pulumi repro.
+- Once AWSX ownership is established, use
+  `.agents/skills/awsx-issue-planning/SKILL.md` when a nontrivial issue still
+  has unsettled scope, API shape, compatibility, or spec needs. Produce the
+  planning brief and stop by default; do not let the same session self-approve
+  implementation unless the prompt explicitly asks to proceed after planning
+  without a maintainer review checkpoint.
 - Use `.agents/skills/awsx-start-issue-planning-session/SKILL.md` and
   `.agents/skills/awsx-implement-approved-plan/SKILL.md` only when explicitly
   invoked as session launchers. They are control-flow wrappers around the

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,278 @@
+lockfile_version: '1'
+generated_at: '2026-07-24T15:06:32.890679+00:00'
+apm_version: 0.26.0
+dependencies:
+- repo_url: pulumi-labs/provider-agent-skills
+  name: pulumi-provider-core
+  host: github.com
+  resolved_commit: d8cd869c23ce3ca699e8f8f03776af89d0d7eb8b
+  resolved_ref: v0.1.0
+  version: 0.1.0
+  virtual_path: packages/core
+  is_virtual: true
+  package_type: skill_bundle
+  deployed_files:
+  - .agents/skills/stage-pulumi-provider-repro
+  - .agents/skills/stage-pulumi-provider-repro/SKILL.md
+  - .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  - .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  - .agents/skills/triage-provider-issue
+  - .agents/skills/triage-provider-issue/SKILL.md
+  - .agents/skills/triage-provider-issue/agents/openai.yaml
+  - .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  - .agents/skills/triage-provider-issue/references/disposition-gates.md
+  - .agents/skills/triage-provider-issue/references/helper-switches.md
+  - .agents/skills/triage-provider-issue/references/provider-families.md
+  - .agents/skills/triage-provider-issue/references/workaround-investigation.md
+  - .claude/skills/stage-pulumi-provider-repro
+  - .claude/skills/stage-pulumi-provider-repro/SKILL.md
+  - .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  - .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  - .claude/skills/triage-provider-issue
+  - .claude/skills/triage-provider-issue/SKILL.md
+  - .claude/skills/triage-provider-issue/agents/openai.yaml
+  - .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  - .claude/skills/triage-provider-issue/references/disposition-gates.md
+  - .claude/skills/triage-provider-issue/references/helper-switches.md
+  - .claude/skills/triage-provider-issue/references/provider-families.md
+  - .claude/skills/triage-provider-issue/references/workaround-investigation.md
+  deployed_file_hashes:
+    .agents/skills/stage-pulumi-provider-repro/SKILL.md: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+    .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+    .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+    .agents/skills/triage-provider-issue/SKILL.md: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+    .agents/skills/triage-provider-issue/agents/openai.yaml: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+    .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+    .agents/skills/triage-provider-issue/references/disposition-gates.md: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+    .agents/skills/triage-provider-issue/references/helper-switches.md: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+    .agents/skills/triage-provider-issue/references/provider-families.md: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+    .agents/skills/triage-provider-issue/references/workaround-investigation.md: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+    .claude/skills/stage-pulumi-provider-repro/SKILL.md: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+    .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+    .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+    .claude/skills/triage-provider-issue/SKILL.md: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+    .claude/skills/triage-provider-issue/agents/openai.yaml: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+    .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+    .claude/skills/triage-provider-issue/references/disposition-gates.md: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+    .claude/skills/triage-provider-issue/references/helper-switches.md: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+    .claude/skills/triage-provider-issue/references/provider-families.md: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+    .claude/skills/triage-provider-issue/references/workaround-investigation.md: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+  content_hash: sha256:41aec87854c0b4b34e5fa6ed829796c282b1f68bb10ecc32f1253e037f1525a7
+  declared_license: Apache-2.0
+deployments:
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/disposition-gates.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/helper-switches.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/provider-families.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/workaround-investigation.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/disposition-gates.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/helper-switches.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/provider-families.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/workaround-investigation.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,11 @@
+name: pulumi-awsx-agent-context
+version: "1.0.0"
+
+targets:
+  - codex
+  - claude
+  - opencode
+
+dependencies:
+  apm:
+    - pulumi-labs/provider-agent-skills/packages/core#v0.1.0

--- a/docs/ai-harness/README.md
+++ b/docs/ai-harness/README.md
@@ -6,6 +6,10 @@ generated-file rules, and basic repo map. Do not duplicate those here.
 Current harness files:
 
 - `docs/ai-harness/testing.md` - how to choose and write new AWSX tests.
+- `.agents/skills/triage-provider-issue/SKILL.md` - APM-managed initial issue
+  assessment when ownership or the next evidence artifact is unclear.
+- `.agents/skills/stage-pulumi-provider-repro/SKILL.md` - APM-managed durable
+  Pulumi repro staging.
 - `REVIEW.md` - AWSX-specific review notes.
 - `.agents/skills/awsx-issue-planning/SKILL.md` - pre-implementation planning
   for nontrivial AWSX issues where scope, API shape, compatibility, or spec
@@ -31,13 +35,15 @@ Routing:
 - Use `AGENTS.md` first for repo map, commands, generated boundaries, and
   required validation.
 - Use `REVIEW.md` for the short AWSX-specific review checklist.
-- Treat `.agents/skills/` as the source of truth for skill content. Keep
-  `.claude/skills/` as symlinks except when a skill needs Claude-specific
-  invocation controls that Codex skill validation does not allow in
-  `.agents/skills`.
-- Use `$awsx-issue-planning` first for GitHub issue implementation unless the
-  prompt explicitly says the plan/API shape is already approved. For nontrivial
-  issues, the planning brief is the first-session deliverable; stop there unless
+- Treat repo-owned `.agents/skills/awsx-*` entries as the source of truth for
+  AWSX skill content. Core provider skills are declared in `apm.yml` and
+  deployed locally; do not edit the deployed copies.
+- Start with `$triage-provider-issue` when ownership or the next evidence
+  artifact is unclear. Use `$stage-pulumi-provider-repro` when triage selects a
+  durable Pulumi repro.
+- Once AWSX ownership is established, use `$awsx-issue-planning` when a
+  nontrivial issue still has unsettled scope, API shape, compatibility, or spec
+  needs. The planning brief is the first-session deliverable; stop there unless
   the prompt explicitly asks to proceed after planning without a maintainer
   review checkpoint.
 - Use `$awsx-start-issue-planning-session` and

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,21 @@
+[settings]
+experimental = true
+
+[hooks]
+postinstall = "mise deps install agent-skills"
+
 [tools]
+"pipx:apm-cli" = "0.26.0"
 golangci-lint = "2.7.0"
 # Root mise.toml is the supported repo-local override for versions generated
 # into .config/mise.toml by ci-mgmt.
 "github:pulumi/schema-tools" = "0.7.1"
+
+[deps.agent-skills]
+sources = ["apm.yml", "apm.lock.yaml"]
+outputs = [
+  "apm_modules/",
+  ".agents/skills/",
+  ".claude/skills/",
+]
+run = "apm install --frozen"


### PR DESCRIPTION
## Summary

Install the shared provider core skill pack through APM. This adds the provider triage and durable Pulumi repro skills without checking their deployed copies into the repository.

Uncertain issues now start with core triage. AWSX planning remains the next step after AWSX ownership is established and API shape, compatibility, or scope is still unsettled. Repository-owned AWSX skills remain tracked while current and future APM-managed skills are ignored.

## Compatibility
- [x] No public behavior/API change
- [ ] Public behavior/API changed (describe impact)

## Generated Artifacts
- [x] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

## Validation
- [ ] `make test_provider`
- [ ] `make lint`
- [ ] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed)
- [ ] `make test` (if integration-impacting; requires AWS creds/resources)
- [x] Other targeted checks listed in PR body

Validated with:

- `mise deps install agent-skills`
- `apm audit`
- `git diff --check`

## Risk

The harness now depends on the locked APM package and `mise` post-install hook. `apm.lock.yaml` pins the deployed content, and `apm audit` reports no drift.

## Rollback

Revert this commit to remove the APM dependency and restore the previous AWSX-only routing.
