### PR TITLE
Upgrade generated Node.js SDK compiler

### DIFF
--- a/examples/compatibility/node-typescript-3.8/invalid-classic.ts
+++ b/examples/compatibility/node-typescript-3.8/invalid-classic.ts
@@ -1,7 +1,7 @@
 import * as awsx from "@pulumi/awsx";
 
 const args: awsx.classic.ec2.VpcArgs = {
-    numberOfAvailabilityZones: "three",
+    numberOfNatGateways: "three",
 };
 
 export { args };

--- a/provider/cmd/pulumi-resource-awsx/schema.json
+++ b/provider/cmd/pulumi-resource-awsx/schema.json
@@ -53,8 +53,8 @@
             },
             "devDependencies": {
                 "@types/mime": "^2.0.0",
-                "@types/node": "^18",
-                "typescript": "^5.7.0"
+                "@types/node": "^22",
+                "typescript": "^7.0.0"
             },
             "respectSchemaVersion": true
         },

--- a/provider/pkg/schemagen/schema.go
+++ b/provider/pkg/schemagen/schema.go
@@ -92,9 +92,9 @@ func GenerateSchema(packageDir string) schema.PackageSpec {
 					"mime":                 "^2.0.0",
 				},
 				"devDependencies": map[string]string{
-					"@types/node": "^18",
+					"@types/node": "^22",
 					"@types/mime": "^2.0.0",
-					"typescript":  "^5.7.0",
+					"typescript":  "^7.0.0",
 				},
 				"respectSchemaVersion": true,
 			}),

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@types/mime": "^2.0.0",
-        "@types/node": "^18",
-        "typescript": "^5.7.0"
+        "@types/node": "^22",
+        "typescript": "^7.0.0"
     },
     "pulumi": {
         "resource": true,


### PR DESCRIPTION
Build the generated Node.js SDK with TypeScript 7 and Node.js 22 type
declarations. Keep the TypeScript 3.8 compatibility fixture focused on a
classic-specific argument while verifying the supported customer baseline.

closes #2132
