### PR TITLE
Add Node.js SDK compatibility tests

### DIFF
--- a/examples/compatibility/README.md
+++ b/examples/compatibility/README.md
@@ -1,0 +1,21 @@
+# Node.js SDK compatibility programs
+
+These Pulumi programs use the normal `integration.ProgramTest` harness with the built and linked `@pulumi/awsx` SDK.
+
+- `node-typescript-3.8` checks the documented minimum TypeScript compiler and compatible Node declarations.
+- `node-typescript-7` uses TypeScript 7 for type checking and TypeScript 6 for Pulumi program execution.
+- `bun` runs the package with Pulumi's Bun runtime.
+
+The Bun program exercises modern package loading and classic code that does not use function serialization. It does not claim support for classic callback APIs or dynamic providers; Pulumi's Bun runtime does not support those features.
+
+The Node programs run their type checks through the package `build` script. The checks compile valid modern and classic AWSX usage and require invalid arguments to produce `TS2322`. Compiler fixtures are versioned by major version so that a new fixture can be added for each supported major.
+
+Build and link the SDK before running the compatibility matrix through the normal integration-test target:
+
+```sh
+make build_nodejs install_nodejs_sdk
+GOTESTARGS="-run '^TestNodeJSCompatibility$' -count=1" \
+    make test TESTTAGS=nodejs
+```
+
+The Node.js integration test uses Mise to run the programs with Node 22, 24, and 26 and Bun 1.3. The Bun test registers the built SDK in an isolated temporary link directory.

--- a/examples/compatibility/bun/Pulumi.yaml
+++ b/examples/compatibility/bun/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: awsx-bun-compatibility
+runtime: bun

--- a/examples/compatibility/bun/index.ts
+++ b/examples/compatibility/bun/index.ts
@@ -1,0 +1,14 @@
+import * as awsx from "@pulumi/awsx";
+
+// Vpc is lazy-loaded, so call a public method to test the modern runtime module as well as its types.
+if (awsx.ec2.Vpc.isInstance(undefined)) {
+    throw new Error("Vpc.isInstance unexpectedly accepted undefined.");
+}
+
+const cidr = awsx.classic.ec2.Cidr32Block.fromCidrNotation("10.0.0.1/24").toString();
+if (cidr !== "10.0.0.0/24") {
+    throw new Error(`Classic AWSX code returned an unexpected CIDR block: ${cidr}`);
+}
+
+export const bunVersion = Bun.version;
+export { cidr };

--- a/examples/compatibility/bun/package.json
+++ b/examples/compatibility/bun/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "awsx-bun-compatibility",
+  "private": true,
+  "dependencies": {
+    "@pulumi/awsx": "*"
+  }
+}

--- a/examples/compatibility/node-typescript-3.8/Pulumi.yaml
+++ b/examples/compatibility/node-typescript-3.8/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: awsx-node-typescript-3-8-compatibility
+runtime: nodejs

--- a/examples/compatibility/node-typescript-3.8/check-types.js
+++ b/examples/compatibility/node-typescript-3.8/check-types.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const tsc = path.join(__dirname, "node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc");
+
+function run(project) {
+    return spawnSync(tsc, ["--project", project], {
+        cwd: __dirname,
+        encoding: "utf8",
+    });
+}
+
+const version = spawnSync(tsc, ["--version"], { encoding: "utf8" });
+assert.strictEqual(version.status, 0, version.stderr);
+assert.match(version.stdout, /^Version 3\.8\./);
+
+const valid = run("tsconfig.json");
+assert.strictEqual(valid.status, 0, valid.stdout + valid.stderr);
+
+for (const fixture of ["modern", "classic"]) {
+    const invalid = run(`tsconfig-invalid-${fixture}.json`);
+    const output = invalid.stdout + invalid.stderr;
+    assert.notStrictEqual(invalid.status, 0, `Expected invalid ${fixture} arguments to fail type checking.`);
+    assert.match(output, new RegExp(`invalid-${fixture}\\.ts.*error TS2322`));
+}

--- a/examples/compatibility/node-typescript-3.8/index.ts
+++ b/examples/compatibility/node-typescript-3.8/index.ts
@@ -1,0 +1,24 @@
+import * as awsx from "@pulumi/awsx";
+
+const modernArgs: awsx.ec2.VpcArgs = {
+    numberOfAvailabilityZones: 3,
+};
+const classicArgs: awsx.classic.ec2.VpcArgs = {
+    cidrBlock: "10.0.0.0/16",
+    numberOfAvailabilityZones: 2,
+};
+
+// Vpc is lazy-loaded, so call a public method to test the modern runtime module as well as its types.
+if (awsx.ec2.Vpc.isInstance(undefined)) {
+    throw new Error("Vpc.isInstance unexpectedly accepted undefined.");
+}
+
+const cidr = awsx.classic.ec2.Cidr32Block.fromCidrNotation("10.0.0.1/24").toString();
+if (cidr !== "10.0.0.0/24") {
+    throw new Error(`Classic AWSX code returned an unexpected CIDR block: ${cidr}`);
+}
+
+export const nodeVersion = process.version;
+export const modernAvailabilityZones = modernArgs.numberOfAvailabilityZones;
+export const classicAvailabilityZones = classicArgs.numberOfAvailabilityZones;
+export { cidr };

--- a/examples/compatibility/node-typescript-3.8/invalid-classic.ts
+++ b/examples/compatibility/node-typescript-3.8/invalid-classic.ts
@@ -1,0 +1,7 @@
+import * as awsx from "@pulumi/awsx";
+
+const args: awsx.classic.ec2.VpcArgs = {
+    numberOfAvailabilityZones: "three",
+};
+
+export { args };

--- a/examples/compatibility/node-typescript-3.8/invalid-modern.ts
+++ b/examples/compatibility/node-typescript-3.8/invalid-modern.ts
@@ -1,0 +1,7 @@
+import * as awsx from "@pulumi/awsx";
+
+const args: awsx.ec2.VpcArgs = {
+    numberOfAvailabilityZones: "three",
+};
+
+export { args };

--- a/examples/compatibility/node-typescript-3.8/package.json
+++ b/examples/compatibility/node-typescript-3.8/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "awsx-node-typescript-3-8-compatibility",
+  "private": true,
+  "scripts": {
+    "build": "node check-types.js"
+  },
+  "dependencies": {
+    "@pulumi/awsx": "*"
+  },
+  "devDependencies": {
+    "@types/node": "17.0.21",
+    "typescript": "3.8.3"
+  }
+}

--- a/examples/compatibility/node-typescript-3.8/tsconfig-invalid-classic.json
+++ b/examples/compatibility/node-typescript-3.8/tsconfig-invalid-classic.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["invalid-classic.ts"]
+}

--- a/examples/compatibility/node-typescript-3.8/tsconfig-invalid-modern.json
+++ b/examples/compatibility/node-typescript-3.8/tsconfig-invalid-modern.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["invalid-modern.ts"]
+}

--- a/examples/compatibility/node-typescript-3.8/tsconfig.json
+++ b/examples/compatibility/node-typescript-3.8/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "ES2017",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "files": ["index.ts"]
+}

--- a/examples/compatibility/node-typescript-7/Pulumi.yaml
+++ b/examples/compatibility/node-typescript-7/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: awsx-node-typescript-7-compatibility
+runtime: nodejs

--- a/examples/compatibility/node-typescript-7/check-types.js
+++ b/examples/compatibility/node-typescript-7/check-types.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const assert = require("assert");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const tsc = path.join(__dirname, "node_modules", ".bin", process.platform === "win32" ? "tsc.cmd" : "tsc");
+
+function run(project) {
+    return spawnSync(tsc, ["--project", project], {
+        cwd: __dirname,
+        encoding: "utf8",
+    });
+}
+
+const version = spawnSync(tsc, ["--version"], { encoding: "utf8" });
+assert.strictEqual(version.status, 0, version.stderr);
+assert.match(version.stdout, /^Version 7\./);
+
+const valid = run("tsconfig.json");
+assert.strictEqual(valid.status, 0, valid.stdout + valid.stderr);
+
+for (const fixture of ["modern", "classic"]) {
+    const invalid = run(`tsconfig-invalid-${fixture}.json`);
+    const output = invalid.stdout + invalid.stderr;
+    assert.notStrictEqual(invalid.status, 0, `Expected invalid ${fixture} arguments to fail type checking.`);
+    assert.match(output, new RegExp(`invalid-${fixture}\\.ts.*error TS2322`));
+}

--- a/examples/compatibility/node-typescript-7/index.ts
+++ b/examples/compatibility/node-typescript-7/index.ts
@@ -1,0 +1,26 @@
+import * as awsx from "@pulumi/awsx";
+import * as typescript from "typescript";
+
+const modernArgs: awsx.ec2.VpcArgs = {
+    numberOfAvailabilityZones: 3,
+};
+const classicArgs: awsx.classic.ec2.VpcArgs = {
+    cidrBlock: "10.0.0.0/16",
+    numberOfAvailabilityZones: 2,
+};
+
+// Vpc is lazy-loaded, so call a public method to test the modern runtime module as well as its types.
+if (awsx.ec2.Vpc.isInstance(undefined)) {
+    throw new Error("Vpc.isInstance unexpectedly accepted undefined.");
+}
+
+const cidr = awsx.classic.ec2.Cidr32Block.fromCidrNotation("10.0.0.1/24").toString();
+if (cidr !== "10.0.0.0/24") {
+    throw new Error(`Classic AWSX code returned an unexpected CIDR block: ${cidr}`);
+}
+
+export const nodeVersion = process.version;
+export const typescriptVersion = typescript.version;
+export const modernAvailabilityZones = modernArgs.numberOfAvailabilityZones;
+export const classicAvailabilityZones = classicArgs.numberOfAvailabilityZones;
+export { cidr };

--- a/examples/compatibility/node-typescript-7/invalid-classic.ts
+++ b/examples/compatibility/node-typescript-7/invalid-classic.ts
@@ -1,0 +1,7 @@
+import * as awsx from "@pulumi/awsx";
+
+const args: awsx.classic.ec2.VpcArgs = {
+    numberOfAvailabilityZones: "three",
+};
+
+export { args };

--- a/examples/compatibility/node-typescript-7/invalid-modern.ts
+++ b/examples/compatibility/node-typescript-7/invalid-modern.ts
@@ -1,0 +1,7 @@
+import * as awsx from "@pulumi/awsx";
+
+const args: awsx.ec2.VpcArgs = {
+    numberOfAvailabilityZones: "three",
+};
+
+export { args };

--- a/examples/compatibility/node-typescript-7/package.json
+++ b/examples/compatibility/node-typescript-7/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "awsx-node-typescript-7-compatibility",
+  "private": true,
+  "scripts": {
+    "build": "node check-types.js"
+  },
+  "dependencies": {
+    "@pulumi/awsx": "*",
+    "typescript": "npm:@typescript/typescript6@6.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@typescript/native": "npm:typescript@7"
+  }
+}

--- a/examples/compatibility/node-typescript-7/tsconfig-invalid-classic.json
+++ b/examples/compatibility/node-typescript-7/tsconfig-invalid-classic.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["invalid-classic.ts"]
+}

--- a/examples/compatibility/node-typescript-7/tsconfig-invalid-modern.json
+++ b/examples/compatibility/node-typescript-7/tsconfig-invalid-modern.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "files": ["invalid-modern.ts"]
+}

--- a/examples/compatibility/node-typescript-7/tsconfig.json
+++ b/examples/compatibility/node-typescript-7/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true
+  },
+  "files": ["index.ts"]
+}

--- a/examples/examples_nodejs_compatibility_test.go
+++ b/examples/examples_nodejs_compatibility_test.go
@@ -33,6 +33,7 @@ func TestNodeJSCompatibility(t *testing.T) {
 		t.Run("Node"+nodeMajor, func(t *testing.T) {
 			node := miseExecutable(t, "node@"+nodeMajor, "node")
 			path := filepath.Dir(node) + string(os.PathListSeparator) + os.Getenv("PATH")
+			pulumi, pulumiEnv := pulumiWithNode(t, node)
 
 			for _, testCase := range []struct {
 				name                   string
@@ -46,7 +47,8 @@ func TestNodeJSCompatibility(t *testing.T) {
 					test := integration.ProgramTestOptions{
 						Dir:          filepath.Join(getCwd(t), "compatibility", testCase.dir),
 						Dependencies: []string{"@pulumi/awsx"},
-						Env:          []string{"PATH=" + path},
+						Bin:          pulumi,
+						Env:          append([]string{"PATH=" + path}, pulumiEnv...),
 						NoParallel:   true,
 						Quick:        true,
 						RunBuild:     true,
@@ -102,16 +104,40 @@ func TestNodeJSCompatibility(t *testing.T) {
 
 func miseExecutable(t *testing.T, tool, executable string) string {
 	t.Helper()
-	command := exec.Command("mise", "x", tool, "--", executable, "-e", "console.log(process.execPath)")
-	output, err := command.Output()
+
+	// Use the installation path directly so child processes cannot fall back to the repository's default runtime.
+	output, err := exec.Command("mise", "install", tool).CombinedOutput()
+	require.NoError(t, err, "install %s with Mise:\n%s", tool, output)
+
+	command := exec.Command("mise", "where", tool)
+	output, err = command.Output()
 	if exitError, ok := err.(*exec.ExitError); ok {
-		t.Fatalf("find %s executable with Mise: %v\n%s", tool, err, exitError.Stderr)
+		t.Fatalf("find %s installation with Mise: %v\n%s", tool, err, exitError.Stderr)
 	}
 	require.NoError(t, err)
 
-	path := strings.TrimSpace(string(output))
+	path := filepath.Join(strings.TrimSpace(string(output)), "bin", executable)
 	require.FileExists(t, path)
 	return path
+}
+
+func pulumiWithNode(t *testing.T, node string) (string, []string) {
+	t.Helper()
+
+	pulumi, err := exec.LookPath("pulumi")
+	require.NoError(t, err)
+
+	wrapper := filepath.Join(t.TempDir(), "pulumi")
+	err = os.WriteFile(wrapper, []byte(`#!/bin/sh
+export PATH="${AWSX_TEST_NODE_DIR}:${PATH}"
+exec "${AWSX_TEST_PULUMI}" "$@"
+`), 0o700)
+	require.NoError(t, err)
+
+	return wrapper, []string{
+		"AWSX_TEST_NODE_DIR=" + filepath.Dir(node),
+		"AWSX_TEST_PULUMI=" + pulumi,
+	}
 }
 
 func registerBunLink(t *testing.T, bun, bunInstall string) {

--- a/examples/examples_nodejs_compatibility_test.go
+++ b/examples/examples_nodejs_compatibility_test.go
@@ -1,0 +1,124 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build nodejs || all
+// +build nodejs all
+
+package examples
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeJSCompatibility(t *testing.T) {
+	for _, nodeMajor := range []string{"22", "24", "26"} {
+		t.Run("Node"+nodeMajor, func(t *testing.T) {
+			node := miseExecutable(t, "node@"+nodeMajor, "node")
+			path := filepath.Dir(node) + string(os.PathListSeparator) + os.Getenv("PATH")
+
+			for _, testCase := range []struct {
+				name                   string
+				dir                    string
+				runtimeTypeScriptMajor string
+			}{
+				{name: "TypeScript3.8", dir: "node-typescript-3.8"},
+				{name: "TypeScript7", dir: "node-typescript-7", runtimeTypeScriptMajor: "6"},
+			} {
+				t.Run(testCase.name, func(t *testing.T) {
+					test := integration.ProgramTestOptions{
+						Dir:          filepath.Join(getCwd(t), "compatibility", testCase.dir),
+						Dependencies: []string{"@pulumi/awsx"},
+						Env:          []string{"PATH=" + path},
+						NoParallel:   true,
+						Quick:        true,
+						RunBuild:     true,
+						ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+							require.Equal(t, "10.0.0.0/24", stack.Outputs["cidr"])
+							require.Equal(t, float64(3), stack.Outputs["modernAvailabilityZones"])
+							require.Equal(t, float64(2), stack.Outputs["classicAvailabilityZones"])
+
+							nodeVersion, ok := stack.Outputs["nodeVersion"].(string)
+							require.True(t, ok)
+							require.True(t, strings.HasPrefix(nodeVersion, "v"+nodeMajor+"."),
+								"expected Node %s, got %s", nodeMajor, nodeVersion)
+
+							if testCase.runtimeTypeScriptMajor != "" {
+								typescriptVersion, ok := stack.Outputs["typescriptVersion"].(string)
+								require.True(t, ok)
+								require.True(t, strings.HasPrefix(typescriptVersion, testCase.runtimeTypeScriptMajor+"."),
+									"expected TypeScript %s, got %s", testCase.runtimeTypeScriptMajor, typescriptVersion)
+							}
+						},
+					}
+
+					integration.ProgramTest(t, &test)
+				})
+			}
+		})
+	}
+
+	t.Run("Bun1.3", func(t *testing.T) {
+		bun := miseExecutable(t, "bun@1.3", "bun")
+		bunInstall := t.TempDir()
+		registerBunLink(t, bun, bunInstall)
+		path := filepath.Dir(bun) + string(os.PathListSeparator) + os.Getenv("PATH")
+
+		test := integration.ProgramTestOptions{
+			Dir:          filepath.Join(getCwd(t), "compatibility", "bun"),
+			Dependencies: []string{"@pulumi/awsx"},
+			BunBin:       bun,
+			Env:          []string{"BUN_INSTALL=" + bunInstall, "PATH=" + path},
+			NoParallel:   true,
+			Quick:        true,
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				require.Equal(t, "10.0.0.0/24", stack.Outputs["cidr"])
+				bunVersion, ok := stack.Outputs["bunVersion"].(string)
+				require.True(t, ok)
+				require.True(t, strings.HasPrefix(bunVersion, "1.3."), "expected Bun 1.3, got %s", bunVersion)
+			},
+		}
+
+		integration.ProgramTest(t, &test)
+	})
+}
+
+func miseExecutable(t *testing.T, tool, executable string) string {
+	t.Helper()
+	command := exec.Command("mise", "x", tool, "--", executable, "-e", "console.log(process.execPath)")
+	output, err := command.Output()
+	if exitError, ok := err.(*exec.ExitError); ok {
+		t.Fatalf("find %s executable with Mise: %v\n%s", tool, err, exitError.Stderr)
+	}
+	require.NoError(t, err)
+
+	path := strings.TrimSpace(string(output))
+	require.FileExists(t, path)
+	return path
+}
+
+func registerBunLink(t *testing.T, bun, bunInstall string) {
+	t.Helper()
+	command := exec.Command(bun, "link")
+	command.Dir = filepath.Join(getCwd(t), "..", "sdk", "nodejs", "bin")
+	command.Env = append(os.Environ(), "BUN_INSTALL="+bunInstall)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("register the built AWSX SDK with Bun:\n%s", output))
+}


### PR DESCRIPTION
## Summary

AWSX tooling upgrades can pass the repository build while changing the syntax or runtime requirements of the generated Node.js SDK. This adds a consumer compatibility matrix for the built and linked `@pulumi/awsx` package:

- Node.js 22, 24, and 26
- TypeScript 3.8 and 7
- TypeScript 6 for Pulumi program execution
- Bun 1.3

The TypeScript fixtures compile valid modern and classic APIs and confirm that invalid arguments produce type errors. The runtime programs force the lazy modern `Vpc` module to load through its public API and execute a classic CIDR helper.

Each matrix entry performs a successful Pulumi update and validates its stack outputs. The programs do not create AWS resources.

Closes #2128.

## Compatibility
- [x] No public behavior/API change
- [ ] Public behavior/API changed (describe impact)

## Generated Artifacts
- [x] N/A
- [ ] Ran regeneration (`make generate` or scoped equivalent) and committed generated diffs

## Validation
- [ ] `make test_provider`
- [ ] `make lint`
- [ ] `yarn --cwd awsx-classic lint` (if `awsx-classic/**` changed)
- [ ] `make test` (if integration-impacting; requires AWS creds/resources)
- [x] `cd examples && go test -tags nodejs . -run '^$'`
- [x] TypeScript 3.8 and 7 fixture build scripts with Yarn 1
- [x] Bun 1.3 runtime fixture
- [ ] Full compatibility matrix with the locally built and linked SDK

The full compatibility matrix was not run because the locally built Node.js SDK was not present.

## Risk

This is test-only. The matrix intentionally follows patch releases within the selected Node.js, TypeScript, and Bun major or minor versions, so a new incompatible patch can cause CI to fail.

## Rollback

Revert this PR. It does not change user resources or require state migration.
