### PR TITLE
Remove "Crosswalk" branding from schema displayName and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Pulumi's framework for Amazon Web Services (AWS) infrastructure.
 
-To use this package, [install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/). For a streamlined Pulumi walkthrough, including language runtime installation and AWS configuration, see the [Crosswalk for AWS documentation](https://www.pulumi.com/docs/guides/crosswalk/aws/).
+To use this package, [install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/). For a streamlined Pulumi walkthrough, including language runtime installation and AWS configuration, see the [AWS Guides](https://www.pulumi.com/docs/iac/guides/clouds/aws/).
 
 The AWS Infrastructure package is intended to provide [component](https://www.pulumi.com/docs/intro/concepts/resources/components/) wrappers around many core AWS 'raw' resources to make them easier and more convenient to use.  In general, the `@pulumi/awsx` package mirrors the module structure of `@pulumi/aws` (i.e. `@pulumi/awsx/ecs` or `@pulumi/awsx/ec2`).  These [components](https://www.pulumi.com/docs/intro/concepts/resources/components/) are designed to take care of much of the redundancy and boilerplate necessary when using the raw AWS resources, while still striving to expose all underlying functionality if needed.
 
@@ -26,7 +26,7 @@ The AWS Infrastructure package exposes many high level abstractions.  Including:
 * [`lb`](https://github.com/pulumi/pulumi-awsx/tree/master/awsx/lb).  A module for simply setting up [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/). This module provides convenient ways to set up either `Network` or `Application` load balancers, along with the appropriate ELB Target Groups and Listeners in order to have a high availability, automatically-scaled service.  These ELB components also work well with the other awsx components.  For example, an `lb.defaultTarget` can be passed in directly as the `portMapping` target of an `ecs.FargateService`.
 
 <div>
-    <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/" title="Get Started">
+    <a href="https://www.pulumi.com/docs/iac/guides/clouds/aws/" title="Get Started">
        <img src="https://www.pulumi.com/images/get-started.svg?" width="120">
     </a>
 </div>
@@ -109,7 +109,6 @@ Before version 1, this package only supported components in TypeScript. All the 
 
 ## References
 
-* [Tutorial](https://www.pulumi.com/blog/crosswalk-for-aws-1-0/)
 * [API Reference Documentation](https://www.pulumi.com/registry/packages/awsx/api-docs/)
 * [Examples](./examples)
-* [Crosswalk for AWS Guide](https://www.pulumi.com/docs/guides/crosswalk/aws/)
+* [AWS Guides](https://www.pulumi.com/docs/iac/guides/clouds/aws/)

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -1,6 +1,6 @@
 {
     "name": "awsx",
-    "displayName": "AWSx (Pulumi Crosswalk for AWS)",
+    "displayName": "AWSx (Pulumi Components for AWS)",
     "description": "Pulumi Amazon Web Services (AWS) AWSX Components.",
     "keywords": [
         "pulumi",

--- a/provider/pkg/schemagen/schema.go
+++ b/provider/pkg/schemagen/schema.go
@@ -41,7 +41,7 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 
 	packageSpec := schema.PackageSpec{
 		Name:        "awsx",
-		DisplayName: "AWSx (Pulumi Crosswalk for AWS)",
+		DisplayName: "AWSx (Pulumi Components for AWS)",
 		Description: "Pulumi Amazon Web Services (AWS) AWSX Components.",
 		License:     "Apache-2.0",
 		Publisher:   "Pulumi",

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -10,7 +10,7 @@
 
 Pulumi's framework for Amazon Web Services (AWS) infrastructure.
 
-To use this package, [install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/). For a streamlined Pulumi walkthrough, including language runtime installation and AWS configuration, see the [Crosswalk for AWS documentation](https://www.pulumi.com/docs/guides/crosswalk/aws/).
+To use this package, [install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/). For a streamlined Pulumi walkthrough, including language runtime installation and AWS configuration, see the [AWS Guides](https://www.pulumi.com/docs/iac/guides/clouds/aws/).
 
 The AWS Infrastructure package is intended to provide [component](https://www.pulumi.com/docs/intro/concepts/resources/components/) wrappers around many core AWS 'raw' resources to make them easier and more convenient to use.  In general, the `@pulumi/awsx` package mirrors the module structure of `@pulumi/aws` (i.e. `@pulumi/awsx/ecs` or `@pulumi/awsx/ec2`).  These [components](https://www.pulumi.com/docs/intro/concepts/resources/components/) are designed to take care of much of the redundancy and boilerplate necessary when using the raw AWS resources, while still striving to expose all underlying functionality if needed.
 
@@ -26,7 +26,7 @@ The AWS Infrastructure package exposes many high level abstractions.  Including:
 * [`lb`](https://github.com/pulumi/pulumi-awsx/tree/master/awsx/lb).  A module for simply setting up [Elastic Load Balancing](https://aws.amazon.com/elasticloadbalancing/). This module provides convenient ways to set up either `Network` or `Application` load balancers, along with the appropriate ELB Target Groups and Listeners in order to have a high availability, automatically-scaled service.  These ELB components also work well with the other awsx components.  For example, an `lb.defaultTarget` can be passed in directly as the `portMapping` target of an `ecs.FargateService`.
 
 <div>
-    <a href="https://www.pulumi.com/docs/guides/crosswalk/aws/" title="Get Started">
+    <a href="https://www.pulumi.com/docs/iac/guides/clouds/aws/" title="Get Started">
        <img src="https://www.pulumi.com/images/get-started.svg?" width="120">
     </a>
 </div>
@@ -109,7 +109,6 @@ Before version 1, this package only supported components in TypeScript. All the 
 
 ## References
 
-* [Tutorial](https://www.pulumi.com/blog/crosswalk-for-aws-1-0/)
 * [API Reference Documentation](https://www.pulumi.com/registry/packages/awsx/api-docs/)
 * [Examples](./examples)
-* [Crosswalk for AWS Guide](https://www.pulumi.com/docs/guides/crosswalk/aws/)
+* [AWS Guides](https://www.pulumi.com/docs/iac/guides/clouds/aws/)


### PR DESCRIPTION
# Josh says

This should be an easy one - it just replaces the obsolete "crosswalk" terminology and updates some docs links. The diff should be very readable.

# Claude says

We no longer refer to any libraries as "Crosswalk"; this removes the last references to the term in this repo.

Fixes #2119  

## What changed

| File | Kind | Change |
|---|---|---|
| `provider/pkg/schemagen/schema.go` | source | `DisplayName` → `AWSx (Pulumi Components for AWS)` |
| `README.md` | source | four link/copy edits (below) |
| `provider/cmd/pulumi-resource-awsx/schema.json` | generated | regenerated `displayName` |
| `sdk/python/README.md` | generated | regenerated copy of the root README |

### The `displayName` (the load-bearing one)

It flows into the published `schema.json` and from there into `themes/default/data/registry/packages/awsx.yaml` in `pulumi/registry`, which is what renders as the package title on https://www.pulumi.com/registry/packages/awsx/. That YAML is generated, so it **can't** be fixed in the registry repo — it self-heals on the next `generate-package-metadata` run after an awsx release carries the new schema.

### README links

`/docs/guides/crosswalk/aws/` is now only an alias; the canonical page is `/docs/iac/guides/clouds/aws/`.

- The intro sentence and the References entry are repointed there, with the link text changed to "AWS Guides".
- The "Get Started" badge `href` is repointed there too.
- The `* [Tutorial](https://www.pulumi.com/blog/crosswalk-for-aws-1-0/)` bullet is **dropped** rather than repointed — blog posts are historical and shouldn't be renamed, and the References list still covers API docs, examples, and the AWS Guides.

## Verification

- `grep -ri crosswalk` across the repo returns no matches.
- `git diff` on `schema.json` is exactly the one `displayName` line — no dependency-version drift from regeneration.
- `diff README.md sdk/python/README.md` is empty (the generated copy is faithful; it's produced by the same `cp README.md sdk/python/` step `make generate_python` runs).
- No SDK regeneration needed: `displayName` isn't emitted into any generated SDK file. The other SDK READMEs (`nodejs`, `dotnet`, `java`, `pulumi_awsx`) derive from the schema `Description`, which never said "Crosswalk". `schema-embed.json` is gitignored and rebuilt by `go generate`.
- Nothing under `awsx/**` changed, so `make test_provider` isn't implicated.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPK7SyxSXmR4csLBEiwjiT
