### PR TITLE
docs: correct spelling

### DIFF
--- a/awsx-classic/cloudwatch/README.md
+++ b/awsx-classic/cloudwatch/README.md
@@ -165,4 +165,4 @@ const dashboard = new awsx.cloudwatch.Dashboard("TopicData", {
 });
 ```
 
-More complex widget customization is possible.  See the invidual types and arguments in the [Cloudwatch API](https://pulumi.io/reference/pkg/nodejs/@pulumi/awsx/cloudwatch/) for more details.
+More complex widget customization is possible.  See the individual types and arguments in the [Cloudwatch API](https://pulumi.io/reference/pkg/nodejs/@pulumi/awsx/cloudwatch/) for more details.

--- a/awsx-classic/ec2/vpc.ts
+++ b/awsx-classic/ec2/vpc.ts
@@ -342,7 +342,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
     private static getProvider(opts: pulumi.InvokeOptions = {}) {
         // Pull out the provider to ensure we're looking up the default vpc in the right location.
         // Note that we do not pass 'parent' along as we want the default vpc to always be parented
-        // logically by hte stack.
+        // logically by the stack.
         const provider = opts.provider ? opts.provider :
                          opts.parent   ? opts.parent.getProvider("aws::") : undefined;
         return provider;
@@ -386,7 +386,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
     public static getDefault(opts: pulumi.InvokeOptions = {}): Vpc {
         // Pull out the provider to ensure we're looking up the default vpc in the right location.
         // Note that we do not pass 'parent' along as we want the default vpc to always be parented
-        // logically by hte stack.
+        // logically by the stack.
         const provider = Vpc.getProvider(opts);
 
         let vpc = providerToDefaultVpc.get(provider);

--- a/awsx-classic/ec2/vpcTopology.ts
+++ b/awsx-classic/ec2/vpcTopology.ts
@@ -382,7 +382,7 @@ class ExplicitLocationTopology extends VpcTopology {
                     // at least route things.
                     let publicSubnetForAz: SubnetDescription | undefined;
                     if (azToPublicSubnets.has(az)) {
-                        // ok, we've got a public subnet for this az.  Just place hte natgateway in
+                        // ok, we've got a public subnet for this az.  Just place the natgateway in
                         // the first public subnet in that az.
 
                         publicSubnetForAz = azToPublicSubnets.get(az)![0];

--- a/awsx-classic/ecr/lifecyclePolicy.ts
+++ b/awsx-classic/ecr/lifecyclePolicy.ts
@@ -65,7 +65,7 @@ function convertRules(rules: pulumi.Unwrap<LifecyclePolicyRule>[]): LifecyclePol
         throw new Error(`At most one [selection: "any"] rule can be provided.`);
     }
 
-    // Place the 'any' rule last so it has higest priority.
+    // Place the 'any' rule last so it has highest priority.
     const orderedRules = [...nonAnyRules, ...anyRules];
 
     let rulePriority = 1;

--- a/awsx-classic/ecs/image.ts
+++ b/awsx-classic/ecs/image.ts
@@ -182,7 +182,7 @@ export function computeImageFromAsset(
 
     // If we haven't, build and push the local build context to the ECR repository.  Then return
     // the unique image name we pushed to.  The name will change if the image changes ensuring
-    // the TaskDefinition get's replaced IFF the built image changes.
+    // the TaskDefinition gets replaced IFF the built image changes.
 
     const uniqueImageName = docker.buildAndPushImage(
             imageName, pathOrBuild, repositoryUrl, parent, async () => {

--- a/awsx-classic/lb/listener.ts
+++ b/awsx-classic/lb/listener.ts
@@ -47,7 +47,7 @@ export abstract class Listener
                 defaultListenerAction: ListenerDefaultAction | undefined,
                 args: ListenerArgs, opts: pulumi.ComponentResourceOptions) {
         // By default, we'd like to be parented by the LB .  However, we didn't use to do this.
-        // Create an alias from teh old urn to the new one so that we don't cause these to eb
+        // Create an alias from the old urn to the new one so that we don't cause these to eb
         // created/destroyed.
         super(type, name, {}, {
             parent: args.loadBalancer,

--- a/awsx/ecr/image.ts
+++ b/awsx/ecr/image.ts
@@ -51,7 +51,7 @@ export function computeImageFromAsset(
 
   // If we haven't, build and push the local build context to the ECR repository.  Then return
   // the unique image name we pushed to.  The name will change if the image changes ensuring
-  // the TaskDefinition get's replaced IFF the built image changes.
+  // the TaskDefinition gets replaced IFF the built image changes.
 
   const registryCredentials = getDockerCredentials(
     { repositoryUrl: repositoryUrl, registryId: inputRegistryId },

--- a/awsx/ecr/repository.ts
+++ b/awsx/ecr/repository.ts
@@ -84,7 +84,7 @@ function convertRules(
     throw new Error(`At most one [selection: "any"] rule can be provided.`);
   }
 
-  // Place the 'any' rule last so it has higest priority.
+  // Place the 'any' rule last so it has highest priority.
   const orderedRules = [...nonAnyRules, ...anyRules];
 
   let rulePriority = 1;

--- a/examples_legacy/ec2/update2/index.ts
+++ b/examples_legacy/ec2/update2/index.ts
@@ -143,7 +143,7 @@ const config = new Config("containers");
 const redisPassword = config.require("redisPassword");
 
 /**
- * A simple Cache abstration, built on top of a Redis container Service.
+ * A simple Cache abstraction, built on top of a Redis container Service.
  */
 class Ec2Cache {
     get: (key: string) => Promise<string>;

--- a/examples_legacy/nlb/fargate/index.ts
+++ b/examples_legacy/nlb/fargate/index.ts
@@ -118,7 +118,7 @@ const config = new Config("containers");
 const redisPassword = config.require("redisPassword");
 
 /**
- * A simple Cache abstration, built on top of a Redis container Service.
+ * A simple Cache abstraction, built on top of a Redis container Service.
  */
 class FargateCache {
     get: (key: string) => Promise<string>;

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -867,7 +867,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction."
+                    "description": "An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction."
                 },
                 "builderVersion": {
                     "$ref": "#/types/awsx:ecr:BuilderVersion",
@@ -2379,7 +2379,7 @@
                     "additionalProperties": {
                         "type": "string"
                     },
-                    "description": "An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction."
+                    "description": "An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction."
                 },
                 "builderVersion": {
                     "$ref": "#/types/awsx:ecr:BuilderVersion",

--- a/provider/pkg/schemagen/ecr.go
+++ b/provider/pkg/schemagen/ecr.go
@@ -282,7 +282,7 @@ func dockerBuildProperties() map[string]schema.PropertySpec {
 		"args": {
 			Description: "An optional map of named build-time argument variables to " +
 				"set during the Docker build.  This flag allows you to pass " +
-				"built-time variables that can be accessed like environment " +
+				"build-time variables that can be accessed like environment " +
 				"variables inside the `RUN` instruction.",
 			TypeSpec: schema.TypeSpec{
 				Type: "object",

--- a/scripts/upgrade-aws.sh
+++ b/scripts/upgrade-aws.sh
@@ -26,5 +26,5 @@ echo "V=$VER"
 # We need to run this before rebuilding the SDKs or they may be missing types
 make provider
 
-# Rebulid the SDKs, which will also rebuild the schema and all other files.
+# Rebuild the SDKs, which will also rebuild the schema and all other files.
 make build_sdks

--- a/scripts/upstream.sh
+++ b/scripts/upstream.sh
@@ -84,7 +84,7 @@ This was likely caused by running a 'checkout' command but not running
 To turn the commits in the 'pulumi/patch-checkout' branch back into patches, run:
   ${original_exec} check_in
 
-To disgard changes in the 'pulumi/patch-checkout' branch, use the 'force' flag (-f):
+To discard changes in the 'pulumi/patch-checkout' branch, use the 'force' flag (-f):
   ${original_exec} ${original_cmd} -f
 
 EOF

--- a/sdk/dotnet/Ecr/Image.cs
+++ b/sdk/dotnet/Ecr/Image.cs
@@ -53,7 +53,7 @@ namespace Pulumi.Awsx.Ecr
         private InputMap<string>? _args;
 
         /// <summary>
-        /// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+        /// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
         /// </summary>
         public InputMap<string> Args
         {

--- a/sdk/go/awsx/ecr/image.go
+++ b/sdk/go/awsx/ecr/image.go
@@ -40,7 +40,7 @@ func NewImage(ctx *pulumi.Context,
 }
 
 type imageArgs struct {
-	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
 	Args map[string]string `pulumi:"args"`
 	// The version of the Docker builder.
 	BuilderVersion *BuilderVersion `pulumi:"builderVersion"`
@@ -66,7 +66,7 @@ type imageArgs struct {
 
 // The set of arguments for constructing a Image resource.
 type ImageArgs struct {
-	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
 	Args pulumi.StringMapInput
 	// The version of the Docker builder.
 	BuilderVersion *BuilderVersion

--- a/sdk/go/awsx/ecr/pulumiTypes.go
+++ b/sdk/go/awsx/ecr/pulumiTypes.go
@@ -15,7 +15,7 @@ var _ = internal.GetEnvOrDefault
 
 // Arguments for building a docker image
 type DockerBuild struct {
-	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+	// An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
 	Args map[string]string `pulumi:"args"`
 	// The version of the Docker builder.
 	BuilderVersion *BuilderVersion `pulumi:"builderVersion"`

--- a/sdk/go/awsx/internal/pulumiUtilities.go
+++ b/sdk/go/awsx/internal/pulumiUtilities.go
@@ -73,8 +73,8 @@ func PkgVersion() (semver.Version, error) {
 	if !SdkVersion.Equals(semver.Version{}) {
 		return SdkVersion, nil
 	}
-	type sentinal struct{}
-	pkgPath := reflect.TypeOf(sentinal{}).PkgPath()
+	type sentinel struct{}
+	pkgPath := reflect.TypeOf(sentinel{}).PkgPath()
 	re := regexp.MustCompile("^.*/pulumi-awsx/sdk(/v\\d+)?")
 	if match := re.FindStringSubmatch(pkgPath); match != nil {
 		vStr := match[1]
@@ -140,7 +140,7 @@ func callPlainInner(
 		return nil, err
 	}
 
-	// Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
+	// Ignoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
 	known := outputData.Known
 	value := outputData.Value
 	secret := outputData.Secret

--- a/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/awsx/ecr/ImageArgs.java
@@ -20,14 +20,14 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
     public static final ImageArgs Empty = new ImageArgs();
 
     /**
-     * An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+     * An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
      * 
      */
     @Import(name="args")
     private @Nullable Output<Map<String,String>> args;
 
     /**
-     * @return An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+     * @return An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
      * 
      */
     public Optional<Output<Map<String,String>>> args() {
@@ -219,7 +219,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param args An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+         * @param args An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
          * 
          * @return builder
          * 
@@ -230,7 +230,7 @@ public final class ImageArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param args An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+         * @param args An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/classic/ec2/vpc.ts
+++ b/sdk/nodejs/classic/ec2/vpc.ts
@@ -342,7 +342,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
     private static getProvider(opts: pulumi.InvokeOptions = {}) {
         // Pull out the provider to ensure we're looking up the default vpc in the right location.
         // Note that we do not pass 'parent' along as we want the default vpc to always be parented
-        // logically by hte stack.
+        // logically by the stack.
         const provider = opts.provider ? opts.provider :
                          opts.parent   ? opts.parent.getProvider("aws::") : undefined;
         return provider;
@@ -386,7 +386,7 @@ export class Vpc extends pulumi.ComponentResource<VpcData> {
     public static getDefault(opts: pulumi.InvokeOptions = {}): Vpc {
         // Pull out the provider to ensure we're looking up the default vpc in the right location.
         // Note that we do not pass 'parent' along as we want the default vpc to always be parented
-        // logically by hte stack.
+        // logically by the stack.
         const provider = Vpc.getProvider(opts);
 
         let vpc = providerToDefaultVpc.get(provider);

--- a/sdk/nodejs/classic/ec2/vpcTopology.ts
+++ b/sdk/nodejs/classic/ec2/vpcTopology.ts
@@ -382,7 +382,7 @@ class ExplicitLocationTopology extends VpcTopology {
                     // at least route things.
                     let publicSubnetForAz: SubnetDescription | undefined;
                     if (azToPublicSubnets.has(az)) {
-                        // ok, we've got a public subnet for this az.  Just place hte natgateway in
+                        // ok, we've got a public subnet for this az.  Just place the natgateway in
                         // the first public subnet in that az.
 
                         publicSubnetForAz = azToPublicSubnets.get(az)![0];

--- a/sdk/nodejs/classic/ecr/lifecyclePolicy.ts
+++ b/sdk/nodejs/classic/ecr/lifecyclePolicy.ts
@@ -65,7 +65,7 @@ function convertRules(rules: pulumi.Unwrap<LifecyclePolicyRule>[]): LifecyclePol
         throw new Error(`At most one [selection: "any"] rule can be provided.`);
     }
 
-    // Place the 'any' rule last so it has higest priority.
+    // Place the 'any' rule last so it has highest priority.
     const orderedRules = [...nonAnyRules, ...anyRules];
 
     let rulePriority = 1;

--- a/sdk/nodejs/classic/ecs/image.ts
+++ b/sdk/nodejs/classic/ecs/image.ts
@@ -182,7 +182,7 @@ export function computeImageFromAsset(
 
     // If we haven't, build and push the local build context to the ECR repository.  Then return
     // the unique image name we pushed to.  The name will change if the image changes ensuring
-    // the TaskDefinition get's replaced IFF the built image changes.
+    // the TaskDefinition gets replaced IFF the built image changes.
 
     const uniqueImageName = docker.buildAndPushImage(
             imageName, pathOrBuild, repositoryUrl, parent, async () => {

--- a/sdk/nodejs/classic/lb/listener.ts
+++ b/sdk/nodejs/classic/lb/listener.ts
@@ -47,7 +47,7 @@ export abstract class Listener
                 defaultListenerAction: ListenerDefaultAction | undefined,
                 args: ListenerArgs, opts: pulumi.ComponentResourceOptions) {
         // By default, we'd like to be parented by the LB .  However, we didn't use to do this.
-        // Create an alias from teh old urn to the new one so that we don't cause these to eb
+        // Create an alias from the old urn to the new one so that we don't cause these to eb
         // created/destroyed.
         super(type, name, {}, {
             parent: args.loadBalancer,

--- a/sdk/nodejs/ecr/image.ts
+++ b/sdk/nodejs/ecr/image.ts
@@ -69,7 +69,7 @@ export class Image extends pulumi.ComponentResource {
  */
 export interface ImageArgs {
     /**
-     * An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+     * An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
      */
     args?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
     /**

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -83,7 +83,7 @@ export async function callAsync<T>(
         !isKnown ? "an unknown value"
         : isSecret ? "a secret value"
         : undefined;
-    // Ingoring o.resources silently. They are typically non-empty, r.f() calls include r as a dependency.
+    // Ignoring o.resources silently. They are typically non-empty, r.f() calls include r as a dependency.
     if (problem) {
         throw new Error(`Plain resource method "${tok}" incorrectly returned ${problem}. ` +
             "This is an error in the provider, please report this to the provider developer.");

--- a/sdk/python/pulumi_awsx/_utilities.py
+++ b/sdk/python/pulumi_awsx/_utilities.py
@@ -262,7 +262,7 @@ def call_plain(
 
     output = pulumi.runtime.call(tok, props, res, typ)
 
-    # Ingoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
+    # Ignoring deps silently. They are typically non-empty, r.f() calls include r as a dependency.
     result, known, secret, _ = _sync_await(asyncio.create_task(_await_output(output)))
 
     problem = None

--- a/sdk/python/pulumi_awsx/ecr/image.py
+++ b/sdk/python/pulumi_awsx/ecr/image.py
@@ -35,7 +35,7 @@ class ImageArgs:
         The set of arguments for constructing a Image resource.
 
         :param pulumi.Input[_builtins.str] repository_url: Url of the repository
-        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
         :param 'BuilderVersion' builder_version: The version of the Docker builder.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[_builtins.str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.
@@ -84,7 +84,7 @@ class ImageArgs:
     @pulumi.getter
     def args(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]]:
         """
-        An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+        An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
         """
         return pulumi.get(self, "args")
 
@@ -224,7 +224,7 @@ class Image(pulumi.ComponentResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass built-time variables that can be accessed like environment variables inside the `RUN` instruction.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] args: An optional map of named build-time argument variables to set during the Docker build.  This flag allows you to pass build-time variables that can be accessed like environment variables inside the `RUN` instruction.
         :param 'BuilderVersion' builder_version: The version of the Docker builder.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] cache_from: Images to consider as cache sources
         :param pulumi.Input[_builtins.str] context: Path to a directory to use for the Docker build context, usually the directory in which the Dockerfile resides (although dockerfile may be used to choose a custom location independent of this choice). If not specified, the context defaults to the current working directory; if a relative path is used, it is relative to the current working directory that Pulumi is evaluating.


### PR DESCRIPTION
## Summary

Correct spelling across documentation and source code comments.

## Compatibility
- [X] No public behavior/API change
- [ ] Public behavior/API changed (describe impact)

## Generated Artifacts
- [X] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

## Validation
- [X] `make test_provider`
- [X] `make lint`
- [X] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed)
- [X] `make test` (if integration-impacting; requires AWS creds/resources)
- [X] Other targeted checks listed in PR body

## Risk

N/A

## Rollback

N/A